### PR TITLE
Flatpak ビルド対応と GitHub Releases ワークフローの追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: Build karukan-im
+        run: cargo build --release --target ${{ matrix.target }} -p karukan-im
+
+      - name: Build karukan-cli
+        run: cargo build --release --target ${{ matrix.target }} -p karukan-cli
+
+      - name: Package artifacts
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          STAGING="karukan-${TAG}-${{ matrix.target }}"
+          mkdir -p "${STAGING}/lib" "${STAGING}/bin"
+
+          # karukan-im shared library
+          cp target/${{ matrix.target }}/release/libkarukan_im.so "${STAGING}/lib/"
+
+          # karukan-cli binaries
+          for bin in karukan-server karukan-dict sudachi-dict ajimee-bench; do
+            if [ -f "target/${{ matrix.target }}/release/${bin}" ]; then
+              cp "target/${{ matrix.target }}/release/${bin}" "${STAGING}/bin/"
+            fi
+          done
+
+          # License files
+          cp LICENSE-MIT LICENSE-APACHE "${STAGING}/"
+
+          tar czf "${STAGING}.tar.gz" "${STAGING}"
+          echo "ASSET=${STAGING}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: karukan-${{ matrix.target }}
+          path: ${{ env.ASSET }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: "*.tar.gz"

--- a/karukan-im/fcitx5-addon/CMakeLists.txt
+++ b/karukan-im/fcitx5-addon/CMakeLists.txt
@@ -22,24 +22,32 @@ include(ECMUninstallTarget)
 # Use fcitx5 compiler settings
 include("${FCITX_INSTALL_CMAKECONFIG_DIR}/Fcitx5Utils/Fcitx5CompilerSettings.cmake")
 
-# Path to the Rust library
-set(KARUKAN_RUST_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../../target/release/libkarukan_im.so")
-set(KARUKAN_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+# Path to the Rust library (overridable via -D for Flatpak builds)
+if(NOT DEFINED KARUKAN_RUST_LIB)
+    set(KARUKAN_RUST_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../../target/release/libkarukan_im.so")
+endif()
+if(NOT DEFINED KARUKAN_INCLUDE_DIR)
+    set(KARUKAN_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+endif()
 
-# Build Rust library as a custom target
-find_program(CARGO cargo REQUIRED)
-add_custom_target(karukan_rust_lib ALL
-    COMMAND ${CARGO} build --release -p karukan-im
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
-    COMMENT "Building karukan-im Rust library"
-    BYPRODUCTS "${KARUKAN_RUST_LIB}"
-)
+# Build Rust library as a custom target (skipped when KARUKAN_SKIP_CARGO is set)
+if(NOT KARUKAN_SKIP_CARGO)
+    find_program(CARGO cargo REQUIRED)
+    add_custom_target(karukan_rust_lib ALL
+        COMMAND ${CARGO} build --release -p karukan-im
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
+        COMMENT "Building karukan-im Rust library"
+        BYPRODUCTS "${KARUKAN_RUST_LIB}"
+    )
+endif()
 
 # Add the addon
 add_library(karukan MODULE
     src/karukan.cpp
 )
-add_dependencies(karukan karukan_rust_lib)
+if(NOT KARUKAN_SKIP_CARGO)
+    add_dependencies(karukan karukan_rust_lib)
+endif()
 
 target_include_directories(karukan PRIVATE
     ${KARUKAN_INCLUDE_DIR}


### PR DESCRIPTION
## 概要

- GitHub Releases でビルド済みバイナリ（`libkarukan_im.so`、CLI ツール）を配布するワークフローを追加
- `karukan-im/fcitx5-addon/CMakeLists.txt` を外部ビルドシステムから利用可能に変更
- #1 

## 変更内容

### `.github/workflows/release.yml`
タグ push (`v*`) をトリガーに、`karukan-im` と `karukan-cli` をビルドして GitHub Releases に tar.gz として添付します。

### `karukan-im/fcitx5-addon/CMakeLists.txt`
以下の CMake 変数を外部から設定可能にしました（既存の動作はデフォルト値で維持）：
- `KARUKAN_RUST_LIB` — `libkarukan_im.so` のパス
- `KARUKAN_INCLUDE_DIR` — ヘッダーのパス
- `KARUKAN_SKIP_CARGO` — `ON` にすると CMake 内の cargo ビルドをスキップ

## 動機

[fcitx/flatpak-fcitx5](https://github.com/fcitx/flatpak-fcitx5) で karukan を Flatpak アドオンとして配布するための前提作業です。

Flatpak ビルドでは SDK の Rust バージョン制約があるため、GitHub Releases のビルド済みバイナリを使用する方式にしています。これにより Flatpak ビルド時に Rust ツールチェーンが不要になります。

## 動作確認

**Ubuntu** 環境にて、以下を確認済みです：

- [jijinbei/flatpak-fcitx5 (add-karukan-addon)](https://github.com/jijinbei/flatpak-fcitx5/tree/add-karukan-addon) にて `org.fcitx.Fcitx5.Addon.Karukan` マニフェストを作成
- `flatpak-builder` によるローカルビルドが成功
- `flatpak install` によるローカルインストールが成功し、`org.fcitx.Fcitx5.Addon.Karukan` として認識される

## 今後の予定

この PR が承認された場合、続けて [fcitx/flatpak-fcitx5](https://github.com/fcitx/flatpak-fcitx5) 本家にも `org.fcitx.Fcitx5.Addon.Karukan.yaml` を追加する PR を送る予定です。これにより Flathub 経由で karukan を Flatpak アドオンとして配布できるようになります。