### PR TITLE
モデルのダウンロードが必要なテストに #[ignore] を追加

### DIFF
--- a/karukan-engine/src/kanji/backend.rs
+++ b/karukan-engine/src/kanji/backend.rs
@@ -184,7 +184,7 @@ mod tests {
     use super::*;
 
     #[test]
-
+    #[ignore = "requires model download from Hugging Face"]
     fn test_default_model_conversion() {
         let backend =
             Backend::from_variant_id("jinen-v1-small-q5").expect("Failed to load default model");
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-
+    #[ignore = "requires model download from Hugging Face"]
     fn test_xsmall_special_tokens() {
         use super::super::hf_download::{get_path_by_id, get_tokenizer_path_by_id};
         use super::super::{CONTEXT_TOKEN, INPUT_START_TOKEN, OUTPUT_START_TOKEN};
@@ -240,7 +240,7 @@ mod tests {
     }
 
     #[test]
-
+    #[ignore = "requires model download from Hugging Face"]
     fn test_xsmall_conversion() {
         let backend =
             Backend::from_variant_id("jinen-v1-xsmall-q5").expect("Failed to download GGUF");

--- a/karukan-engine/tests/kanji_conversion_tests.rs
+++ b/karukan-engine/tests/kanji_conversion_tests.rs
@@ -2,7 +2,12 @@
 //!
 //! These tests verify that the kanji conversion functionality works correctly.
 //!
-//! Note: These tests require downloading models from HuggingFace on first run.
+//! Note: Most tests in this file require downloading models from HuggingFace
+//! and are marked with `#[ignore]`. To run them:
+//!
+//! ```sh
+//! cargo test -p karukan-engine -- --ignored
+//! ```
 
 use karukan_engine::kanji::ConversionConfig;
 

--- a/karukan-engine/tests/kanji_conversion_tests.rs
+++ b/karukan-engine/tests/kanji_conversion_tests.rs
@@ -62,6 +62,7 @@ mod llamacpp_tests {
     }
 
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_tokenization() {
         let model = load_model().expect("Failed to load");
         let tokens = model.tokenize("コンニチハ").expect("Tokenize failed");
@@ -69,6 +70,7 @@ mod llamacpp_tests {
     }
 
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_generation() {
         let model = load_model().expect("Failed to load");
         let prompt = build_prompt("ワセダ");
@@ -88,6 +90,7 @@ mod llamacpp_tests {
     }
 
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_expected_conversions() {
         let model = load_model().expect("Failed to load");
         let test_cases = [
@@ -117,6 +120,7 @@ mod llamacpp_tests {
     }
 
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_beam_search_basic() {
         let model = load_model().expect("Failed to load");
         let prompt = build_prompt("ヘンカン");
@@ -146,6 +150,7 @@ mod llamacpp_tests {
     }
 
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_beam_search_multiple_inputs() {
         let model = load_model().expect("Failed to load");
         let test_cases = [
@@ -183,6 +188,7 @@ mod llamacpp_tests {
     }
 
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_beam_search_score_ordering() {
         let model = load_model().expect("Failed to load");
         let prompt = build_prompt("ヘンカン");
@@ -207,6 +213,7 @@ mod llamacpp_tests {
     }
 
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_conversion_with_context() {
         let model = load_model().expect("Failed to load");
 
@@ -245,6 +252,7 @@ mod llamacpp_tests {
     }
 
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_context_variations() {
         let model = load_model().expect("Failed to load");
 
@@ -277,6 +285,7 @@ mod llamacpp_tests {
     /// Test that context significantly changes conversion results
     /// Same reading "こうえん" should produce different kanji based on context
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_context_disambiguation() {
         let model = load_model().expect("Failed to load");
 
@@ -329,6 +338,7 @@ mod llamacpp_tests {
 
     /// Test "zenninn" -> "ゼンイン" conversion (reported crash)
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_zenninn_llamacpp() {
         let model = load_model().expect("Failed to load");
 
@@ -360,6 +370,7 @@ mod llamacpp_tests {
 
     /// Test beam search with multiple candidates (this was causing decode errors)
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_zenninn_beam_search() {
         let model = load_model().expect("Failed to load");
 
@@ -395,6 +406,7 @@ mod llamacpp_tests {
 
     /// Test that long context inputs work within n_ctx=256 limit
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_long_context_input() {
         let model = load_model().expect("Failed to load");
 
@@ -427,6 +439,7 @@ mod llamacpp_tests {
     /// half-width equivalents by the tokenizer's NFKC normalizer, producing the
     /// same token ids as the half-width input.
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_tokenizer_nfkc_normalization() {
         let model = load_model().expect("Failed to load");
 
@@ -465,6 +478,7 @@ mod llamacpp_tests {
 
     /// Test token counts for various input lengths
     #[test]
+    #[ignore = "requires model download from Hugging Face"]
     fn test_token_counts() {
         let model = load_model().expect("Failed to load");
 

--- a/karukan-engine/tests/romaji_tests.rs
+++ b/karukan-engine/tests/romaji_tests.rs
@@ -938,6 +938,7 @@ fn test_zenninn_crash() {
 }
 
 #[test]
+#[ignore = "requires model download from Hugging Face"]
 fn test_zenninn_kanji_conversion() {
     use karukan_engine::{Backend, KanaKanjiConverter};
     let mut conv = RomajiConverter::new();


### PR DESCRIPTION
Hugging Face からモデルをダウンロードする必要があるテスト（18件）に `#[ignore]` を追加しました。

### 背景

Open Build Service (OBS) で karukan のパッケージをビルドしているのですが、OBS のビルド環境はネットワークが遮断されているため、モデルダウンロードに依存するテストが全て失敗します。

現状は spec の `%check` で `--skip` を使ってテスト名を個別に除外していますが、上流側で `#[ignore]` が付いていれば、パッケージャ側の対応が不要になり、今後他のディストリビューションのパッケージャにも恩恵があるかと思います。

### 変更内容

- backend.rs: 3件
- kanji_conversion_tests.rs: 14件（`llamacpp_tests` モジュール内全て）
- romaji_tests.rs: 1件（`test_zenninn_kanji_conversion`）

### 動作

```bash
# デフォルトではスキップされる
cargo test -p karukan-engine
# 明示的に実行する場合
cargo test -p karukan-engine -- --ignored
```

ネットワーク不要のテスト（ローマ字変換、辞書、学習キャッシュ等）はこれまで通り `cargo test` で実行されます。