### PR TITLE
CMake に Rust ビルドをスキップする `SKIP_RUST_BUILD` オプションを追加

### DIFF
--- a/karukan-im/fcitx5-addon/CMakeLists.txt
+++ b/karukan-im/fcitx5-addon/CMakeLists.txt
@@ -26,20 +26,33 @@ include("${FCITX_INSTALL_CMAKECONFIG_DIR}/Fcitx5Utils/Fcitx5CompilerSettings.cma
 set(KARUKAN_RUST_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../../target/release/libkarukan_im.so")
 set(KARUKAN_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
-# Build Rust library as a custom target
-find_program(CARGO cargo REQUIRED)
-add_custom_target(karukan_rust_lib ALL
-    COMMAND ${CARGO} build --release -p karukan-im
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
-    COMMENT "Building karukan-im Rust library"
-    BYPRODUCTS "${KARUKAN_RUST_LIB}"
-)
+# Option to skip building the Rust library (useful when it is already built
+# externally, e.g. by a distribution package manager)
+option(SKIP_RUST_BUILD "Skip building the Rust library (assume it is already built)" OFF)
+
+if(SKIP_RUST_BUILD AND NOT EXISTS "${KARUKAN_RUST_LIB}")
+    message(FATAL_ERROR
+        "SKIP_RUST_BUILD is ON but the pre-built library was not found at: ${KARUKAN_RUST_LIB}")
+endif()
+
+if(NOT SKIP_RUST_BUILD)
+    # Build Rust library as a custom target
+    find_program(CARGO cargo REQUIRED)
+    add_custom_target(karukan_rust_lib ALL
+        COMMAND ${CARGO} build --release -p karukan-im
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+        COMMENT "Building karukan-im Rust library"
+        BYPRODUCTS "${KARUKAN_RUST_LIB}"
+    )
+endif()
 
 # Add the addon
 add_library(karukan MODULE
     src/karukan.cpp
 )
-add_dependencies(karukan karukan_rust_lib)
+if(NOT SKIP_RUST_BUILD)
+    add_dependencies(karukan karukan_rust_lib)
+endif()
 
 target_include_directories(karukan PRIVATE
     ${KARUKAN_INCLUDE_DIR}


### PR DESCRIPTION
### 背景

Open Build Service (OBS) で karukan の RPM パッケージをビルドする際、Rust ライブラリ (`libkarukan_im.so`) は spec の `%build` で `cargo build` によって先にビルドされます。その後 fcitx5 の C++ アドオンを CMake でビルドしますが、現状の CMakeLists.txt では `add_custom_target` で再度 `cargo build` が実行されてしまいます。

### 変更内容

`SKIP_RUST_BUILD` という CMake オプション（デフォルト `OFF`）を追加しました。

- `OFF`（デフォルト）: 従来通り CMake 内で `cargo build` を実行
- `ON`: Rust ビルドをスキップし、事前にビルド済みの `libkarukan_im.so` をそのまま使用

### 使い方

```bash
# 従来通り（変更なし）
cmake -B build

# パッケージャ向け: Rust は外部で事前ビルド済み
cmake -B build -DSKIP_RUST_BUILD=ON
```

既存の動作には影響しません。