### PR TITLE
Add candidate rewriter system for width/case/symbol variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,7 @@ target/
 build
 *.bin
 data/
+# Tracked data: symbol descriptions / variants for the rewriter
+!karukan-engine/data/
 *.json
 *.cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 karukan is a Linux Japanese Input Method system consisting of three Rust crates:
 
-- **karukan-engine**: Core library — romaji-to-hiragana conversion, neural kana-kanji conversion via llama.cpp, system dictionary, learning cache
+- **karukan-engine**: Core library — romaji-to-hiragana conversion, neural kana-kanji conversion via llama.cpp, system dictionary, learning cache, candidate rewriter (width/case/symbol variants)
 - **karukan-cli**: CLI tools and server — dictionary builder, Sudachi converter, dict viewer, AJIMEE-Bench, HTTP API server
 - **karukan-im**: fcitx5 IME addon using karukan-engine for Japanese input on Linux
 
@@ -91,9 +91,14 @@ cargo clippy --workspace  # Lint all crates
   - `hf_download.rs` — HuggingFace model download
   - `model_config.rs` — models.toml registry
   - `error.rs` — KanjiError type
+- `rewriter/` — Candidate rewriter system
+  - `mod.rs` — Rewriter trait, RewriterChain, default_chain()
+  - `alphabet.rs` — Alphabet width/case variants (e.g. `abc` → `ABC`, `ａｂｃ`, `ＡＢＣ`)
+  - `half_katakana.rs` — Half-width katakana variants (e.g. `がっこう` → `ｶﾞｯｺｳ`)
+  - `symbol.rs` — Symbol variant chains and reading→symbol lookup (Mozc symbol.tsv derived)
 - `dict.rs` — Double-array trie system dictionary
 - `learning.rs` — Learning cache (user conversion history, TSV persistence, recency+frequency scoring)
-- `kana.rs` — Hiragana/katakana utilities
+- `kana.rs` — Hiragana/katakana utilities, full-width/half-width conversion functions
 
 ### karukan-cli (`karukan-cli/src/`)
 
@@ -132,7 +137,7 @@ cargo clippy --workspace  # Lint all crates
 - RomajiConverter accumulates output; consumed into input_buf via delta tracking
 - Models use jinen format with special Unicode tokens (U+EE00–U+EE02) from the Private Use Area; model input is katakana (hiragana is converted to katakana before inference)
 - Model registry defined in `karukan-engine/models.toml`; default models use Q5_K_M quantization
-- Learning cache records user-selected conversions and boosts them on subsequent conversions; candidate priority: Learning → User Dictionary → Model → System Dictionary → Fallback
+- Learning cache records user-selected conversions and boosts them on subsequent conversions; candidate priority: Learning → User Dictionary → Model → System Dictionary → Fallback → Rewriter
 - Learning cache is persisted as TSV (`~/.local/share/karukan-im/learning.tsv`); saved on deactivate and engine free, not on every commit
 - Learning score uses recency-weighted formula (mozc-inspired): `recency * 10.0 + ln(1 + frequency)`; eviction removes lowest-score entries when over `max_entries` (default: 10,000)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ dependencies = [
  "llama-cpp-2",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
  "tokenizers",
@@ -2217,6 +2218,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,6 +2814,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - **コンテキスト対応**: 周辺テキストを考慮した日本語変換
 - **変換学習**: ユーザーが選択した変換結果を記憶し、次回以降の変換で優先表示。予測変換（前方一致）にも対応し、入力途中でも学習済みの候補を提示
 - **システム辞書**: [SudachiDict](https://github.com/WorksApplications/SudachiDict)の辞書データからシステム辞書を構築
+- **候補リライター (Mozcから移植)**: 半角カタカナ、英字の大文字小文字・全角半角、記号の関連候補、数字の各種表記（漢数字・大字・ローマ数字・丸数字・16/8/2進数）を自動生成。各候補にはMozc由来の注釈（「半角カタカナ」「16進数」など）が付く
 
 > **Note:** 初回起動時にHugging Faceからモデルをダウンロードするため、初回の変換開始までに時間がかかります。2回目以降はダウンロード済みのモデルが使用されます。
 
@@ -39,3 +40,5 @@ MIT OR Apache-2.0 のデュアルライセンスで提供しています。
 
 - [MIT License](LICENSE-MIT)
 - [Apache License 2.0](LICENSE-APACHE)
+
+[karukan-engine/data/](karukan-engine/data/) 配下には [Mozc](https://github.com/google/mozc)（Google製日本語入力システム）から派生したデータを含み、こちらは [BSD 3-Clause License](http://opensource.org/licenses/BSD-3-Clause) のもとで配布されています。各派生ファイルの由来およびMozcの著作権表記は [THIRD_PARTY_LICENSES](THIRD_PARTY_LICENSES) を参照してください。

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,0 +1,35 @@
+===============================================================================
+Mozc - Japanese Input Method Editor
+https://github.com/google/mozc
+===============================================================================
+
+karukan-engine/data/symbols.yml is derived from Mozc's symbol.tsv.
+
+Copyright 2010-2018, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/karukan-engine/Cargo.toml
+++ b/karukan-engine/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml = "0.9"
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/karukan-engine/data/symbols.yml
+++ b/karukan-engine/data/symbols.yml
@@ -1,0 +1,13214 @@
+# Derived from Mozc symbol.tsv (https://github.com/google/mozc)
+# Copyright 2010-2018, Google Inc. Licensed under BSD 3-Clause.
+# See /THIRD_PARTY_LICENSES for the full license text.
+
+descriptions:
+  # Single-bracket forms (mozc keeps these under POS=括弧開/括弧閉 with
+  # ASCII/halfwidth-only readings, so they're filtered out of `entries`).
+  # Other curated overrides also live here. Anything in `entries` whose
+  # description matches mozc need NOT be repeated below.
+  〈: 始め山括弧
+  〉: 終わり山括弧
+  《: 始め二重山括弧
+  》: 終わり二重山括弧
+  「: 始めかぎ括弧
+  」: 終わりかぎ括弧
+  『: 始め二重かぎ括弧
+  』: 終わり二重かぎ括弧
+  【: 始めすみつき括弧
+  】: 終わりすみつき括弧
+  〔: 始め甲括弧
+  〕: 終わり甲括弧
+  〘: 始め二重甲括弧
+  〙: 終わり二重甲括弧
+  〚: 始め二重角括弧
+  〛: 終わり二重角括弧
+  （: 始め丸括弧
+  ）: 終わり丸括弧
+  ［: 始め角括弧
+  ］: 終わり角括弧
+  ｛: 始め波括弧
+  ｝: 終わり波括弧
+variants:
+- key: 「
+  chain:
+  - 『
+  - 【
+  - 〔
+  - （
+  - 〈
+  - 《
+  - ［
+  - ｛
+  - 〘
+  - 〚
+  - ｢
+- key: 『
+  chain:
+  - 「
+  - 【
+  - 〔
+  - （
+  - 〈
+  - 《
+  - ［
+  - ｛
+  - 〘
+  - 〚
+- key: 【
+  chain:
+  - 「
+  - 『
+  - 〔
+  - （
+  - 〈
+  - 《
+  - ［
+  - ｛
+  - 〘
+  - 〚
+- key: （
+  chain:
+  - 「
+  - 『
+  - 【
+  - 〔
+  - 〈
+  - 《
+  - ［
+  - ｛
+  - (
+  - 〘
+  - 〚
+- key: 〔
+  chain:
+  - 「
+  - 『
+  - 【
+  - （
+  - 〈
+  - 《
+  - ［
+  - ｛
+  - 〘
+  - 〚
+- key: 〈
+  chain:
+  - 「
+  - 『
+  - 【
+  - （
+  - 〔
+  - 《
+  - ［
+  - ｛
+  - 〘
+  - 〚
+- key: 《
+  chain:
+  - 「
+  - 『
+  - 【
+  - （
+  - 〔
+  - 〈
+  - ［
+  - ｛
+  - 〘
+  - 〚
+- key: ［
+  chain:
+  - 「
+  - 『
+  - 【
+  - （
+  - 〔
+  - 〈
+  - 《
+  - ｛
+  - '['
+  - 〘
+  - 〚
+- key: ｛
+  chain:
+  - 「
+  - 『
+  - 【
+  - （
+  - 〔
+  - 〈
+  - 《
+  - ［
+  - '{'
+  - 〘
+  - 〚
+- key: (
+  chain:
+  - 「
+  - 『
+  - 【
+  - （
+  - '['
+  - 〔
+  - '{'
+- key: '['
+  chain:
+  - 「
+  - 『
+  - 【
+  - ［
+  - (
+  - 〔
+  - '{'
+- key: '{'
+  chain:
+  - 「
+  - 『
+  - 【
+  - ｛
+  - (
+  - '['
+  - 〔
+- key: 」
+  chain:
+  - 』
+  - 】
+  - 〕
+  - ）
+  - 〉
+  - 》
+  - ］
+  - ｝
+  - 〙
+  - 〛
+  - ｣
+- key: 』
+  chain:
+  - 」
+  - 】
+  - 〕
+  - ）
+  - 〉
+  - 》
+  - ］
+  - ｝
+  - 〙
+  - 〛
+- key: 】
+  chain:
+  - 」
+  - 』
+  - 〕
+  - ）
+  - 〉
+  - 》
+  - ］
+  - ｝
+  - 〙
+  - 〛
+- key: ）
+  chain:
+  - 」
+  - 』
+  - 】
+  - 〕
+  - 〉
+  - 》
+  - ］
+  - ｝
+  - )
+  - 〙
+  - 〛
+- key: 〕
+  chain:
+  - 」
+  - 』
+  - 】
+  - ）
+  - 〉
+  - 》
+  - ］
+  - ｝
+  - 〙
+  - 〛
+- key: 〉
+  chain:
+  - 」
+  - 』
+  - 】
+  - ）
+  - 〕
+  - 》
+  - ］
+  - ｝
+  - 〙
+  - 〛
+- key: 》
+  chain:
+  - 」
+  - 』
+  - 】
+  - ）
+  - 〕
+  - 〉
+  - ］
+  - ｝
+  - 〙
+  - 〛
+- key: ］
+  chain:
+  - 」
+  - 』
+  - 】
+  - ）
+  - 〕
+  - 〉
+  - 》
+  - ｝
+  - ']'
+  - 〙
+  - 〛
+- key: ｝
+  chain:
+  - 」
+  - 』
+  - 】
+  - ）
+  - 〕
+  - 〉
+  - 》
+  - ］
+  - '}'
+  - 〙
+  - 〛
+- key: )
+  chain:
+  - 」
+  - 』
+  - 】
+  - ）
+  - ']'
+  - 〕
+  - '}'
+- key: ']'
+  chain:
+  - 」
+  - 』
+  - 】
+  - ］
+  - )
+  - 〕
+  - '}'
+- key: '}'
+  chain:
+  - 」
+  - 』
+  - 】
+  - ｝
+  - )
+  - ']'
+  - 〕
+- key: 「」
+  chain:
+  - 『』
+  - 【】
+  - 〔〕
+  - （）
+  - 〈〉
+  - 《》
+  - ［］
+  - ｛｝
+  - 〘〙
+  - 〚〛
+  - ｢｣
+  - ()
+  - '[]'
+  - '{}'
+  - '""'
+  - ''''''
+  - “”
+  - ‘’
+- key: 『』
+  chain:
+  - 「」
+  - 【】
+  - 〔〕
+  - （）
+  - 〈〉
+  - 《》
+  - ［］
+  - ｛｝
+  - 〘〙
+  - 〚〛
+  - ()
+  - '[]'
+  - '{}'
+- key: 【】
+  chain:
+  - 「」
+  - 『』
+  - 〔〕
+  - （）
+  - 〈〉
+  - 《》
+  - ［］
+  - ｛｝
+  - 〘〙
+  - 〚〛
+  - ()
+  - '[]'
+  - '{}'
+- key: （）
+  chain:
+  - 「」
+  - 『』
+  - 【】
+  - 〔〕
+  - 〈〉
+  - 《》
+  - ［］
+  - ｛｝
+  - 〘〙
+  - 〚〛
+  - ()
+  - '[]'
+  - '{}'
+- key: 〔〕
+  chain:
+  - 「」
+  - 『』
+  - 【】
+  - （）
+  - 〈〉
+  - 《》
+  - ［］
+  - ｛｝
+  - 〘〙
+  - 〚〛
+- key: 〈〉
+  chain:
+  - 「」
+  - 『』
+  - 【】
+  - （）
+  - 〔〕
+  - 《》
+  - ［］
+  - ｛｝
+  - 〘〙
+  - 〚〛
+  - <>
+  - ＜＞
+- key: 《》
+  chain:
+  - 「」
+  - 『』
+  - 【】
+  - （）
+  - 〔〕
+  - 〈〉
+  - ［］
+  - ｛｝
+  - 〘〙
+  - 〚〛
+  - <<>>
+- key: ［］
+  chain:
+  - 「」
+  - 『』
+  - 【】
+  - （）
+  - 〔〕
+  - 〈〉
+  - 《》
+  - ｛｝
+  - 〘〙
+  - 〚〛
+  - '[]'
+  - ()
+  - '{}'
+- key: ｛｝
+  chain:
+  - 「」
+  - 『』
+  - 【】
+  - （）
+  - 〔〕
+  - 〈〉
+  - 《》
+  - ［］
+  - 〘〙
+  - 〚〛
+  - '{}'
+  - ()
+  - '[]'
+- key: ()
+  chain:
+  - 「」
+  - 『』
+  - 【】
+  - （）
+  - 〔〕
+  - 〈〉
+  - 《》
+  - ［］
+  - ｛｝
+  - '[]'
+  - '{}'
+- key: '[]'
+  chain:
+  - 「」
+  - 『』
+  - 【】
+  - （）
+  - 〔〕
+  - 〈〉
+  - 《》
+  - ［］
+  - ｛｝
+  - ()
+  - '{}'
+- key: '{}'
+  chain:
+  - 「」
+  - 『』
+  - 【】
+  - （）
+  - 〔〕
+  - 〈〉
+  - 《》
+  - ［］
+  - ｛｝
+  - ()
+  - '[]'
+- key: “”
+  chain:
+  - '""'
+  - 「」
+  - 『』
+  - ‘’
+- key: ‘’
+  chain:
+  - ''''''
+  - 「」
+  - 『』
+  - “”
+- key: '""'
+  chain:
+  - “”
+  - 「」
+  - 『』
+- key: ''''''
+  chain:
+  - ‘’
+  - 「」
+  - 『』
+- key: <>
+  chain:
+  - 〈〉
+  - 《》
+  - ＜＞
+- key: ＜＞
+  chain:
+  - 〈〉
+  - 《》
+  - <>
+- key: 、
+  chain:
+  - ，
+  - ','
+  - ､
+- key: 。
+  chain:
+  - ．
+  - .
+  - ｡
+- key: ，
+  chain:
+  - 、
+  - ','
+- key: ．
+  chain:
+  - 。
+  - .
+- key: ','
+  chain:
+  - 、
+  - ，
+- key: .
+  chain:
+  - 。
+  - ．
+- key: ‥
+  chain:
+  - 。。
+  - ..
+  - ・・
+  - ．．
+  - …
+- key: 。。
+  chain:
+  - ‥
+  - ..
+  - ・・
+  - ．．
+  - …
+- key: ..
+  chain:
+  - ‥
+  - 。。
+  - ・・
+  - ．．
+  - …
+- key: ・・
+  chain:
+  - ‥
+  - 。。
+  - ..
+  - ．．
+- key: ．．
+  chain:
+  - ‥
+  - 。。
+  - ..
+  - ・・
+- key: …
+  chain:
+  - 。。。
+  - '...'
+  - ・・・
+  - ．．．
+  - ‥
+- key: 。。。
+  chain:
+  - …
+  - '...'
+  - ・・・
+  - ．．．
+  - ‥
+- key: '...'
+  chain:
+  - …
+  - 。。。
+  - ・・・
+  - ．．．
+  - ‥
+- key: ・・・
+  chain:
+  - …
+  - 。。。
+  - '...'
+  - ．．．
+- key: ．．．
+  chain:
+  - …
+  - 。。。
+  - '...'
+  - ・・・
+- key: ！！
+  chain:
+  - '!!'
+  - ‼
+- key: '!!'
+  chain:
+  - ！！
+  - ‼
+- key: ？？
+  chain:
+  - ??
+  - ⁇
+- key: ??
+  chain:
+  - ？？
+  - ⁇
+- key: ！？
+  chain:
+  - '!?'
+  - ?!
+  - ？！
+  - ⁉
+- key: ？！
+  chain:
+  - ?!
+  - '!?'
+  - ！？
+  - ⁈
+- key: '!?'
+  chain:
+  - ?!
+  - ！？
+  - ？！
+  - ⁉
+- key: ?!
+  chain:
+  - '!?'
+  - ？！
+  - ！？
+  - ⁈
+- key: ・
+  chain:
+  - ･
+  - /
+  - ／
+- key: ！
+  chain:
+  - '!'
+  - ！？
+  - '!?'
+- key: '!'
+  chain:
+  - ！
+  - ！？
+  - '!?'
+- key: ？
+  chain:
+  - '?'
+  - ？！
+  - ?!
+- key: '?'
+  chain:
+  - ？
+  - ？！
+  - ?!
+- key: ：
+  chain:
+  - ':'
+- key: ':'
+  chain:
+  - ：
+  - ;
+- key: ；
+  chain:
+  - ;
+- key: ;
+  chain:
+  - ；
+  - ':'
+- key: ／
+  chain:
+  - /
+  - ＼
+  - ・
+- key: /
+  chain:
+  - ／
+  - ＼
+- key: ＼
+  chain:
+  - \
+  - ／
+- key: \
+  chain:
+  - ＼
+- key: 〜
+  chain:
+  - '~'
+  - ～
+- key: '~'
+  chain:
+  - 〜
+  - ～
+- key: ー
+  chain:
+  - —
+  - –
+  - '-'
+  - ｰ
+- key: '-'
+  chain:
+  - ー
+  - —
+  - –
+  - ｰ
+- key: '"'
+  chain:
+  - ”
+  - “
+  - ＂
+  - 「
+  - 『
+- key: ''''
+  chain:
+  - ’
+  - ‘
+  - ｀
+- key: ”
+  chain:
+  - '"'
+  - “
+  - ＂
+- key: “
+  chain:
+  - '"'
+  - ”
+  - ＂
+- key: ＂
+  chain:
+  - '"'
+  - ”
+  - “
+- key: ’
+  chain:
+  - ''''
+  - ‘
+- key: ‘
+  chain:
+  - ''''
+  - ’
+- key: ｀
+  chain:
+  - '`'
+  - ''''
+- key: '`'
+  chain:
+  - ｀
+  - ''''
+- key: +
+  chain:
+  - ＋
+  - ±
+- key: ＋
+  chain:
+  - +
+  - ±
+- key: '='
+  chain:
+  - ＝
+  - ≠
+- key: ＝
+  chain:
+  - '='
+  - ≠
+- key: '*'
+  chain:
+  - ＊
+  - ×
+  - ・
+  - ※
+  - ★
+  - ☆
+- key: ＊
+  chain:
+  - '*'
+  - ×
+- key: <
+  chain:
+  - ＜
+  - ≦
+  - ≪
+- key: ＜
+  chain:
+  - <
+  - ≦
+  - ≪
+- key: '>'
+  chain:
+  - ＞
+  - ≧
+  - ≫
+- key: ＞
+  chain:
+  - '>'
+  - ≧
+  - ≫
+- key: '&'
+  chain:
+  - ＆
+- key: ＆
+  chain:
+  - '&'
+- key: '@'
+  chain:
+  - ＠
+- key: ＠
+  chain:
+  - '@'
+- key: '#'
+  chain:
+  - ＃
+  - ♯
+- key: ＃
+  chain:
+  - '#'
+  - ♯
+- key: '%'
+  chain:
+  - ％
+  - ‰
+- key: ％
+  chain:
+  - '%'
+  - ‰
+- key: $
+  chain:
+  - ＄
+  - ¥
+  - ￥
+  - €
+- key: ＄
+  chain:
+  - $
+  - ¥
+  - ￥
+  - €
+- key: _
+  chain:
+  - ＿
+  - ー
+- key: ＿
+  chain:
+  - _
+- key: '|'
+  chain:
+  - ｜
+  - ￤
+- key: ｜
+  chain:
+  - '|'
+  - ￤
+- key: ^
+  chain:
+  - ＾
+- key: ＾
+  chain:
+  - ^
+- key: 　
+  chain:
+  - ' '
+- key: ' '
+  chain:
+  - 　
+- key: 〒
+  chain:
+  - 〶
+- key: 円
+  chain:
+  - ¥
+  - ￥
+  - $
+  - ＄
+  - €
+- key: ¥
+  chain:
+  - ￥
+  - $
+  - ＄
+  - €
+- key: ￥
+  chain:
+  - ¥
+  - $
+  - ＄
+  - €
+
+# ---------------------------------------------------------------------------
+# Auto-generated section from mozc/src/data/symbol/symbol.tsv.
+# Maps reading (hiragana) → symbol candidates. Only rows whose readings
+# contain at least one pure-kana token are included; literal symbol-only
+# readings (e.g. `,`, `「`) are dropped because karukan's fallback/rewriter
+# paths already handle them. Katakana readings have been normalized to
+# hiragana so they match the IM's reading buffer. Re-running the porter
+# (`/tmp/port_mozc_symbols.py` archetype) overwrites only the entries below.
+# ---------------------------------------------------------------------------
+entries:
+- char: 、
+  readings:
+  - とうてん
+  - ','
+  - 、
+  - ，
+  - てん
+  description: 読点
+- char: 。
+  readings:
+  - くてん
+  - .
+  - ．
+  - 。
+  - まる
+  description: 句点
+- char: ，
+  readings:
+  - かんま
+  - こんま
+  - ','
+  - ，
+  - 、
+  - てん
+  description: カンマ
+- char: ．
+  readings:
+  - ぴりおど
+  - どっと
+  - .
+  - ．
+  - 。
+  - てん
+  description: ピリオド
+- char: ・
+  readings:
+  - てん
+  - なかてん
+  - なかぐろ
+  - 、
+  - ・
+  - /
+  description: 中点
+- char: ：
+  readings:
+  - ころん
+  - ':'
+  - ：
+  - てん
+  description: コロン
+- char: ；
+  readings:
+  - せみころん
+  - ;
+  - ；
+  - てん
+  description: セミコロン
+- char: ？
+  readings:
+  - ぎもんふ
+  - .
+  - '?'
+  - ？
+  - くえすちょん
+  - はてな
+  - ・
+  description: 疑問符
+- char: ？？
+  readings:
+  - ぎもんふ
+  - .
+  - '?'
+  - ？
+  - くえすちょん
+  - はてな
+  - ・
+  description: 疑問符
+- char: ？！
+  readings:
+  - ぎもんふ
+  - .
+  - '?'
+  - ？
+  - くえすちょん
+  - はてな
+  - ・
+  description: 疑問符
+- char: ！？
+  readings:
+  - ぎもんふ
+  - かんたんふ
+  - .
+  - '?'
+  - ？
+  - '!'
+  - ！
+  - くえすちょん
+  - はてな
+  - えくすくらめーしょん
+  - びっくり
+  - ・
+  description: 疑問符
+- char: ！
+  readings:
+  - かんたんふ
+  - .
+  - '!'
+  - ！
+  - えくすくらめーしょん
+  - びっくり
+  description: 感嘆符
+- char: ！！
+  readings:
+  - かんたんふ
+  - .
+  - '!'
+  - ！
+  - えくすくらめーしょん
+  - びっくり
+  description: 感嘆符
+- char: ゛
+  readings:
+  - だくてん
+  - '"'
+  - てん
+  - てんてん
+  - きごう
+  description: 濁点
+- char: ゜
+  readings:
+  - はんだくてん
+  - まる
+  - ''''
+  - てん
+  - きごう
+  description: 半濁点
+- char: '"'
+  readings:
+  - '"'
+  - だぶるくおーと
+  - だぶるくおーてーしょん
+  - くぉーと
+  - だぶるくぉーてしょん
+  - きごう
+  description: ダブルクオーテーション
+- char: ´
+  readings:
+  - あきゅーと
+  - きごう
+  - ''''
+  description: アキュートアクセント
+- char: ''''
+  readings:
+  - あぽすとろふぃ
+  - くぉーと
+  - きごう
+  - ''''
+  description: アポストロフィ
+- char: ¨
+  readings:
+  - うむらうと
+  - とれま
+  - きごう
+  description: ウムラウト／トレマ
+- char: ｀
+  readings:
+  - '`'
+  - ぐらーぶ
+  - きごう
+  description: グラーブアクセント
+- char: ˝
+  readings:
+  - だぶるあきゅーと
+  description: ダブルアキュート
+- char: '~'
+  readings:
+  - ちるだ
+  - きごう
+  description: チルダ
+- char: ¯
+  readings:
+  - まくろん
+  - きごう
+  description: マクロン
+- char: ＾
+  readings:
+  - ^
+  - きごう
+  description: ハット
+- char: ￣
+  readings:
+  - '~'
+  - きごう
+  - うえ
+  - おーばーらいん
+  description: オーバーライン
+- char: ＿
+  readings:
+  - _
+  - きごう
+  - した
+  - あんだーばー
+  - あんだーすこあ
+  - あんだーらいん
+  description: アンダーライン
+- char: '　'
+  readings:
+  - すぺーす
+  - くうはく
+  description: 空白
+- char: ␣
+  readings:
+  - すぺーす
+  - くうはく
+  description: 空白記号
+- char: ヽ
+  readings:
+  - おなじ
+  - くりかえし
+  - どう
+  - きごう
+  - おどりじ
+  - おどり
+  - かさねじ
+  - おくりじ
+  - ゆすりじ
+  - じゅうてん
+  - じょうじ
+  description: 繰り返し記号 踊り字
+- char: ヾ
+  readings:
+  - おなじ
+  - くりかえし
+  - どう
+  - きごう
+  - おどりじ
+  - おどり
+  - かさねじ
+  - おくりじ
+  - ゆすりじ
+  - じゅうてん
+  - じょうじ
+  description: 繰り返し記号 踊り字
+- char: ゝ
+  readings:
+  - おなじ
+  - くりかえし
+  - どう
+  - きごう
+  - おどりじ
+  - おどり
+  - かさねじ
+  - おくりじ
+  - ゆすりじ
+  - じゅうてん
+  - じょうじ
+  description: 繰り返し記号 踊り字
+- char: ゞ
+  readings:
+  - おなじ
+  - くりかえし
+  - どう
+  - きごう
+  - おどりじ
+  - おどり
+  - かさねじ
+  - おくりじ
+  - ゆすりじ
+  - じゅうてん
+  - じょうじ
+  description: 繰り返し記号 踊り字
+- char: 〃
+  readings:
+  - おなじ
+  - くりかえし
+  - どう
+  - きごう
+  - おどりじ
+  - おどり
+  - かさねじ
+  - おくりじ
+  - ゆすりじ
+  - じゅうてん
+  - じょうじ
+  - おなじく
+  - どうじょう
+  - のの
+  - ののじ
+  - ののてん
+  - ののじてん
+  description: 繰り返し記号 同上
+- char: 仝
+  readings:
+  - おなじ
+  - どう
+  - きごう
+- char: 々
+  readings:
+  - おなじ
+  - くりかえし
+  - どう
+  - のま
+  - きごう
+  - おどりじ
+  - おどり
+  - かさねじ
+  - おくりじ
+  - ゆすりじ
+  - じゅうてん
+  - じょうじ
+  description: 繰り返し記号 踊り字
+- char: 〆
+  readings:
+  - しめ
+  - きごう
+  description: しめ
+- char: 〇
+  readings:
+  - ぜろ
+  - れい
+  - きごう
+  description: 漢数字ゼロ
+- char: ー
+  readings:
+  - '-'
+  - ー
+  - －
+  - ―
+  description: 長音
+- char: '-'
+  readings:
+  - '-'
+  - ー
+  - －
+  - ―
+  - はいふん
+  - まいなす
+  - きごう
+  description: ハイフン マイナス
+- char: ―
+  readings:
+  - '-'
+  - ー
+  - －
+  - ―
+  - だっしゅ
+  - きごう
+  description: ダッシュ 水平棒
+- char: –
+  readings:
+  - '-'
+  - ー
+  - －
+  - ―
+  - だっしゅ
+  - きごう
+  - えんだっしゅ
+  - にぶだーし
+  - にぶだっしゅ
+  - enだっしゅ
+  - ENだっしゅ
+  description: enダッシュ(二分)
+- char: —
+  readings:
+  - '-'
+  - ー
+  - －
+  - ―
+  - だっしゅ
+  - きごう
+  - えmだっしゅ
+  - えむだっしゅ
+  - ぜんかくだっしゅ
+  - emだっしゅ
+  - EMだっしゅ
+  description: emダッシュ(全角)
+- char: ‐
+  readings:
+  - '-'
+  - ー
+  - －
+  - ―
+  - はいふん
+  description: ハイフン
+- char: ／
+  readings:
+  - すらっしゅ
+  - しゃせん
+  - ・
+  - /
+  - きごう
+  - ななめ
+  description: スラッシュ
+- char: ＼
+  readings:
+  - ばっくすらっしゅ
+  - ぎゃくしゃせん
+  - ・
+  - /
+  - ／
+  - \
+  - ＼
+  - ¥
+  - ￥
+  - きごう
+  - しゃせん
+  - すらっしゅ
+  - ななめ
+  description: バックスラッシュ
+- char: \
+  readings:
+  - ばっくすらっしゅ
+  - ぎゃくしゃせん
+  - ・
+  - /
+  - ／
+  - \
+  - ＼
+  - ¥
+  - ￥
+  - きごう
+  - しゃせん
+  - すらっしゅ
+  - ななめ
+  description: バックスラッシュ
+- char: 〜
+  readings:
+  - にょろ
+  - なみ
+  - から
+  - ー
+  - '-'
+  - '~'
+  - きごう
+  - より
+  description: 波ダッシュ
+- char: ∥
+  readings:
+  - '|'
+  - '||'
+  - たてぼう
+  - たてせん
+  - へいこう
+  - きごう
+  description: 縦線 平行
+- char: ‖
+  readings:
+  - '|'
+  - '||'
+  - たてぼう
+  - たてせん
+  - そうちゅう
+  - きごう
+  description: 縦線 双柱
+- char: ｜
+  readings:
+  - '|'
+  - たてぼう
+  - たてせん
+  - きごう
+  description: 縦線
+- char: …
+  readings:
+  - 。。。
+  - .
+  - ...
+  - ・・・
+  - ・
+  - 。
+  - てん
+  - きごう
+  - あまり
+  - さんてん
+  - さんてんりーだ
+  - さんてんりーだー
+  description: 三点リーダ
+- char: ‥
+  readings:
+  - 。。
+  - ..
+  - ・・
+  - ・
+  - 。
+  - てん
+  - など
+  - きごう
+  - にてんりーだ
+  - にてんりーだー
+  description: 二点リーダ
+- char: ︙
+  readings:
+  - 。。。
+  - .
+  - ...
+  - ・・・
+  - ・
+  - …
+  - ':'
+  - てん
+  - きごう
+  - さんてん
+  - さんてんりーだ
+  - さんてんりーだー
+  - たてさんてんりーだ
+  - たてさんてんりーだー
+  - たてりーだ
+  - たてりーだー
+  description: 三点リーダ (縦)
+- char: ︰
+  readings:
+  - 。。
+  - ..
+  - ・・
+  - ・
+  - ‥
+  - ':'
+  - てん
+  - など
+  - きごう
+  - にてんりーだ
+  - にてんりーだー
+  - たてにてんりーだ
+  - たてにてんりーだー
+  - たてりーだ
+  - たてりーだー
+  description: 二点リーダ (縦)
+- char: ‘
+  readings:
+  - ばっくくおーと
+  - ばっくくぉーと
+  - ''''
+  - '"'
+  - きごう
+  description: 左シングル引用符
+- char: ’
+  readings:
+  - くおーと
+  - くおーてーしょん
+  - くぉーと
+  - くぉーてーしょん
+  - ''''
+  - '"'
+  - きごう
+  description: 右シングル引用符
+- char: “
+  readings:
+  - '"'
+  - ''''
+  - だぶるくおーと
+  - だぶるくおーてーしょん
+  - くぉーと
+  - だぶるくぉーてしょん
+  - きごう
+  description: 左ダブル引用符
+- char: ”
+  readings:
+  - '"'
+  - ''''
+  - だぶるくおーと
+  - だぶるくおーてーしょん
+  - くぉーと
+  - だぶるくぉーてしょん
+  - きごう
+  description: 右ダブル引用符
+- char: （
+  readings:
+  - '['
+  - 「
+  - (
+  - ｢
+  description: 始め丸括弧
+- char: ）
+  readings:
+  - ']'
+  - 」
+  - )
+  - ｣
+  description: 終わり丸括弧
+- char: 〔
+  readings:
+  - '['
+  - 「
+  - (
+  - ｢
+  description: 始め甲括弧
+- char: 〕
+  readings:
+  - ']'
+  - 」
+  - )
+  - ｣
+  description: 終わり甲括弧
+- char: ［
+  readings:
+  - '['
+  - 「
+  - (
+  - ｢
+  description: 始め角括弧
+- char: ］
+  readings:
+  - ']'
+  - 」
+  - )
+  - ｣
+  description: 終わり角括弧
+- char: 〘
+  readings:
+  - '['
+  - 「
+  - (
+  - ｢
+  description: 始め二重甲括弧
+- char: 〙
+  readings:
+  - ']'
+  - 」
+  - )
+  - ｣
+  description: 終わり二重甲括弧
+- char: 〚
+  readings:
+  - '['
+  - 「
+  - (
+  - ｢
+  description: 始め二重角括弧
+- char: 〛
+  readings:
+  - ']'
+  - 」
+  - )
+  - ｣
+  description: 終わり二重角括弧
+- char: ｛
+  readings:
+  - '{'
+  - '['
+  - (
+  - 「
+  - ｢
+  description: 始め波括弧
+- char: ｝
+  readings:
+  - '}'
+  - ']'
+  - )
+  - 」
+  - ｣
+  description: 終わり波括弧
+- char: 〈
+  readings:
+  - <
+  - (
+  - '['
+  - 「
+  - ｢
+  description: 始め山括弧
+- char: 〉
+  readings:
+  - '>'
+  - )
+  - ']'
+  - 」
+  - ｣
+  description: 終わり山括弧
+- char: ‹
+  readings:
+  - <
+  - (
+  - '['
+  - 「
+  - ｢
+  description: 始め山括弧
+- char: ›
+  readings:
+  - '>'
+  - )
+  - ']'
+  - 」
+  - ｣
+  description: 終わり山括弧
+- char: 《
+  readings:
+  - <<
+  - (
+  - '['
+  - 「
+  - ｢
+  description: 始め二重山括弧
+- char: 》
+  readings:
+  - '>>'
+  - )
+  - ']'
+  - 」
+  - ｣
+  description: 終わり二重山括弧
+- char: «
+  readings:
+  - ぎゅめ
+  - <<
+  - (
+  - '['
+  - 「
+  - ｢
+  description: 始め二重山括弧・ギュメ
+- char: »
+  readings:
+  - ぎゅめ
+  - '>>'
+  - )
+  - ']'
+  - 」
+  - ｣
+  description: 終わり二重山括弧・ギュメ
+- char: 「
+  readings:
+  - '['
+  - 「
+  - (
+  - ｢
+  description: 始めかぎ括弧
+- char: 」
+  readings:
+  - ']'
+  - 」
+  - )
+  - ｣
+  description: 終わりかぎ括弧
+- char: 『
+  readings:
+  - '['
+  - 「
+  - (
+  - ｢
+  description: 始め二重かぎ括弧
+- char: 』
+  readings:
+  - ']'
+  - 」
+  - )
+  - ｣
+  description: 終わり二重かぎ括弧
+- char: 【
+  readings:
+  - '['
+  - 「
+  - (
+  - ｢
+  description: 始めすみつき括弧
+- char: 】
+  readings:
+  - ']'
+  - 」
+  - )
+  - ｣
+  description: 終わりすみつき括弧
+- char: 〝
+  readings:
+  - '['
+  - 「
+  - (
+  - ｢
+  - '"'
+  - ''''
+  - きごう
+  description: 始め爪括弧
+- char: 〟
+  readings:
+  - ']'
+  - 」
+  - )
+  - ｣
+  - '"'
+  - ''''
+  - きごう
+  description: 終わり爪括弧
+- char: （）
+  readings:
+  - ()
+  - 「」
+  - かっこ
+  - まるかっこ
+  description: 丸括弧
+- char: 〔〕
+  readings:
+  - ()
+  - 「」
+  - かっこ
+  - こうかっこ
+  description: 甲括弧
+- char: ［］
+  readings:
+  - ()
+  - 「」
+  - かっこ
+  - かくかっこ
+  description: 角括弧
+- char: 〘〙
+  readings:
+  - ()
+  - 「」
+  - かっこ
+  - こうかっこ
+  description: 二重甲括弧
+- char: 〚〛
+  readings:
+  - ()
+  - 「」
+  - かっこ
+  - かくかっこ
+  description: 二重角括弧
+- char: ｛｝
+  readings:
+  - ()
+  - 「」
+  - かっこ
+  - なみかっこ
+  description: 波括弧
+- char: 〈〉
+  readings:
+  - ()
+  - 「」
+  - <>
+  - かっこ
+  - やまかっこ
+  description: 山括弧
+- char: 《》
+  readings:
+  - ()
+  - 「」
+  - <<>>
+  - かっこ
+  - やまかっこ
+  description: 二重山括弧
+- char: «»
+  readings:
+  - ()
+  - 「」
+  - <<>>
+  - かっこ
+  - やまかっこ
+  - ぎゅめ
+  description: 二重山括弧・ギュメ
+- char: ‹›
+  readings:
+  - ()
+  - 「」
+  - <>
+  - かっこ
+  - やまかっこ
+  description: 一重山括弧
+- char: 「」
+  readings:
+  - ()
+  - 「」
+  - かっこ
+  - かぎかっこ
+  description: かぎ括弧
+- char: 『』
+  readings:
+  - ()
+  - 「」
+  - かっこ
+  - かぎかっこ
+  description: 二重かぎ括弧
+- char: 【】
+  readings:
+  - ()
+  - 「」
+  - かっこ
+  description: すみつき括弧
+- char: ‘’
+  readings:
+  - ()
+  - 「」
+  - '""'
+  - ''''''
+  - かっこ
+  description: シングル引用符
+- char: “”
+  readings:
+  - ()
+  - 「」
+  - '""'
+  - ''''''
+  - かっこ
+  description: ダブル引用符
+- char: 〝〟
+  readings:
+  - ()
+  - 「」
+  - '""'
+  - ''''''
+  - かっこ
+  - つめかっこ
+  - だぶるみにゅーと
+  - ののかぎ
+  description: 爪括弧
+- char: ＋
+  readings:
+  - ぷらす
+  - たす
+  - すうがく
+  - +
+  - ＋
+  description: 加算記号
+- char: −
+  readings:
+  - まいなす
+  - ひく
+  - はいふん
+  - すうがく
+  - '-'
+  - ー
+  description: 減算記号 マイナス
+- char: ±
+  readings:
+  - ぷらすまいなす
+  - ぷらまい
+  - +-
+  - +ー
+  - すうがく
+  - きごう
+  description: 正または負記号
+- char: ∓
+  readings:
+  - まいなすぷらす
+  - '-+'
+  - ー+
+  - すうがく
+  - きごう
+  description: 負または正記号
+- char: ×
+  readings:
+  - かける
+  - すうがく
+  - '*'
+  - ばつ
+  - ぺけ
+  - きごう
+  description: 乗算記号
+- char: ÷
+  readings:
+  - わる
+  - すうがく
+  - /
+  - ・
+  - きごう
+  description: 除算記号
+- char: ＝
+  readings:
+  - いこーる
+  - とうごう
+  - すうがく
+  - =
+  description: 等号
+- char: ゠
+  readings:
+  - だぶるはいふん
+  - =
+  description: ダブルハイフン
+- char: ≠
+  readings:
+  - ふとうごう
+  - のっといこーる
+  - すうがく
+  - =
+  - '!='
+  - <>
+  - きごう
+  - とうごう
+  description: 等号否定
+- char: ＜
+  readings:
+  - ふとうごう
+  - しょうなり
+  - すうがく
+  - <
+  description: 不等号
+- char: ＞
+  readings:
+  - ふとうごう
+  - だいなり
+  - すうがく
+  - '>'
+  description: 不等号
+- char: ≦
+  readings:
+  - ふとうごう
+  - しょうなりいこーる
+  - すうがく
+  - <
+  - <=
+  - きごう
+  description: 不等号
+- char: ≧
+  readings:
+  - ふとうごう
+  - だいなりいこーる
+  - すうがく
+  - '>'
+  - '>='
+  - きごう
+  description: 不等号
+- char: ⋮
+  readings:
+  - 。。。
+  - .
+  - ...
+  - ・・・
+  - ・
+  - 。
+  - てん
+  - さんてん
+  - さんてんりーだ
+  - さんてんりーだー
+  description: 省略記号 三点リーダー
+- char: ⋯
+  readings:
+  - 。。。
+  - .
+  - ...
+  - ・・・
+  - ・
+  - 。
+  - てん
+  - あまり
+  - さんてん
+  - さんてんりーだ
+  - さんてんりーだー
+  description: 省略記号 三点リーダー
+- char: ⋰
+  readings:
+  - 。。。
+  - .
+  - ...
+  - ・・・
+  - ・
+  - 。
+  - てん
+  - さんてん
+  - さんてんりーだ
+  - さんてんりーだー
+  description: 省略記号 三点リーダー
+- char: ⋱
+  readings:
+  - 。。。
+  - .
+  - ...
+  - ・・・
+  - ・
+  - 。
+  - てん
+  - さんてん
+  - さんてんりーだ
+  - さんてんりーだー
+  description: 省略記号 三点リーダー
+- char: ∞
+  readings:
+  - むげんだい
+  - むげん
+  - すうがく
+  - きごう
+  description: 無限大
+- char: ∴
+  readings:
+  - ゆえに
+  - すうがく
+  - きごう
+  - さんかく
+  - てん
+  description: ゆえに
+- char: ♀
+  readings:
+  - めす
+  - きごう
+  - きんせい
+  - せんせいじゅつ
+  description: 雌記号, 金星
+- char: ♂
+  readings:
+  - おす
+  - きごう
+  - かせい
+  - せんせいじゅつ
+  description: 雄記号, 火星
+- char: °
+  readings:
+  - ど
+  - たんい
+  - きごう
+  description: 度
+- char: ′
+  readings:
+  - ’
+  - ふん
+  - たんい
+  - きごう
+  description: 分
+- char: ″
+  readings:
+  - ”
+  - びょう
+  - たんい
+  - きごう
+  description: 秒
+- char: ℃
+  readings:
+  - ど
+  - たんい
+  - せっし
+  - どC
+  - どc
+  - どしー
+  - C
+  description: 摂氏温度
+- char: °C
+  readings:
+  - ど
+  - たんい
+  - せっし
+  - どC
+  - どc
+  - どしー
+  - C
+  description: 摂氏温度
+- char: °F
+  readings:
+  - かし
+  - どF
+  - どf
+  - どえふ
+  - F
+  description: 華氏温度
+- char: ￥
+  readings:
+  - えん
+  - つうか
+  - \
+  - ¥
+  - ＼
+  - たんい
+  description: 通貨記号
+- char: ¥
+  readings:
+  - えん
+  - つうか
+  - \
+  - ￥
+  - ＼
+  - たんい
+  description: 通貨記号
+- char: ＄
+  readings:
+  - どる
+  - だらー
+  - だら
+  - つうか
+  - $
+  - たんい
+  description: 通貨記号
+- char: ¢
+  readings:
+  - せんと
+  - つうか
+  - たんい
+  description: 通貨記号
+- char: £
+  readings:
+  - ぽんど
+  - つうか
+  - たんい
+  description: 通貨記号
+- char: €
+  readings:
+  - ゆーろ
+  - つうか
+  - たんい
+  description: 通貨記号
+- char: ％
+  readings:
+  - ぱーせんと
+  - たんい
+  - '%'
+  description: パーセント
+- char: ＃
+  readings:
+  - しゃーぷ
+  - なんばー
+  - いげた
+  - はっしゅ
+  - '#'
+  description: 井げた／ハッシュ
+- char: ＆
+  readings:
+  - あんど
+  - あんぱさんど
+  - '&'
+  description: アンパサンド
+- char: ＊
+  readings:
+  - あすたりすく
+  - あすてりすく
+  - ほし
+  - '*'
+  description: アスタリスク
+- char: ＠
+  readings:
+  - あっとまーく
+  - あっと
+  - '@'
+  description: アットマーク
+- char: §
+  readings:
+  - せくしょん
+  - きごう
+  - だんらく
+  description: 段落記号
+- char: ¶
+  readings:
+  - せくしょん
+  - だんらく
+  - だんらくきごう
+  - ぱらぐらふ
+  - きごう
+  description: 段落記号
+- char: ☆
+  readings:
+  - ほし
+  - しろぼし
+  - しろほし
+  - ずけい
+  description: 星
+- char: ★
+  readings:
+  - ほし
+  - くろぼし
+  - くろほし
+  - ずけい
+  description: 黒星
+- char: ○
+  readings:
+  - まる
+  - しろまる
+  - ずけい
+  description: 丸
+- char: ●
+  readings:
+  - まる
+  - くろまる
+  - ずけい
+  description: 黒丸
+- char: ◎
+  readings:
+  - にじゅうまる
+  - まる
+  - ずけい
+  description: 二重丸
+- char: ◉
+  readings:
+  - じゃのめ
+  - まる
+  - ずけい
+  description: 蛇の目
+- char: ⦿
+  readings:
+  - まるなかぐろ
+  - まる
+  - ずけい
+  description: 丸中黒
+- char: ◇
+  readings:
+  - しかく
+  - だいや
+  - ひしがた
+  - ひし
+  - ずけい
+  description: ひしがた
+- char: ◆
+  readings:
+  - しかく
+  - だいや
+  - ひしがた
+  - ひし
+  - ずけい
+  description: 黒ひしがた
+- char: □
+  readings:
+  - しかく
+  - ずけい
+  description: 四角
+- char: ■
+  readings:
+  - しかく
+  - ずけい
+  description: 黒四角
+- char: △
+  readings:
+  - さんかく
+  - ずけい
+  description: 三角
+- char: ▲
+  readings:
+  - さんかく
+  - ずけい
+  description: 黒三角
+- char: ▽
+  readings:
+  - さんかく
+  - ずけい
+  - ぎゃくさんかく
+  description: 逆三角
+- char: ▼
+  readings:
+  - さんかく
+  - ずけい
+  - ぎゃくさんかく
+  description: 逆黒三角
+- char: ▷
+  readings:
+  - さんかく
+  - ずけい
+  - みぎ
+  - みぎさんかく
+  - '>'
+  description: 右向三角
+- char: ▶
+  readings:
+  - さんかく
+  - ずけい
+  - みぎ
+  - みぎさんかく
+  - '>'
+  description: 右向黒三角
+- char: ◁
+  readings:
+  - さんかく
+  - ずけい
+  - ひだり
+  - ひだりさんかく
+  - <
+  description: 左向三角
+- char: ◀
+  readings:
+  - さんかく
+  - ずけい
+  - ひだり
+  - ひだりさんかく
+  - <
+  description: 左向黒三角
+- char: ⬠
+  readings:
+  - ごかく
+  - ずけい
+  description: 五角
+- char: ⬟
+  readings:
+  - ごかく
+  - ずけい
+  description: 黒五角
+- char: ⬭
+  readings:
+  - だえん
+  - ちょうえん
+  - ずけい
+  description: 横長楕円
+- char: ⬬
+  readings:
+  - だえん
+  - ちょうえん
+  - ずけい
+  description: 横長黒楕円
+- char: ⬯
+  readings:
+  - だえん
+  - ちょうえん
+  - ずけい
+  description: 縦長楕円
+- char: ⬮
+  readings:
+  - だえん
+  - ちょうえん
+  - ずけい
+  description: 縦長黒楕円
+- char: ﹅
+  readings:
+  - ごま
+  - けんてん
+  - ぼうてん
+  - わきてん
+  description: 圏点
+- char: ﹆
+  readings:
+  - しろごま
+  - けんてん
+  - ぼうてん
+  - わきてん
+  description: 圏点
+- char: ※
+  readings:
+  - こめ
+  - '*'
+  - こめじるし
+  - きごう
+  - ほし
+  description: 米印
+- char: ▓
+  readings:
+  - だーくしぇーど
+  - くろぬり
+  - しかく
+  description: ダークシェード
+- char: ▢
+  readings:
+  - しかく
+  - かどまる
+  description: 角丸正方形
+- char: ▣
+  readings:
+  - しかく
+  - いれこ
+  description: 入れ子正方形
+- char: ▤
+  readings:
+  - しかく
+  - よこぬり
+  description: 横塗り正方形
+- char: ▥
+  readings:
+  - しかく
+  - たてぬり
+  description: 縦塗り正方形
+- char: ▦
+  readings:
+  - しかく
+  - じゅうじぬり
+  description: 十字塗り正方形
+- char: ▧
+  readings:
+  - しかく
+  - ななめぬり
+  description: 斜め塗り正方形＼
+- char: ▨
+  readings:
+  - しかく
+  - ななめぬり
+  description: 斜め塗り正方形／
+- char: ▩
+  readings:
+  - しかく
+  - ななめじゅうじぬり
+  description: 斜め十字塗り正方形
+- char: 〒
+  readings:
+  - ゆうびん
+  - ゆうびんばんごう
+  - きごう
+  description: 郵便番号
+- char: →
+  readings:
+  - やじるし
+  - みぎや
+  - '->'
+  - ー>
+  - みぎ
+  description: 矢印
+- char: ←
+  readings:
+  - やじるし
+  - ひだりや
+  - <-
+  - <ー
+  - ひだり
+  description: 矢印
+- char: ↑
+  readings:
+  - やじるし
+  - うえや
+  - うえ
+  description: 矢印
+- char: ↓
+  readings:
+  - やじるし
+  - したや
+  - した
+  description: 矢印
+- char: ☛
+  readings:
+  - みぎへ
+  - →
+  description: 右向き指差し
+- char: ☚
+  readings:
+  - ひだりへ
+  - ←
+  description: 左向き指差し
+- char: ☞
+  readings:
+  - みぎへ
+  - →
+  description: 右向き指差し
+- char: ☜
+  readings:
+  - ひだりへ
+  - →
+  description: 左向き指差し
+- char: ☝
+  readings:
+  - うえへ
+  - ↑
+  description: 上向き指差し
+- char: ☟
+  readings:
+  - したへ
+  - ↓
+  description: 下向き指差し
+- char: 〓
+  readings:
+  - げた
+  - きごう
+  description: げた記号
+- char: ∈
+  readings:
+  - すうがく
+  - しゅうごう
+  - けいさん
+  - きごう
+  - ぞくする
+  - ふくむ
+  description: 属する
+- char: ∉
+  readings:
+  - すうがく
+  - しゅうごう
+  - けいさん
+  - きごう
+  - ぞくさない
+  - ふくまない
+  description: 属さない
+- char: ∋
+  readings:
+  - すうがく
+  - しゅうごう
+  - けいさん
+  - きごう
+  - ぞくする
+  - ふくむ
+  description: 元として含む
+- char: ∌
+  readings:
+  - すうがく
+  - しゅうごう
+  - けいさん
+  - きごう
+  - ぞくさない
+  - ふくまない
+  description: 元として含まない
+- char: ⊆
+  readings:
+  - すうがく
+  - しゅうごう
+  - けいさん
+  - きごう
+  description: 部分集合
+- char: ⊇
+  readings:
+  - すうがく
+  - しゅうごう
+  - けいさん
+  - きごう
+  description: 上位集合
+- char: ⊂
+  readings:
+  - すうがく
+  - しゅうごう
+  - けいさん
+  - きごう
+  description: 真部分集合
+- char: ⊃
+  readings:
+  - すうがく
+  - しゅうごう
+  - けいさん
+  - きごう
+  description: 真上位集合
+- char: ∪
+  readings:
+  - すうがく
+  - きゃっぷ
+  - かっぷ
+  - おあ
+  - しゅうごう
+  - けいさん
+  - U
+  - きごう
+  - わしゅうごう
+  description: 和集合
+- char: ∩
+  readings:
+  - すうがく
+  - きゃっぷ
+  - かっぷ
+  - あんど
+  - しゅうごう
+  - けいさん
+  - きごう
+  - せきしゅうごう
+  description: 積集合
+- char: ∧
+  readings:
+  - すうがく
+  - かつ
+  - および
+  - あんど
+  - しゅうごう
+  - けいさん
+  - ^
+  - きごう
+  description: および
+- char: ∨
+  readings:
+  - すうがく
+  - または
+  - おあ
+  - しゅうごう
+  - けいさん
+  - V
+  - きごう
+  description: または
+- char: ¬
+  readings:
+  - すうがく
+  - のっと
+  - ひてい
+  - しゅうごう
+  - けいさん
+  - きごう
+  description: 否定
+- char: ⇒
+  readings:
+  - すうがく
+  - やじるし
+  - みぎや
+  - '->'
+  - ならば
+  - けいさん
+  - =>
+  - きごう
+  - →
+  description: ならば
+- char: ⇔
+  readings:
+  - すうがく
+  - やじるし
+  - <->
+  - どうち
+  - けいさん
+  - <=>
+  - きごう
+  description: 同値
+- char: ∀
+  readings:
+  - すうがく
+  - すべて
+  - すべての
+  - たーんえー
+  - けいさん
+  - A
+  - きごう
+  - たーんA
+  description: すべての
+- char: ∃
+  readings:
+  - すうがく
+  - そんざい
+  - けいさん
+  - E
+  - きごう
+  description: 存在記号
+- char: ∠
+  readings:
+  - すうがく
+  - かく
+  - けいさん
+  - きごう
+  description: 角
+- char: ⊥
+  readings:
+  - すうがく
+  - すいちょく
+  - けいさん
+  - きごう
+  - かく
+  description: 垂直
+- char: ⊿
+  readings:
+  - すうがく
+  - さんかく
+  - さんかくけい
+  - とらいあんぐる
+  - けいさん
+  - でるた
+  - ちょっかくさんかく
+  - ちょっかくさんかくけい
+  - きごう
+  description: 三角形
+- char: ⌒
+  readings:
+  - すうがく
+  - こ
+  - けいさん
+  - きごう
+  description: 弧
+- char: ∂
+  readings:
+  - すうがく
+  - けいさん
+  - きごう
+  - へんびぶん
+  - らうんど
+  - でる
+  description: 偏微分
+- char: ∇
+  readings:
+  - すうがく
+  - なぶら
+  - けいさん
+  - きごう
+  description: ナブラ
+- char: ∆
+  readings:
+  - でるた
+  - ぞうぶん
+  - らぷらしあん
+  description: 増分 ラプラシアン
+- char: ≡
+  readings:
+  - すうがく
+  - ごうどう
+  - けいさん
+  - =
+  - きごう
+  description: 合同
+- char: ≒
+  readings:
+  - すうがく
+  - やく
+  - きんじ
+  - いこーる
+  - =
+  - けいさん
+  - きごう
+  - とうごう
+  description: ほとんど等しい
+- char: ≪
+  readings:
+  - ふとうごう
+  - しょうなり
+  - すうがく
+  - けいさん
+  - <<
+  - きごう
+  description: 非常に小さい
+- char: ≫
+  readings:
+  - ふとうごう
+  - だいなり
+  - すうがく
+  - けいさん
+  - '>>'
+  - きごう
+  description: 非常に大きい
+- char: √
+  readings:
+  - るーと
+  - へいほうこん
+  - すうがく
+  - けいさん
+  - きごう
+  - こんごう
+  - sqrt
+  description: 根号
+- char: ∛
+  readings:
+  - さんじょうこん
+  - りっぽうこん
+  - こんごう
+  - cbrt
+  description: 三乗根号
+- char: ∜
+  readings:
+  - よんじょうこん
+  - こんごう
+  - qdrt
+  description: 四乗根号
+- char: ∽
+  readings:
+  - すうがく
+  - そうじ
+  - けいさん
+  - きごう
+  description: 相似
+- char: ∝
+  readings:
+  - すうがく
+  - ひれい
+  - けいさん
+  - きごう
+  description: 比例
+- char: ∵
+  readings:
+  - すうがく
+  - なぜならば
+  - けいさん
+  - きごう
+  - さんかく
+  - てん
+  description: なぜならば
+- char: ∫
+  readings:
+  - すうがく
+  - いんてぐらる
+  - せきぶん
+  - けいさん
+  - きごう
+  description: 積分記号
+- char: ∬
+  readings:
+  - すうがく
+  - いんてぐらる
+  - せきぶん
+  - にじゅうせきぶん
+  - けいさん
+  - きごう
+  description: 二重積分記号
+- char: ⊕
+  readings:
+  - すうがく
+  - ちょくわ
+  - えっくすおあ
+  - けいさん
+  - +
+  - きごう
+  description: 直和
+- char: ∅
+  readings:
+  - すうがく
+  - くうしゅうごう
+  - きごう
+  description: 空集合
+- char: ℕ
+  readings:
+  - すうがく
+  - しぜんすう
+  - きごう
+  description: 自然数
+- char: ℤ
+  readings:
+  - すうがく
+  - せいすう
+  - きごう
+  description: 整数
+- char: ℚ
+  readings:
+  - すうがく
+  - ゆうりすう
+  - きごう
+  description: 有理数
+- char: ℝ
+  readings:
+  - すうがく
+  - じっすう
+  - きごう
+  description: 実数
+- char: ℂ
+  readings:
+  - すうがく
+  - ふくそすう
+  - きごう
+  description: 複素数
+- char: Å
+  readings:
+  - おんぐすとろーむ
+  - たんい
+  - A
+  - きごう
+  description: オングストローム
+- char: ‰
+  readings:
+  - ぱーみる
+  - たんい
+  - きごう
+  description: 単位
+- char: ♯
+  readings:
+  - しゃーぷ
+  - おんがく
+  - '#'
+  - きごう
+  description: シャープ(音楽記号)
+- char: ♭
+  readings:
+  - ふらっと
+  - おんがく
+  - きごう
+  description: フラット
+- char: ♪
+  readings:
+  - おんぷ
+  - おんがく
+  - きごう
+  description: 音符
+- char: ♫
+  readings:
+  - おんぷ
+  - おんがく
+  - きごう
+  description: 音符
+- char: ♬
+  readings:
+  - おんぷ
+  - おんがく
+  - きごう
+  description: 音符
+- char: ♮
+  readings:
+  - なちゅらる
+  - おんがく
+  - きごう
+  description: ナチュラル
+- char: †
+  readings:
+  - だがー
+  - きごう
+  description: ダガー
+- char: ‡
+  readings:
+  - だぶるだがー
+  - だがー
+  - きごう
+  description: ダブルダガー
+- char: ◯
+  readings:
+  - まる
+  - しろまる
+  - きごう
+  description: 大きな丸
+- char: Α
+  readings:
+  - ぎりしゃ
+  - あるふぁ
+  description: ギリシャ文字
+- char: Β
+  readings:
+  - ぎりしゃ
+  - べーた
+  description: ギリシャ文字
+- char: Γ
+  readings:
+  - ぎりしゃ
+  - がんま
+  - がんまー
+  description: ギリシャ文字
+- char: Δ
+  readings:
+  - ぎりしゃ
+  - でるた
+  description: ギリシャ文字
+- char: Ε
+  readings:
+  - ぎりしゃ
+  - いぷしろん
+  description: ギリシャ文字
+- char: Ζ
+  readings:
+  - ぎりしゃ
+  - ぜーた
+  - つぇーた
+  - じーた
+  description: ギリシャ文字
+- char: Η
+  readings:
+  - ぎりしゃ
+  - いーた
+  - えーた
+  description: ギリシャ文字
+- char: Θ
+  readings:
+  - ぎりしゃ
+  - しーた
+  - てーた
+  description: ギリシャ文字
+- char: Ι
+  readings:
+  - ぎりしゃ
+  - いおた
+  description: ギリシャ文字
+- char: Κ
+  readings:
+  - ぎりしゃ
+  - かっぱ
+  description: ギリシャ文字
+- char: Λ
+  readings:
+  - ぎりしゃ
+  - らむだ
+  description: ギリシャ文字
+- char: Μ
+  readings:
+  - ぎりしゃ
+  - みゅー
+  description: ギリシャ文字
+- char: Ν
+  readings:
+  - ぎりしゃ
+  - にゅー
+  description: ギリシャ文字
+- char: Ξ
+  readings:
+  - ぎりしゃ
+  - くさい
+  - くしい
+  - くしー
+  - ぐざい
+  description: ギリシャ文字
+- char: Ο
+  readings:
+  - ぎりしゃ
+  - おみくろん
+  description: ギリシャ文字
+- char: Π
+  readings:
+  - ぎりしゃ
+  - ぱい
+  description: ギリシャ文字
+- char: Ρ
+  readings:
+  - ぎりしゃ
+  - ろー
+  description: ギリシャ文字
+- char: Σ
+  readings:
+  - ぎりしゃ
+  - しぐま
+  description: ギリシャ文字
+- char: Τ
+  readings:
+  - ぎりしゃ
+  - たう
+  description: ギリシャ文字
+- char: Υ
+  readings:
+  - ぎりしゃ
+  - ゆぷしろん
+  - いぷしろん
+  - うぷしろん
+  description: ギリシャ文字
+- char: Φ
+  readings:
+  - ぎりしゃ
+  - ふぁい
+  description: ギリシャ文字
+- char: Χ
+  readings:
+  - ぎりしゃ
+  - かい
+  description: ギリシャ文字
+- char: Ψ
+  readings:
+  - ぎりしゃ
+  - ぷさい
+  - ぷしー
+  description: ギリシャ文字
+- char: Ω
+  readings:
+  - ぎりしゃ
+  - おめが
+  - おーむ
+  description: ギリシャ文字
+- char: α
+  readings:
+  - ぎりしゃ
+  - あるふぁ
+  description: ギリシャ文字
+- char: β
+  readings:
+  - ぎりしゃ
+  - べーた
+  description: ギリシャ文字
+- char: γ
+  readings:
+  - ぎりしゃ
+  - がんま
+  - がんまー
+  description: ギリシャ文字
+- char: δ
+  readings:
+  - ぎりしゃ
+  - でるた
+  description: ギリシャ文字
+- char: ε
+  readings:
+  - ぎりしゃ
+  - いぷしろん
+  description: ギリシャ文字
+- char: ζ
+  readings:
+  - ぎりしゃ
+  - ぜーた
+  - つぇーた
+  - じーた
+  description: ギリシャ文字
+- char: η
+  readings:
+  - ぎりしゃ
+  - いーた
+  - えーた
+  description: ギリシャ文字
+- char: θ
+  readings:
+  - ぎりしゃ
+  - しーた
+  - てーた
+  description: ギリシャ文字
+- char: ι
+  readings:
+  - ぎりしゃ
+  - いおた
+  description: ギリシャ文字
+- char: κ
+  readings:
+  - ぎりしゃ
+  - かっぱ
+  description: ギリシャ文字
+- char: λ
+  readings:
+  - ぎりしゃ
+  - らむだ
+  description: ギリシャ文字
+- char: μ
+  readings:
+  - ぎりしゃ
+  - みゅー
+  - まいくろ
+  - みくろん
+  description: ギリシャ文字
+- char: ν
+  readings:
+  - ぎりしゃ
+  - にゅー
+  description: ギリシャ文字
+- char: ξ
+  readings:
+  - ぎりしゃ
+  - くさい
+  - くしい
+  - くしー
+  - ぐざい
+  description: ギリシャ文字
+- char: ο
+  readings:
+  - ぎりしゃ
+  - おみくろん
+  description: ギリシャ文字
+- char: π
+  readings:
+  - ぎりしゃ
+  - ぱい
+  description: ギリシャ文字
+- char: ρ
+  readings:
+  - ぎりしゃ
+  - ろー
+  description: ギリシャ文字
+- char: σ
+  readings:
+  - ぎりしゃ
+  - しぐま
+  description: ギリシャ文字
+- char: ς
+  readings:
+  - ぎりしゃ
+  - しぐま
+  description: ギリシャ文字
+- char: τ
+  readings:
+  - ぎりしゃ
+  - たう
+  description: ギリシャ文字
+- char: υ
+  readings:
+  - ぎりしゃ
+  - ゆぷしろん
+  - いぷしろん
+  - うぷしろん
+  description: ギリシャ文字
+- char: φ
+  readings:
+  - ぎりしゃ
+  - ふぁい
+  description: ギリシャ文字
+- char: χ
+  readings:
+  - ぎりしゃ
+  - かい
+  description: ギリシャ文字
+- char: ψ
+  readings:
+  - ぎりしゃ
+  - ぷさい
+  - ぷしー
+  description: ギリシャ文字
+- char: ω
+  readings:
+  - ぎりしゃ
+  - おめが
+  - おーむ
+  description: ギリシャ文字
+- char: А
+  readings:
+  - きりる
+  - ろしあ
+  - あー
+  description: キリル文字
+- char: Б
+  readings:
+  - きりる
+  - ろしあ
+  - べー
+  description: キリル文字
+- char: В
+  readings:
+  - きりる
+  - ろしあ
+  - ゔぇー
+  description: キリル文字
+- char: Г
+  readings:
+  - きりる
+  - ろしあ
+  - げー
+  description: キリル文字
+- char: Д
+  readings:
+  - きりる
+  - ろしあ
+  - でー
+  description: キリル文字
+- char: Е
+  readings:
+  - きりる
+  - ろしあ
+  - いぇー
+  - ぃえー
+  description: キリル文字
+- char: Ё
+  readings:
+  - きりる
+  - ろしあ
+  - よー
+  - ぃよー
+  description: キリル文字
+- char: Ж
+  readings:
+  - きりる
+  - ろしあ
+  - じぇー
+  description: キリル文字
+- char: З
+  readings:
+  - きりる
+  - ろしあ
+  - ぜー
+  - ぜぇー
+  description: キリル文字
+- char: И
+  readings:
+  - きりる
+  - ろしあ
+  - いー
+  description: キリル文字
+- char: Й
+  readings:
+  - きりる
+  - ろしあ
+  - いー
+  description: キリル文字
+- char: К
+  readings:
+  - きりる
+  - ろしあ
+  - かー
+  description: キリル文字
+- char: Л
+  readings:
+  - きりる
+  - ろしあ
+  - える
+  description: キリル文字
+- char: М
+  readings:
+  - きりる
+  - ろしあ
+  - えむ
+  description: キリル文字
+- char: Н
+  readings:
+  - きりる
+  - ろしあ
+  - えぬ
+  description: キリル文字
+- char: О
+  readings:
+  - きりる
+  - ろしあ
+  - おー
+  description: キリル文字
+- char: П
+  readings:
+  - きりる
+  - ろしあ
+  - ぺー
+  description: キリル文字
+- char: Р
+  readings:
+  - きりる
+  - ろしあ
+  - える
+  description: キリル文字
+- char: С
+  readings:
+  - きりる
+  - ろしあ
+  - えす
+  description: キリル文字
+- char: Т
+  readings:
+  - きりる
+  - ろしあ
+  - てー
+  description: キリル文字
+- char: У
+  readings:
+  - きりる
+  - ろしあ
+  - うー
+  description: キリル文字
+- char: Ф
+  readings:
+  - きりる
+  - ろしあ
+  - えふ
+  - ふぃたー
+  description: キリル文字
+- char: Х
+  readings:
+  - きりる
+  - ろしあ
+  - はー
+  description: キリル文字
+- char: Ц
+  readings:
+  - きりる
+  - ろしあ
+  - つぇー
+  description: キリル文字
+- char: Ч
+  readings:
+  - きりる
+  - ろしあ
+  - ちぇー
+  description: キリル文字
+- char: Ш
+  readings:
+  - きりる
+  - ろしあ
+  - しゃー
+  description: キリル文字
+- char: Щ
+  readings:
+  - きりる
+  - ろしあ
+  - しちゃー
+  - ししゃー
+  description: キリル文字
+- char: Ъ
+  readings:
+  - きりる
+  - ろしあ
+  description: キリル文字
+- char: Ы
+  readings:
+  - きりる
+  - ろしあ
+  - うぃ
+  description: キリル文字
+- char: Ь
+  readings:
+  - きりる
+  - ろしあ
+  description: キリル文字
+- char: Э
+  readings:
+  - きりる
+  - ろしあ
+  - えー
+  description: キリル文字
+- char: Ю
+  readings:
+  - きりる
+  - ろしあ
+  - ゆー
+  description: キリル文字
+- char: Я
+  readings:
+  - きりる
+  - ろしあ
+  - やー
+  description: キリル文字
+- char: а
+  readings:
+  - きりる
+  - ろしあ
+  - あー
+  description: キリル文字
+- char: б
+  readings:
+  - きりる
+  - ろしあ
+  - べー
+  description: キリル文字
+- char: в
+  readings:
+  - きりる
+  - ろしあ
+  - ゔぇー
+  description: キリル文字
+- char: г
+  readings:
+  - きりる
+  - ろしあ
+  - げー
+  description: キリル文字
+- char: д
+  readings:
+  - きりる
+  - ろしあ
+  - でー
+  description: キリル文字
+- char: е
+  readings:
+  - きりる
+  - ろしあ
+  - いぇー
+  - ぃえー
+  description: キリル文字
+- char: ё
+  readings:
+  - きりる
+  - ろしあ
+  - よー
+  - ぃよー
+  description: キリル文字
+- char: ж
+  readings:
+  - きりる
+  - ろしあ
+  - じぇー
+  description: キリル文字
+- char: з
+  readings:
+  - きりる
+  - ろしあ
+  - ぜー
+  - ぜぇー
+  description: キリル文字
+- char: и
+  readings:
+  - きりる
+  - ろしあ
+  - いー
+  description: キリル文字
+- char: й
+  readings:
+  - きりる
+  - ろしあ
+  - いー
+  description: キリル文字
+- char: к
+  readings:
+  - きりる
+  - ろしあ
+  - かー
+  description: キリル文字
+- char: л
+  readings:
+  - きりる
+  - ろしあ
+  - える
+  description: キリル文字
+- char: м
+  readings:
+  - きりる
+  - ろしあ
+  - えむ
+  description: キリル文字
+- char: н
+  readings:
+  - きりる
+  - ろしあ
+  - えぬ
+  description: キリル文字
+- char: о
+  readings:
+  - きりる
+  - ろしあ
+  - おー
+  description: キリル文字
+- char: п
+  readings:
+  - きりる
+  - ろしあ
+  - ぺー
+  description: キリル文字
+- char: р
+  readings:
+  - きりる
+  - ろしあ
+  - える
+  description: キリル文字
+- char: с
+  readings:
+  - きりる
+  - ろしあ
+  - えす
+  description: キリル文字
+- char: т
+  readings:
+  - きりる
+  - ろしあ
+  - てー
+  description: キリル文字
+- char: у
+  readings:
+  - きりる
+  - ろしあ
+  - うー
+  description: キリル文字
+- char: ф
+  readings:
+  - きりる
+  - ろしあ
+  - えふ
+  - ふぃたー
+  description: キリル文字
+- char: х
+  readings:
+  - きりる
+  - ろしあ
+  - はー
+  description: キリル文字
+- char: ц
+  readings:
+  - きりる
+  - ろしあ
+  - つぇー
+  description: キリル文字
+- char: ч
+  readings:
+  - きりる
+  - ろしあ
+  - ちぇー
+  description: キリル文字
+- char: ш
+  readings:
+  - きりる
+  - ろしあ
+  - しゃー
+  description: キリル文字
+- char: щ
+  readings:
+  - きりる
+  - ろしあ
+  - しちゃー
+  - ししゃー
+  description: キリル文字
+- char: ъ
+  readings:
+  - きりる
+  - ろしあ
+  description: キリル文字
+- char: ы
+  readings:
+  - きりる
+  - ろしあ
+  - うぃ
+  - うい
+  description: キリル文字
+- char: ь
+  readings:
+  - きりる
+  - ろしあ
+  description: キリル文字
+- char: э
+  readings:
+  - きりる
+  - ろしあ
+  - えー
+  description: キリル文字
+- char: ю
+  readings:
+  - きりる
+  - ろしあ
+  - ゆー
+  description: キリル文字
+- char: я
+  readings:
+  - きりる
+  - ろしあ
+  - やー
+  description: キリル文字
+- char: ─
+  readings:
+  - けいせん
+  - ほそわく
+  - よこ
+  description: 罫線
+- char: │
+  readings:
+  - けいせん
+  - ほそわく
+  - たて
+  description: 罫線
+- char: ┌
+  readings:
+  - けいせん
+  - ほそわく
+  - ひだりうえ
+  description: 罫線
+- char: ┐
+  readings:
+  - けいせん
+  - ほそわく
+  - みぎうえ
+  description: 罫線
+- char: ┘
+  readings:
+  - けいせん
+  - ほそわく
+  - みぎした
+  description: 罫線
+- char: └
+  readings:
+  - けいせん
+  - ほそわく
+  - ひだりした
+  description: 罫線
+- char: ├
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┬
+  readings:
+  - けいせん
+  - ほそわく
+  description: 罫線
+- char: ┤
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┴
+  readings:
+  - けいせん
+  - ほそわく
+  description: 罫線
+- char: ┼
+  readings:
+  - けいせん
+  - まんなか
+  description: 罫線
+- char: ━
+  readings:
+  - けいせん
+  - ふとわく
+  - よこ
+  description: 罫線
+- char: ┃
+  readings:
+  - けいせん
+  - ふとわく
+  - たて
+  description: 罫線
+- char: ┏
+  readings:
+  - けいせん
+  - ふとわく
+  - ひだりうえ
+  description: 罫線
+- char: ┓
+  readings:
+  - けいせん
+  - ふとわく
+  - みぎうえ
+  description: 罫線
+- char: ┛
+  readings:
+  - けいせん
+  - ふとわく
+  - みぎした
+  description: 罫線
+- char: ┗
+  readings:
+  - けいせん
+  - ふとわく
+  - ひだりした
+  description: 罫線
+- char: ┣
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┳
+  readings:
+  - けいせん
+  - ふとわく
+  description: 罫線
+- char: ┫
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┻
+  readings:
+  - けいせん
+  - ふとわく
+  description: 罫線
+- char: ╋
+  readings:
+  - けいせん
+  - まんなか
+  description: 罫線
+- char: ┠
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┯
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┨
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┷
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┿
+  readings:
+  - けいせん
+  - まんなか
+  description: 罫線
+- char: ┝
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┰
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┥
+  readings:
+  - けいせん
+  description: 罫線
+- char: ┸
+  readings:
+  - けいせん
+  description: 罫線
+- char: ╂
+  readings:
+  - けいせん
+  - まんなか
+  description: 罫線
+- char: №
+  readings:
+  - なんばー
+  - 'no'
+  - 'NO'
+  description: ナンバー
+- char: ℡
+  readings:
+  - でんわ
+  - tel
+  - TEL
+  description: 電話
+- char: ☏
+  readings:
+  - でんわ
+  description: 電話
+- char: ☎
+  readings:
+  - でんわ
+  description: 電話
+- char: ☖
+  readings:
+  - しょうぎ
+  - ごて
+  description: 将棋
+- char: ☗
+  readings:
+  - しょうぎ
+  - せんて
+  description: 将棋
+- char: ⛉
+  readings:
+  - しょうぎ
+  description: 将棋
+- char: ⛊
+  readings:
+  - しょうぎ
+  description: 将棋
+- char: ♤
+  readings:
+  - すぺーど
+  description: スペード
+- char: ♠
+  readings:
+  - すぺーど
+  description: スペード
+- char: ♡
+  readings:
+  - はーと
+  description: ハート
+- char: ♥
+  readings:
+  - はーと
+  description: ハート
+- char: ♢
+  readings:
+  - だいや
+  - ひしがた
+  - ひし
+  description: ダイヤ
+- char: ♦
+  readings:
+  - だいや
+  - ひしがた
+  - ひし
+  description: ダイヤ
+- char: ♧
+  readings:
+  - くらぶ
+  - くろーばー
+  - みつば
+  description: クラブ
+- char: ♣
+  readings:
+  - くらぶ
+  - くろーばー
+  - みつば
+  description: クラブ
+- char: ♨
+  readings:
+  - おんせん
+  description: 温泉記号
+- char: ☠
+  readings:
+  - どくろ
+  - がいこつ
+  - どくぶつ
+  description: 骸骨記号
+- char: ☡
+  readings:
+  - こーしょん
+  - ちゅうい
+  description: 注意記号
+- char: ☢
+  readings:
+  - ほうしゃのう
+  description: 放射能記号
+- char: ☣
+  readings:
+  - ばいおはざーど
+  description: バイオハザード記号
+- char: ☤
+  readings:
+  - かどぅけうす
+  - けりゅけいおん
+  description: ケリュケイオン
+- char: ☥
+  readings:
+  - あんく
+  description: アンク
+- char: ☯
+  readings:
+  - いんよう
+  - いんやん
+  description: 陰陽
+- char: ☰
+  readings:
+  - はっけ
+  description: 八卦
+- char: ☱
+  readings:
+  - はっけ
+  description: 八卦
+- char: ☲
+  readings:
+  - はっけ
+  description: 八卦
+- char: ☳
+  readings:
+  - はっけ
+  description: 八卦
+- char: ☴
+  readings:
+  - はっけ
+  description: 八卦
+- char: ☵
+  readings:
+  - はっけ
+  description: 八卦
+- char: ☶
+  readings:
+  - はっけ
+  description: 八卦
+- char: ☷
+  readings:
+  - はっけ
+  description: 八卦
+- char: ☸
+  readings:
+  - ほうりん
+  description: 法輪記号
+- char: ☿
+  readings:
+  - すいせい
+  - せんせいじゅつ
+  description: 水星
+- char: ♁
+  readings:
+  - ちきゅう
+  - せんせいじゅつ
+  description: 地球
+- char: ♃
+  readings:
+  - もくせい
+  - せんせいじゅつ
+  description: 木星
+- char: ♄
+  readings:
+  - どせい
+  - せんせいじゅつ
+  description: 土星
+- char: ♅
+  readings:
+  - てんのうせい
+  - せんせいじゅつ
+  description: 天王星
+- char: ♆
+  readings:
+  - かいおうせい
+  - せんせいじゅつ
+  description: 海王星
+- char: ♇
+  readings:
+  - めいおうせい
+  - せんせいじゅつ
+  description: 冥王星
+- char: ♈
+  readings:
+  - せいざ
+  - おひつじざ
+  description: 牡羊座
+- char: ♉
+  readings:
+  - せいざ
+  - おうしざ
+  description: 牡牛座
+- char: ♊
+  readings:
+  - せいざ
+  - ふたござ
+  description: 双子座
+- char: ♋
+  readings:
+  - せいざ
+  - かにざ
+  description: 蟹座
+- char: ♌
+  readings:
+  - せいざ
+  - ししざ
+  description: 獅子座
+- char: ♍
+  readings:
+  - せいざ
+  - おとめざ
+  description: 乙女座
+- char: ♎
+  readings:
+  - せいざ
+  - てんびんざ
+  description: 天秤座
+- char: ♏
+  readings:
+  - せいざ
+  - さそりざ
+  description: 蠍座
+- char: ♐
+  readings:
+  - せいざ
+  - いてざ
+  description: 射手座
+- char: ♑
+  readings:
+  - せいざ
+  - やぎざ
+  description: 山羊座
+- char: ♒
+  readings:
+  - せいざ
+  - みずがめざ
+  description: 水瓶座
+- char: ♓
+  readings:
+  - せいざ
+  - うおざ
+  description: 魚座
+- char: ☹
+  readings:
+  - かおもじ
+  - むむ
+  - ':('
+  description: 顔文字
+- char: ☺
+  readings:
+  - えがお
+  - かおもじ
+  - にこにこ
+  - ':)'
+  description: 顔文字
+- char: ☻
+  readings:
+  - えがお
+  - かおもじ
+  - にこにこ
+  - ':)'
+  description: 顔文字
+- char: ☐
+  readings:
+  - ちぇっくぼっくす
+  description: チェックボックス
+- char: ☑
+  readings:
+  - ちぇっく
+  - ちぇっくぼっくす
+  description: チェックボックス
+- char: ☒
+  readings:
+  - ちぇっく
+  - ちぇっくぼっくす
+  - ばつ
+  - ぺけ
+  description: チェックボックス
+- char: ☓
+  readings:
+  - ちぇっく
+  - ばつ
+  - ぺけじ
+  - ぺけ
+  - ななめじゅうじ
+  description: 斜め十字
+- char: ✓
+  readings:
+  - ちぇっく
+  - きごう
+  description: チェックマーク
+- char: ✔
+  readings:
+  - ちぇっく
+  - きごう
+  description: チェックマーク
+- char: ♲
+  readings:
+  - りさいくる
+  description: リサイクル記号
+- char: ♺
+  readings:
+  - りさいくる
+  description: リサイクル記号
+- char: ♻
+  readings:
+  - りさいくる
+  description: リサイクル記号
+- char: ♼
+  readings:
+  - りさいくる
+  description: リサイクル記号
+- char: ♽
+  readings:
+  - りさいくる
+  description: リサイクル記号
+- char: ♿
+  readings:
+  - くるまいす
+  description: 車椅子記号
+- char: ⚀
+  readings:
+  - さいころ
+  - さいころ1
+  - 1
+  description: サイコロ
+- char: ⚁
+  readings:
+  - さいころ
+  - さいころ2
+  - 2
+  description: サイコロ
+- char: ⚂
+  readings:
+  - さいころ
+  - さいころ3
+  - 3
+  description: サイコロ
+- char: ⚃
+  readings:
+  - さいころ
+  - さいころ4
+  - 4
+  description: サイコロ
+- char: ⚄
+  readings:
+  - さいころ
+  - さいころ5
+  - 5
+  description: サイコロ
+- char: ⚅
+  readings:
+  - さいころ
+  - さいころ6
+  - 6
+  description: サイコロ
+- char: ⚖
+  readings:
+  - てんびん
+  description: 天秤
+- char: ⚙
+  readings:
+  - はぐるま
+  - ぎあ
+  description: 歯車
+- char: ⚠
+  readings:
+  - ちゅうい
+  - けいこく
+  description: 警告記号
+- char: ⚰
+  readings:
+  - かんおけ
+  description: 棺桶記号
+- char: 🀀
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ふぉんぱい
+  - ふうぱい
+  - とん
+  description: 麻雀牌
+- char: 🀁
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ふぉんぱい
+  - ふうぱい
+  - なん
+  description: 麻雀牌
+- char: 🀂
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ふぉんぱい
+  - ふうぱい
+  - しゃー
+  description: 麻雀牌
+- char: 🀃
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ふぉんぱい
+  - ふうぱい
+  - ぺい
+  - ぺー
+  description: 麻雀牌
+- char: 🀄︎
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - さんげんぱい
+  - ほんちゅん
+  - ふぉんちゅん
+  - ほんちゅー
+  - ちゅん
+  description: 麻雀牌
+- char: 🀅
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - さんげんぱい
+  - りゅうふぁ
+  - りゅーふぁ
+  - りゅーふぁー
+  - はつ
+  description: 麻雀牌
+- char: 🀆
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - さんげんぱい
+  - ぱいぱん
+  - はく
+  description: 麻雀牌
+- char: 🀇
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まんず
+  - わんず
+  - いーまん
+  - いーわん
+  description: 麻雀牌
+- char: 🀈
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まんず
+  - わんず
+  - りゃんまん
+  - りゃんわん
+  description: 麻雀牌
+- char: 🀉
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まんず
+  - わんず
+  - さんまん
+  - さんわん
+  description: 麻雀牌
+- char: 🀊
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まんず
+  - わんず
+  - すーまん
+  - すーわん
+  description: 麻雀牌
+- char: 🀋
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まんず
+  - わんず
+  - うーまん
+  - うーわん
+  description: 麻雀牌
+- char: 🀌
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まんず
+  - わんず
+  - ろーまん
+  - ろーわん
+  description: 麻雀牌
+- char: 🀍
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まんず
+  - わんず
+  - ちーまん
+  - ちーわん
+  description: 麻雀牌
+- char: 🀎
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まんず
+  - わんず
+  - ぱーまん
+  - ぱーわん
+  description: 麻雀牌
+- char: 🀏
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まんず
+  - わんず
+  - きゅーまん
+  - きゅーわん
+  - きゅうまん
+  - きゅうわん
+  - ちゅーまん
+  - ちゅーわん
+  description: 麻雀牌
+- char: 🀐
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - そーず
+  - いーそー
+  description: 麻雀牌
+- char: 🀑
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - そーず
+  - りゃんそー
+  description: 麻雀牌
+- char: 🀒
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - そーず
+  - さんそー
+  description: 麻雀牌
+- char: 🀓
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - そーず
+  - すーそー
+  description: 麻雀牌
+- char: 🀔
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - そーず
+  - うーそー
+  description: 麻雀牌
+- char: 🀕
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - そーず
+  - ろーそー
+  description: 麻雀牌
+- char: 🀖
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - そーず
+  - ちーそー
+  description: 麻雀牌
+- char: 🀗
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - そーず
+  - ぱーそー
+  description: 麻雀牌
+- char: 🀘
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - そーず
+  - きゅーそー
+  - きゅうそー
+  - ちゅーそー
+  description: 麻雀牌
+- char: 🀙
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぴんず
+  - いーぴん
+  description: 麻雀牌
+- char: 🀚
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぴんず
+  - りゃんぴん
+  description: 麻雀牌
+- char: 🀛
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぴんず
+  - さんぴん
+  description: 麻雀牌
+- char: 🀜
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぴんず
+  - すーぴん
+  description: 麻雀牌
+- char: 🀝
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぴんず
+  - うーぴん
+  description: 麻雀牌
+- char: 🀞
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぴんず
+  - ろーぴん
+  description: 麻雀牌
+- char: 🀟
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぴんず
+  - ちーぴん
+  description: 麻雀牌
+- char: 🀠
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぴんず
+  - ぱーぴん
+  description: 麻雀牌
+- char: 🀡
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぴんず
+  - きゅーぴん
+  - きゅうぴん
+  - ちゅーぴん
+  description: 麻雀牌
+- char: 🀢
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - うめ
+  description: 麻雀牌
+- char: 🀣
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - らん
+  description: 麻雀牌
+- char: 🀤
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - たけ
+  description: 麻雀牌
+- char: 🀥
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - きく
+  description: 麻雀牌
+- char: 🀦
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - はる
+  description: 麻雀牌
+- char: 🀧
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - なつ
+  description: 麻雀牌
+- char: 🀨
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - あき
+  description: 麻雀牌
+- char: 🀩
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ふゆ
+  description: 麻雀牌
+- char: 🀪
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - ぱいたー
+  - じょーかー
+  description: 麻雀牌
+- char: 🀫
+  readings:
+  - まーじゃん
+  - まーじゃんぱい
+  - まーじゃんうら
+  description: 麻雀牌
+- char: 🂠
+  readings:
+  - とらんぷ
+  - とらんぷうら
+  description: トランプ
+- char: 🂡
+  readings:
+  - とらんぷ
+  - すぺーどA
+  - すぺーど1
+  - すぺーどえーす
+  description: トランプ
+- char: 🂢
+  readings:
+  - とらんぷ
+  - すぺーど2
+  description: トランプ
+- char: 🂣
+  readings:
+  - とらんぷ
+  - すぺーど3
+  description: トランプ
+- char: 🂤
+  readings:
+  - とらんぷ
+  - すぺーど4
+  description: トランプ
+- char: 🂥
+  readings:
+  - とらんぷ
+  - すぺーど5
+  description: トランプ
+- char: 🂦
+  readings:
+  - とらんぷ
+  - すぺーど6
+  description: トランプ
+- char: 🂧
+  readings:
+  - とらんぷ
+  - すぺーど7
+  description: トランプ
+- char: 🂨
+  readings:
+  - とらんぷ
+  - すぺーど8
+  description: トランプ
+- char: 🂩
+  readings:
+  - とらんぷ
+  - すぺーど9
+  description: トランプ
+- char: 🂪
+  readings:
+  - とらんぷ
+  - すぺーど10
+  description: トランプ
+- char: 🂫
+  readings:
+  - とらんぷ
+  - すぺーどJ
+  - すぺーど11
+  - すぺーどじゃっく
+  description: トランプ
+- char: 🂬
+  readings:
+  - すぺーどC
+  - すぺーどないと
+  - かばろ
+  - すぺーどかばろ
+  description: トランプ
+- char: 🂭
+  readings:
+  - とらんぷ
+  - すぺーどQ
+  - すぺーど12
+  - すぺーどくいーん
+  description: トランプ
+- char: 🂮
+  readings:
+  - とらんぷ
+  - すぺーどK
+  - すぺーど13
+  - すぺーどきんぐ
+  description: トランプ
+- char: 🂱
+  readings:
+  - とらんぷ
+  - はーとA
+  - はーと1
+  - はーとえーす
+  description: トランプ
+- char: 🂲
+  readings:
+  - とらんぷ
+  - はーと2
+  description: トランプ
+- char: 🂳
+  readings:
+  - とらんぷ
+  - はーと3
+  description: トランプ
+- char: 🂴
+  readings:
+  - とらんぷ
+  - はーと4
+  description: トランプ
+- char: 🂵
+  readings:
+  - とらんぷ
+  - はーと5
+  description: トランプ
+- char: 🂶
+  readings:
+  - とらんぷ
+  - はーと6
+  description: トランプ
+- char: 🂷
+  readings:
+  - とらんぷ
+  - はーと7
+  description: トランプ
+- char: 🂸
+  readings:
+  - とらんぷ
+  - はーと8
+  description: トランプ
+- char: 🂹
+  readings:
+  - とらんぷ
+  - はーと9
+  description: トランプ
+- char: 🂺
+  readings:
+  - とらんぷ
+  - はーと10
+  description: トランプ
+- char: 🂻
+  readings:
+  - とらんぷ
+  - はーとJ
+  - はーと11
+  - はーとじゃっく
+  description: トランプ
+- char: 🂼
+  readings:
+  - はーとC
+  - はーとないと
+  - かばろ
+  - はーとかばろ
+  description: トランプ
+- char: 🂽
+  readings:
+  - とらんぷ
+  - はーとQ
+  - はーと12
+  - はーとくいーん
+  description: トランプ
+- char: 🂾
+  readings:
+  - とらんぷ
+  - はーとK
+  - はーと13
+  - はーときんぐ
+  description: トランプ
+- char: 🃁
+  readings:
+  - とらんぷ
+  - だいやA
+  - だいや1
+  - だいやえーす
+  description: トランプ
+- char: 🃂
+  readings:
+  - とらんぷ
+  - だいや2
+  description: トランプ
+- char: 🃃
+  readings:
+  - とらんぷ
+  - だいや3
+  description: トランプ
+- char: 🃄
+  readings:
+  - とらんぷ
+  - だいや4
+  description: トランプ
+- char: 🃅
+  readings:
+  - とらんぷ
+  - だいや5
+  description: トランプ
+- char: 🃆
+  readings:
+  - とらんぷ
+  - だいや6
+  description: トランプ
+- char: 🃇
+  readings:
+  - とらんぷ
+  - だいや7
+  description: トランプ
+- char: 🃈
+  readings:
+  - とらんぷ
+  - だいや8
+  description: トランプ
+- char: 🃉
+  readings:
+  - とらんぷ
+  - だいや9
+  description: トランプ
+- char: 🃊
+  readings:
+  - とらんぷ
+  - だいや10
+  description: トランプ
+- char: 🃋
+  readings:
+  - とらんぷ
+  - だいやJ
+  - だいや11
+  - だいやじゃっく
+  description: トランプ
+- char: 🃌
+  readings:
+  - だいやC
+  - だいやないと
+  - かばろ
+  - はーとかばろ
+  description: トランプ
+- char: 🃍
+  readings:
+  - とらんぷ
+  - だいやQ
+  - だいや12
+  - だいやくいーん
+  description: トランプ
+- char: 🃎
+  readings:
+  - とらんぷ
+  - だいやK
+  - だいや13
+  - だいやきんぐ
+  description: トランプ
+- char: 🃑
+  readings:
+  - とらんぷ
+  - くらぶA
+  - くらぶ1
+  - くらぶえーす
+  description: トランプ
+- char: 🃒
+  readings:
+  - とらんぷ
+  - くらぶ2
+  description: トランプ
+- char: 🃓
+  readings:
+  - とらんぷ
+  - くらぶ3
+  description: トランプ
+- char: 🃔
+  readings:
+  - とらんぷ
+  - くらぶ4
+  description: トランプ
+- char: 🃕
+  readings:
+  - とらんぷ
+  - くらぶ5
+  description: トランプ
+- char: 🃖
+  readings:
+  - とらんぷ
+  - くらぶ6
+  description: トランプ
+- char: 🃗
+  readings:
+  - とらんぷ
+  - くらぶ7
+  description: トランプ
+- char: 🃘
+  readings:
+  - とらんぷ
+  - くらぶ8
+  description: トランプ
+- char: 🃙
+  readings:
+  - とらんぷ
+  - くらぶ9
+  description: トランプ
+- char: 🃚
+  readings:
+  - とらんぷ
+  - くらぶ10
+  description: トランプ
+- char: 🃛
+  readings:
+  - とらんぷ
+  - くらぶJ
+  - くらぶ11
+  - くらぶじゃっく
+  description: トランプ
+- char: 🃜
+  readings:
+  - くらぶC
+  - くらぶないと
+  - かばろ
+  - くらぶかばろ
+  description: トランプ
+- char: 🃝
+  readings:
+  - とらんぷ
+  - くらぶQ
+  - くらぶ12
+  - くらぶくいーん
+  description: トランプ
+- char: 🃞
+  readings:
+  - とらんぷ
+  - くらぶK
+  - くらぶ13
+  - くらぶきんぐ
+  description: トランプ
+- char: Ⅰ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: Ⅱ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: Ⅲ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: Ⅳ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: Ⅴ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: Ⅵ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: Ⅶ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: Ⅷ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: Ⅸ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: Ⅹ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅰ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅱ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅲ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅳ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅴ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅵ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅶ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅷ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅸ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ⅹ
+  readings:
+  - きごう
+  - ろーま
+  description: ローマ数字
+- char: ∑
+  readings:
+  - すうがく
+  - しぐま
+  - そうわ
+  - けいさん
+  description: 総和記号
+- char: ∟
+  readings:
+  - すうがく
+  - ちょっかく
+  description: 直角
+- char: ∮
+  readings:
+  - すうがく
+  - いんてぐらる
+  - せきぶん
+  - へいろせきぶん
+  - けいさん
+  - ふぁい
+  - けいろせきぶん
+  - しゅうかいせきぶん
+  description: 閉路積分記号
+- char: ℵ
+  readings:
+  - あれふ
+- char: ①
+  readings:
+  - きごう
+  - まる1
+  - まるいち
+  description: 丸数字
+- char: ②
+  readings:
+  - きごう
+  - まる2
+  - まるに
+  description: 丸数字
+- char: ③
+  readings:
+  - きごう
+  - まる3
+  - まるさん
+  description: 丸数字
+- char: ④
+  readings:
+  - きごう
+  - まる4
+  - まるよん
+  - まるし
+  description: 丸数字
+- char: ⑤
+  readings:
+  - きごう
+  - まる5
+  - まるご
+  description: 丸数字
+- char: ⑥
+  readings:
+  - きごう
+  - まる6
+  - まるろく
+  description: 丸数字
+- char: ⑦
+  readings:
+  - きごう
+  - まる7
+  - まるなな
+  - まるしち
+  description: 丸数字
+- char: ⑧
+  readings:
+  - きごう
+  - まる8
+  - まるはち
+  description: 丸数字
+- char: ⑨
+  readings:
+  - きごう
+  - まる9
+  - まるきゅう
+  - まるく
+  description: 丸数字
+- char: ⑩
+  readings:
+  - きごう
+  - まる10
+  - まるじゅう
+  description: 丸数字
+- char: ⑪
+  readings:
+  - きごう
+  - まる11
+  - まるじゅういち
+  description: 丸数字
+- char: ⑫
+  readings:
+  - きごう
+  - まる12
+  - まるじゅうに
+  description: 丸数字
+- char: ⑬
+  readings:
+  - きごう
+  - まる13
+  - まるじゅうさん
+  description: 丸数字
+- char: ⑭
+  readings:
+  - きごう
+  - まる14
+  - まるじゅうし
+  - まるじゅうよん
+  description: 丸数字
+- char: ⑮
+  readings:
+  - きごう
+  - まる15
+  - まるじゅうご
+  description: 丸数字
+- char: ⑯
+  readings:
+  - きごう
+  - まる16
+  - まるじゅうろく
+  description: 丸数字
+- char: ⑰
+  readings:
+  - きごう
+  - まる17
+  - まるじゅうなな
+  - まるじゅうしち
+  description: 丸数字
+- char: ⑱
+  readings:
+  - きごう
+  - まる18
+  - まるじゅうはち
+  description: 丸数字
+- char: ⑲
+  readings:
+  - きごう
+  - まる19
+  - まるじゅうきゅう
+  - まるじゅうく
+  description: 丸数字
+- char: ⑳
+  readings:
+  - きごう
+  - まる20
+  - まるにじゅう
+  description: 丸数字
+- char: ㉑
+  readings:
+  - きごう
+  - まる21
+  - まるにじゅういち
+  description: 丸数字
+- char: ㉒
+  readings:
+  - きごう
+  - まる22
+  - まるにじゅうに
+  description: 丸数字
+- char: ㉓
+  readings:
+  - きごう
+  - まる23
+  - まるにじゅうさん
+  description: 丸数字
+- char: ㉔
+  readings:
+  - きごう
+  - まる24
+  - まるにじゅうよん
+  - まるにじゅうし
+  description: 丸数字
+- char: ㉕
+  readings:
+  - きごう
+  - まる25
+  - まるにじゅうご
+  description: 丸数字
+- char: ㉖
+  readings:
+  - きごう
+  - まる26
+  - まるにじゅうろく
+  description: 丸数字
+- char: ㉗
+  readings:
+  - きごう
+  - まる27
+  - まるにじゅうなな
+  - まるにじゅうしち
+  description: 丸数字
+- char: ㉘
+  readings:
+  - きごう
+  - まる28
+  - まるにじゅうはち
+  description: 丸数字
+- char: ㉙
+  readings:
+  - きごう
+  - まる29
+  - まるにじゅうきゅう
+  - まるにじゅうく
+  description: 丸数字
+- char: ㉚
+  readings:
+  - きごう
+  - まる30
+  - まるさんじゅう
+  description: 丸数字
+- char: ㉛
+  readings:
+  - きごう
+  - まる31
+  - まるさんじゅういち
+  description: 丸数字
+- char: ㉜
+  readings:
+  - きごう
+  - まる32
+  - まるさんじゅうに
+  description: 丸数字
+- char: ㉝
+  readings:
+  - きごう
+  - まる33
+  - まるさんじゅうさん
+  description: 丸数字
+- char: ㉞
+  readings:
+  - きごう
+  - まる34
+  - まるさんじゅうし
+  - まるさんじゅうよん
+  description: 丸数字
+- char: ㉟
+  readings:
+  - きごう
+  - まる35
+  - まるさんじゅうご
+  description: 丸数字
+- char: ㊱
+  readings:
+  - きごう
+  - まる36
+  - まるさんじゅうろく
+  description: 丸数字
+- char: ㊲
+  readings:
+  - きごう
+  - まる37
+  - まるさんじゅうなな
+  - まるさんじゅうしち
+  description: 丸数字
+- char: ㊳
+  readings:
+  - きごう
+  - まる38
+  - まるさんじゅうはち
+  description: 丸数字
+- char: ㊴
+  readings:
+  - きごう
+  - まる39
+  - まるさんじゅうきゅう
+  - まるさんじゅうく
+  description: 丸数字
+- char: ㊵
+  readings:
+  - きごう
+  - まる40
+  - まるよんじゅう
+  description: 丸数字
+- char: ㊶
+  readings:
+  - きごう
+  - まる41
+  - まるよんじゅういち
+  description: 丸数字
+- char: ㊷
+  readings:
+  - きごう
+  - まる42
+  - まるよんじゅうに
+  description: 丸数字
+- char: ㊸
+  readings:
+  - きごう
+  - まる43
+  - まるよんじゅうさん
+  description: 丸数字
+- char: ㊹
+  readings:
+  - きごう
+  - まる44
+  - まるよんじゅうし
+  - まるよんじゅうよん
+  description: 丸数字
+- char: ㊺
+  readings:
+  - きごう
+  - まる45
+  - まるよんじゅうご
+  description: 丸数字
+- char: ㊻
+  readings:
+  - きごう
+  - まる46
+  - まるよんじゅうろく
+  description: 丸数字
+- char: ㊼
+  readings:
+  - きごう
+  - まる47
+  - まるよんじゅうなな
+  - まるよんじゅうしち
+  description: 丸数字
+- char: ㊽
+  readings:
+  - きごう
+  - まる48
+  - まるよんじゅうはち
+  description: 丸数字
+- char: ㊾
+  readings:
+  - きごう
+  - まる49
+  - まるよんじゅうきゅう
+  - まるよんじゅうく
+  description: 丸数字
+- char: ㊿
+  readings:
+  - きごう
+  - まる50
+  - まるごじゅう
+  description: 丸数字
+- char: ㈠
+  readings:
+  - かっこ1
+  - かっこいち
+  description: 括弧漢数字
+- char: ㈡
+  readings:
+  - かっこ2
+  - かっこに
+  description: 括弧漢数字
+- char: ㈢
+  readings:
+  - かっこ3
+  - かっこさん
+  description: 括弧漢数字
+- char: ㈣
+  readings:
+  - かっこ4
+  - かっこよん
+  description: 括弧漢数字
+- char: ㈤
+  readings:
+  - かっこ5
+  - かっこご
+  description: 括弧漢数字
+- char: ㈥
+  readings:
+  - かっこ6
+  - かっころく
+  description: 括弧漢数字
+- char: ㈦
+  readings:
+  - かっこ7
+  - かっこなな
+  - かっこしち
+  description: 括弧漢数字
+- char: ㈧
+  readings:
+  - かっこ8
+  - かっこはち
+  description: 括弧漢数字
+- char: ㈨
+  readings:
+  - かっこ9
+  - かっこきゅう
+  description: 括弧漢数字
+- char: ㈩
+  readings:
+  - かっこ10
+  - かっこじゅう
+  description: 括弧漢数字
+- char: ㈱
+  readings:
+  - かぶ
+  - かぶしきがいしゃ
+  - かぶしき
+  description: 株式会社
+- char: ㈲
+  readings:
+  - ゆう
+  - ゆうげんがいしゃ
+  - ゆうげん
+  description: 有限会社
+- char: ㈹
+  readings:
+  - だい
+  - だいひょう
+  description: 代表
+- char: ©
+  readings:
+  - ちょさくけん
+  - こぴーらいと
+  - C
+  - まるしー
+  - (c)
+  - (C)
+  - まるc
+  - まるC
+  description: コピーライト
+- char: ®
+  readings:
+  - とうろくしょうひょう
+  - とれーどまーく
+  - R
+  - まるあーる
+  - (r)
+  - (R)
+  - まるr
+  - まるR
+  description: 登録商標
+- char: ™
+  readings:
+  - しょうひょう
+  - とれーどまーく
+  - TM
+  description: トレードマーク
+- char: ㊤
+  readings:
+  - うえ
+  - じょう
+  description: 丸上
+- char: ㊥
+  readings:
+  - なか
+  - ちゅう
+  description: 丸中
+- char: ㊦
+  readings:
+  - した
+  - げ
+  description: 丸下
+- char: ㊧
+  readings:
+  - ひだり
+  description: 丸左
+- char: ㊨
+  readings:
+  - みぎ
+  description: 丸右
+- char: ㋿
+  readings:
+  - れいわ
+  - ねんごう
+  description: 年号
+- char: ㍻
+  readings:
+  - へいせい
+  - ねんごう
+  description: 年号
+- char: ㍼
+  readings:
+  - しょうわ
+  - ねんごう
+  description: 年号
+- char: ㍽
+  readings:
+  - たいしょう
+  - ねんごう
+  description: 年号
+- char: ㍾
+  readings:
+  - めいじ
+  - ねんごう
+  description: 年号
+- char: ㎎
+  readings:
+  - みりぐらむ
+  - たんい
+  - mg
+  - MG
+  description: 単位
+- char: ㎏
+  readings:
+  - きろぐらむ
+  - たんい
+  - kg
+  - KG
+  description: 単位
+- char: ㎜
+  readings:
+  - みりめーとる
+  - たんい
+  - mm
+  - MM
+  description: 単位
+- char: ㎝
+  readings:
+  - せんちめーとる
+  - たんい
+  - cm
+  - CM
+  description: 単位
+- char: ㎞
+  readings:
+  - きろめーとる
+  - たんい
+  - km
+  - KM
+  description: 単位
+- char: ㎡
+  readings:
+  - へいほうめーとる
+  - たんい
+  - へいべい
+  - mm
+  - MM
+  description: 単位
+- char: ㎥
+  readings:
+  - りっぽうめーとる
+  - たんい
+  - りゅうべい
+  - りゅーべー
+  - りゅーべ
+  description: 単位
+- char: ㏄
+  readings:
+  - しーしー
+  - たんい
+  - cc
+  description: 単位
+- char: ㏍
+  readings:
+  - かぶしきがいしゃ
+  - kk
+- char: ＂
+  readings:
+  - さん
+  - せん
+- char: ＇
+  readings:
+  - ’
+- char: ￤
+  readings:
+  - たて
+  - たてぼう
+  - '|'
+  description: 縦線
+- char: ゐ
+  readings:
+  - い
+  - うぃ
+- char: ゑ
+  readings:
+  - え
+  - うぇ
+- char: ヰ
+  readings:
+  - い
+  - うぃ
+- char: ヱ
+  readings:
+  - え
+  - うぇ
+- char: ぁ
+  readings:
+  - あ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ぃ
+  readings:
+  - い
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ぅ
+  readings:
+  - う
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ぇ
+  readings:
+  - え
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ぉ
+  readings:
+  - お
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: っ
+  readings:
+  - つ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ゃ
+  readings:
+  - や
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ゅ
+  readings:
+  - ゆ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ょ
+  readings:
+  - よ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ゎ
+  readings:
+  - わ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ゟ
+  readings:
+  - より
+  - ごうじ
+  description: 合字
+- char: ァ
+  readings:
+  - あ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ィ
+  readings:
+  - い
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ゥ
+  readings:
+  - う
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ェ
+  readings:
+  - え
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ォ
+  readings:
+  - お
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ヵ
+  readings:
+  - か
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ヶ
+  readings:
+  - け
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ッ
+  readings:
+  - つ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ャ
+  readings:
+  - や
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ュ
+  readings:
+  - ゆ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ョ
+  readings:
+  - よ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: ヮ
+  readings:
+  - わ
+  - すてがな
+  - こがきもじ
+  description: 捨て仮名 小書き文字
+- char: Ａ
+  readings:
+  - えー
+  - えい
+  description: 英数字
+- char: Ｂ
+  readings:
+  - びー
+  - びぃ
+  - びい
+  description: 英数字
+- char: Ｃ
+  readings:
+  - しー
+  description: 英数字
+- char: Ｄ
+  readings:
+  - でぃー
+  - でー
+  description: 英数字
+- char: Ｅ
+  readings:
+  - いー
+  description: 英数字
+- char: Ｆ
+  readings:
+  - えふ
+  description: 英数字
+- char: Ｇ
+  readings:
+  - じー
+  description: 英数字
+- char: Ｈ
+  readings:
+  - えいち
+  - えっち
+  description: 英数字
+- char: Ｉ
+  readings:
+  - あい
+  description: 英数字
+- char: Ｊ
+  readings:
+  - じぇい
+  - じぇー
+  description: 英数字
+- char: Ｋ
+  readings:
+  - けい
+  - けー
+  description: 英数字
+- char: Ｌ
+  readings:
+  - える
+  description: 英数字
+- char: Ｍ
+  readings:
+  - えむ
+  description: 英数字
+- char: Ｎ
+  readings:
+  - えぬ
+  description: 英数字
+- char: Ｏ
+  readings:
+  - おー
+  description: 英数字
+- char: Ｐ
+  readings:
+  - ぴー
+  description: 英数字
+- char: Ｑ
+  readings:
+  - きゅー
+  - きゅう
+  description: 英数字
+- char: Ｒ
+  readings:
+  - あーる
+  description: 英数字
+- char: Ｓ
+  readings:
+  - えす
+  description: 英数字
+- char: Ｔ
+  readings:
+  - てぃ
+  - てぃー
+  - てー
+  description: 英数字
+- char: Ｕ
+  readings:
+  - ゆー
+  description: 英数字
+- char: Ｖ
+  readings:
+  - ゔぃ
+  - ぶい
+  - ぶぃ
+  description: 英数字
+- char: Ｗ
+  readings:
+  - だぶりゅー
+  - だぶる
+  - だぶるー
+  description: 英数字
+- char: Ｘ
+  readings:
+  - えっくす
+  description: 英数字
+- char: Ｙ
+  readings:
+  - わい
+  description: 英数字
+- char: Ｚ
+  readings:
+  - ぜっと
+  description: 英数字
+- char: ａ
+  readings:
+  - えー
+  - えい
+  description: 英数字
+- char: ｂ
+  readings:
+  - びー
+  - びぃ
+  - びい
+  description: 英数字
+- char: ｃ
+  readings:
+  - しー
+  description: 英数字
+- char: ｄ
+  readings:
+  - でぃー
+  - でー
+  description: 英数字
+- char: ｅ
+  readings:
+  - いー
+  description: 英数字
+- char: ｆ
+  readings:
+  - えふ
+  description: 英数字
+- char: ｇ
+  readings:
+  - じー
+  description: 英数字
+- char: ｈ
+  readings:
+  - えいち
+  - えっち
+  description: 英数字
+- char: ｉ
+  readings:
+  - あい
+  description: 英数字
+- char: ｊ
+  readings:
+  - じぇい
+  - じぇー
+  description: 英数字
+- char: ｋ
+  readings:
+  - けい
+  - けー
+  description: 英数字
+- char: ｌ
+  readings:
+  - える
+  description: 英数字
+- char: ｍ
+  readings:
+  - えむ
+  description: 英数字
+- char: ｎ
+  readings:
+  - えぬ
+  description: 英数字
+- char: ｏ
+  readings:
+  - おー
+  description: 英数字
+- char: ｐ
+  readings:
+  - ぴー
+  description: 英数字
+- char: ｑ
+  readings:
+  - きゅー
+  - きゅう
+  description: 英数字
+- char: ｒ
+  readings:
+  - あーる
+  description: 英数字
+- char: ｓ
+  readings:
+  - えす
+  description: 英数字
+- char: ｔ
+  readings:
+  - てぃ
+  - てぃー
+  - てー
+  description: 英数字
+- char: ｕ
+  readings:
+  - ゆー
+  description: 英数字
+- char: ｖ
+  readings:
+  - ゔぃ
+  - ぶい
+  - ぶぃ
+  description: 英数字
+- char: ｗ
+  readings:
+  - だぶりゅー
+  - だぶる
+  - だぶるー
+  description: 英数字
+- char: ｘ
+  readings:
+  - えっくす
+  description: 英数字
+- char: ｙ
+  readings:
+  - わい
+  description: 英数字
+- char: ｚ
+  readings:
+  - ぜっと
+  description: 英数字
+- char: ☀
+  readings:
+  - てんき
+  - はれ
+  - たいよう
+  description: 天気
+- char: ☼
+  readings:
+  - てんき
+  - はれ
+  - たいよう
+  description: 天気
+- char: ☁
+  readings:
+  - てんき
+  - くもり
+  - くも
+  description: 天気
+- char: ☂
+  readings:
+  - てんき
+  - あめ
+  - かさ
+  description: 天気
+- char: ☔
+  readings:
+  - てんき
+  - あめ
+  - かさ
+  description: 天気
+- char: ☃
+  readings:
+  - てんき
+  - ゆき
+  - ゆきだるま
+  description: 天気
+- char: ☄
+  readings:
+  - ながれぼし
+  - こめっと
+  description: 流れ星
+- char: ☇
+  readings:
+  - かみなり
+  description: 天気
+- char: ☈
+  readings:
+  - らいう
+  description: 天気
+- char: ☽
+  readings:
+  - みかづき
+  description: 右三日月
+- char: ☾
+  readings:
+  - みかづき
+  description: 左三日月
+- char: ☘
+  readings:
+  - くろーばー
+  description: クローバー
+- char: ☕
+  readings:
+  - こーひー
+  - こうちゃ
+  - てぃーかっぷ
+  description: ティーカップ
+- char: ♔
+  readings:
+  - ちぇす
+  - きんぐ
+  description: チェス
+- char: ♕
+  readings:
+  - ちぇす
+  - くいーん
+  - くぃーん
+  description: チェス
+- char: ♖
+  readings:
+  - ちぇす
+  - るーく
+  description: チェス
+- char: ♗
+  readings:
+  - ちぇす
+  - びしょっぷ
+  description: チェス
+- char: ♘
+  readings:
+  - ちぇす
+  - ないと
+  description: チェス
+- char: ♙
+  readings:
+  - ちぇす
+  - ぽーん
+  description: チェス
+- char: ♚
+  readings:
+  - ちぇす
+  - きんぐ
+  description: チェス
+- char: ♛
+  readings:
+  - ちぇす
+  - くいーん
+  - くぃーん
+  description: チェス
+- char: ♜
+  readings:
+  - ちぇす
+  - るーく
+  description: チェス
+- char: ♝
+  readings:
+  - ちぇす
+  - びしょっぷ
+  description: チェス
+- char: ♞
+  readings:
+  - ちぇす
+  - ないと
+  description: チェス
+- char: ♟
+  readings:
+  - ちぇす
+  - ぽーん
+  description: チェス
+- char: ⌘
+  readings:
+  - こまんど
+  - こまんどきー
+  description: コマンドキー
+- char: ⌥
+  readings:
+  - おぷしょん
+  - おぷしょんきー
+  description: オプションキー
+- char: ⌫
+  readings:
+  - ばっくすぺーす
+  - ばっくすぺーすきー
+  description: バックスペースキー
+- char: ⌚
+  readings:
+  - うでどけい
+  - とけい
+  description: 時計記号
+- char: Á
+  readings:
+  - a
+  - A
+  - あきゅーと
+  description: アキュート付き文字
+- char: É
+  readings:
+  - e
+  - E
+  - あきゅーと
+  description: アキュート付き文字
+- char: Í
+  readings:
+  - i
+  - I
+  - あきゅーと
+  description: アキュート付き文字
+- char: Ó
+  readings:
+  - o
+  - O
+  - あきゅーと
+  description: アキュート付き文字
+- char: Ú
+  readings:
+  - u
+  - U
+  - あきゅーと
+  description: アキュート付き文字
+- char: á
+  readings:
+  - a
+  - A
+  - あきゅーと
+  description: アキュート付き文字
+- char: é
+  readings:
+  - e
+  - E
+  - あきゅーと
+  description: アキュート付き文字
+- char: í
+  readings:
+  - i
+  - I
+  - あきゅーと
+  description: アキュート付き文字
+- char: ó
+  readings:
+  - o
+  - O
+  - あきゅーと
+  description: アキュート付き文字
+- char: ú
+  readings:
+  - u
+  - U
+  - あきゅーと
+  description: アキュート付き文字
+- char: Ä
+  readings:
+  - a
+  - A
+  - うむらうと
+  - とれま
+  description: ウムラウト／トレマ付き文字
+- char: Ö
+  readings:
+  - o
+  - O
+  - うむらうと
+  - とれま
+  description: ウムラウト／トレマ付き文字
+- char: Ü
+  readings:
+  - u
+  - U
+  - うむらうと
+  - とれま
+  description: ウムラウト／トレマ付き文字
+- char: ä
+  readings:
+  - a
+  - A
+  - うむらうと
+  - とれま
+  description: ウムラウト／トレマ付き文字
+- char: ö
+  readings:
+  - o
+  - O
+  - うむらうと
+  - とれま
+  description: ウムラウト／トレマ付き文字
+- char: ü
+  readings:
+  - u
+  - U
+  - うむらうと
+  - とれま
+  description: ウムラウト／トレマ付き文字
+- char: À
+  readings:
+  - a
+  - A
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: È
+  readings:
+  - e
+  - E
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: Ì
+  readings:
+  - i
+  - I
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: Ò
+  readings:
+  - o
+  - O
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: Ù
+  readings:
+  - u
+  - U
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: à
+  readings:
+  - a
+  - A
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: è
+  readings:
+  - e
+  - E
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: ì
+  readings:
+  - i
+  - I
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: ò
+  readings:
+  - o
+  - O
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: ù
+  readings:
+  - u
+  - U
+  - ぐらーぶ
+  description: グラーブ付き文字
+- char: Â
+  readings:
+  - a
+  - A
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: Ê
+  readings:
+  - e
+  - E
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: Î
+  readings:
+  - i
+  - I
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: Ô
+  readings:
+  - o
+  - O
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: Û
+  readings:
+  - u
+  - U
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: â
+  readings:
+  - a
+  - A
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: ê
+  readings:
+  - e
+  - E
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: î
+  readings:
+  - i
+  - I
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: ô
+  readings:
+  - o
+  - O
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: û
+  readings:
+  - u
+  - U
+  - さーかむふれっくす
+  - はっと
+  description: サーカムフレックス(ハット)付き文字
+- char: Ø
+  readings:
+  - o
+  - O
+  - すらっしゅ
+  description: スラッシュ付き文字
+- char: ø
+  readings:
+  - o
+  - O
+  - すらっしゅ
+  description: スラッシュ付き文字
+- char: Ç
+  readings:
+  - c
+  - C
+  - せでぃーゆ
+  description: セディーユ付き文字
+- char: ç
+  readings:
+  - c
+  - C
+  - せでぃーゆ
+  description: セディーユ付き文字
+- char: Ő
+  readings:
+  - o
+  - O
+  - だぶるあきゅーと
+  description: ダブルアキュート付き文字
+- char: Ű
+  readings:
+  - u
+  - U
+  - だぶるあきゅーと
+  description: ダブルアキュート付き文字
+- char: ő
+  readings:
+  - o
+  - O
+  - だぶるあきゅーと
+  description: ダブルアキュート付き文字
+- char: ű
+  readings:
+  - u
+  - U
+  - だぶるあきゅーと
+  description: ダブルアキュート付き文字
+- char: Ã
+  readings:
+  - a
+  - A
+  - ちるだ
+  description: チルダ付き文字
+- char: Ñ
+  readings:
+  - n
+  - N
+  - ちるだ
+  description: チルダ付き文字
+- char: Õ
+  readings:
+  - o
+  - O
+  - ちるだ
+  description: チルダ付き文字
+- char: ã
+  readings:
+  - a
+  - A
+  - ちるだ
+  description: チルダ付き文字
+- char: ñ
+  readings:
+  - n
+  - N
+  - ちるだ
+  description: チルダ付き文字
+- char: õ
+  readings:
+  - o
+  - O
+  - ちるだ
+  description: チルダ付き文字
+- char: Ë
+  readings:
+  - e
+  - E
+  - うむらうと
+  - とれま
+  description: トレマ付き文字
+- char: Ï
+  readings:
+  - i
+  - I
+  - うむらうと
+  - とれま
+  description: トレマ付き文字
+- char: ë
+  readings:
+  - e
+  - E
+  - うむらうと
+  - とれま
+  description: トレマ付き文字
+- char: ï
+  readings:
+  - i
+  - I
+  - うむらうと
+  - とれま
+  description: トレマ付き文字
+- char: ÿ
+  readings:
+  - y
+  - Y
+  - うむらうと
+  - とれま
+  description: トレマ付き文字
+- char: Ơ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: Ư
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: Ớ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: Ờ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: Ở
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: Ỡ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: Ợ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: Ứ
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: Ừ
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: Ử
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: Ữ
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: Ự
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: ơ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: ư
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: ớ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: ờ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: ở
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: ỡ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: ợ
+  readings:
+  - o
+  - O
+  - ほーん
+  description: ホーン付き文字
+- char: ứ
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: ừ
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: ử
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: ữ
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: ự
+  readings:
+  - u
+  - U
+  - ほーん
+  description: ホーン付き文字
+- char: Ā
+  readings:
+  - a
+  - A
+  - まくろん
+  description: マクロン付き文字
+- char: Ǟ
+  readings:
+  - a
+  - A
+  - まくろん
+  description: マクロン付き文字
+- char: Ǣ
+  readings:
+  - a
+  - A
+  - ae
+  - AE
+  - まくろん
+  description: マクロン付き文字
+- char: Ē
+  readings:
+  - e
+  - E
+  - まくろん
+  description: マクロン付き文字
+- char: Ḡ
+  readings:
+  - g
+  - G
+  - まくろん
+  description: マクロン付き文字
+- char: Ī
+  readings:
+  - i
+  - I
+  - まくろん
+  description: マクロン付き文字
+- char: Ō
+  readings:
+  - o
+  - O
+  - まくろん
+  description: マクロン付き文字
+- char: Ȫ
+  readings:
+  - o
+  - O
+  - まくろん
+  description: マクロン付き文字
+- char: Ū
+  readings:
+  - u
+  - U
+  - まくろん
+  description: マクロン付き文字
+- char: Ǖ
+  readings:
+  - u
+  - U
+  - まくろん
+  description: マクロン付き文字
+- char: Ȳ
+  readings:
+  - y
+  - Y
+  - まくろん
+  description: マクロン付き文字
+- char: ā
+  readings:
+  - a
+  - A
+  - まくろん
+  description: マクロン付き文字
+- char: ǟ
+  readings:
+  - a
+  - A
+  - まくろん
+  description: マクロン付き文字
+- char: ǣ
+  readings:
+  - a
+  - A
+  - ae
+  - AE
+  - まくろん
+  description: マクロン付き文字
+- char: ē
+  readings:
+  - e
+  - E
+  - まくろん
+  description: マクロン付き文字
+- char: ḡ
+  readings:
+  - g
+  - G
+  - まくろん
+  description: マクロン付き文字
+- char: ī
+  readings:
+  - i
+  - I
+  - まくろん
+  description: マクロン付き文字
+- char: ō
+  readings:
+  - o
+  - O
+  - まくろん
+  description: マクロン付き文字
+- char: ȫ
+  readings:
+  - o
+  - O
+  - まくろん
+  description: マクロン付き文字
+- char: ū
+  readings:
+  - u
+  - U
+  - まくろん
+  description: マクロン付き文字
+- char: ǖ
+  readings:
+  - u
+  - U
+  - まくろん
+  description: マクロン付き文字
+- char: ȳ
+  readings:
+  - y
+  - Y
+  - まくろん
+  description: マクロン付き文字
+- char: Å
+  readings:
+  - a
+  - A
+  - りんぐ
+  description: リング付き文字
+- char: å
+  readings:
+  - a
+  - A
+  - りんぐ
+  description: リング付き文字
+- char: Æ
+  readings:
+  - a
+  - A
+  - ae
+  - AE
+  - にじゅうぼいん
+  - ごうじ
+  - あっしゅ
+  description: 二重母音 合字
+- char: æ
+  readings:
+  - a
+  - A
+  - ae
+  - AE
+  - にじゅうぼいん
+  - ごうじ
+  - あっしゅ
+  - はつおんきごう
+  description: 発音記号 二重母音 合字
+- char: ß
+  readings:
+  - s
+  - S
+  - ss
+  - SS
+  - ごうじ
+  - えすつぇっと
+  description: エスツェット 合字
+- char: ẞ
+  readings:
+  - s
+  - S
+  - ss
+  - SS
+  - ごうじ
+  - えすつぇっと
+  description: エスツェット大文字 合字
+- char: ɑ
+  readings:
+  - a
+  - A
+  - はつおんきごう
+  - えー
+  - えい
+  - ぶろーどえー
+  - ぶろーどえい
+  - ぶろーどa
+  - ぶろーどA
+  - ぶろーどあ
+  description: 発音記号
+- char: ɒ
+  readings:
+  - a
+  - A
+  - はつおんきごう
+  description: 発音記号
+- char: ʌ
+  readings:
+  - はつおんきごう
+  - いんばーてっどぶい
+  - いんばーてぃっどぶい
+  - いんゔぁーてぃっどゔぃー
+  - いんゔぁーてっどゔぃー
+  - うぇっじ
+  - v
+  - u
+  - V
+  - U
+  description: 発音記号
+- char: ə
+  readings:
+  - はつおんきごう
+  - あいまいぼいん
+  - しゅわー
+  - しゅわ
+  - e
+  - E
+  description: 発音記号
+- char: ɚ
+  readings:
+  - はつおんきごう
+  - あいまいぼいん
+  - ふっくとしゅわー
+  - ふっくとしゅわ
+  - ふっくどしゅわー
+  - ふっくどしゅわ
+  - しゅわー
+  - しゅわ
+  - e
+  - E
+  description: 発音記号
+- char: ɔ
+  readings:
+  - はつおんきごう
+  - おーぷんおー
+  - o
+  - O
+  description: 発音記号
+- char: ɪ
+  readings:
+  - はつおんきごう
+  - i
+  - I
+  description: 発音記号
+- char: ʊ
+  readings:
+  - はつおんきごう
+  - ゆぷしろん
+  - u
+  - U
+  description: 発音記号
+- char: ð
+  readings:
+  - はつおんきごう
+  - えず
+  - えす
+  description: 発音記号
+- char: ŋ
+  readings:
+  - はつおんきごう
+  - えんぐ
+  - えん
+  - んg
+  - ng
+  - NG
+  description: 発音記号
+- char: ʃ
+  readings:
+  - はつおんきごう
+  - えしゅ
+  - sh
+  - SH
+  description: 発音記号
+- char: ʒ
+  readings:
+  - はつおんきごう
+  - えじゅ
+  - えっじゅ
+  - zh
+  - ZH
+  description: 発音記号
+- char: ʧ
+  readings:
+  - はつおんきごう
+  - tsh
+  - TSH
+  description: 発音記号
+- char: ʤ
+  readings:
+  - はつおんきごう
+  - dzh
+  - DZH
+  description: 発音記号
+- char: ː
+  readings:
+  - はつおんきごう
+  - ちょうぼいん
+  - ：
+  - ':'
+  description: 発音記号
+- char: ␀
+  readings:
+  - NUL
+  description: 制御記号
+- char: ␁
+  readings:
+  - SOH
+  description: 制御記号
+- char: ␂
+  readings:
+  - STX
+  description: 制御記号
+- char: ␃
+  readings:
+  - ETX
+  description: 制御記号
+- char: ␄
+  readings:
+  - EOT
+  description: 制御記号
+- char: ␅
+  readings:
+  - ENQ
+  description: 制御記号
+- char: ␆
+  readings:
+  - ACK
+  description: 制御記号
+- char: ␇
+  readings:
+  - BEL
+  description: 制御記号
+- char: ␈
+  readings:
+  - BS
+  description: 制御記号
+- char: ␉
+  readings:
+  - HT
+  description: 制御記号
+- char: ␊
+  readings:
+  - LF
+  description: 制御記号
+- char: ␋
+  readings:
+  - VT
+  description: 制御記号
+- char: ␌
+  readings:
+  - FF
+  description: 制御記号
+- char: ␍
+  readings:
+  - CR
+  description: 制御記号
+- char: ␎
+  readings:
+  - SO
+  description: 制御記号
+- char: ␏
+  readings:
+  - SI
+  description: 制御記号
+- char: ␐
+  readings:
+  - DLE
+  description: 制御記号
+- char: ␑
+  readings:
+  - DC1
+  description: 制御記号
+- char: ␒
+  readings:
+  - DC2
+  description: 制御記号
+- char: ␓
+  readings:
+  - DC3
+  description: 制御記号
+- char: ␔
+  readings:
+  - DC4
+  description: 制御記号
+- char: ␕
+  readings:
+  - NAK
+  description: 制御記号
+- char: ␖
+  readings:
+  - SYN
+  description: 制御記号
+- char: ␗
+  readings:
+  - ETB
+  description: 制御記号
+- char: ␘
+  readings:
+  - CAN
+  description: 制御記号
+- char: ␙
+  readings:
+  - EM
+  description: 制御記号
+- char: ␚
+  readings:
+  - SUB
+  description: 制御記号
+- char: ␛
+  readings:
+  - ESC
+  description: 制御記号
+- char: ␜
+  readings:
+  - FS
+  description: 制御記号
+- char: ␝
+  readings:
+  - GS
+  description: 制御記号
+- char: ␞
+  readings:
+  - RS
+  description: 制御記号
+- char: ␟
+  readings:
+  - US
+  description: 制御記号
+- char: ␠
+  readings:
+  - SP
+  description: 制御記号
+- char: ␡
+  readings:
+  - DEL
+  description: 制御記号
+- char: ␤
+  readings:
+  - NL
+  description: 制御記号
+- char: ʬ
+  readings:
+  - ww
+  - ばいらびあるぱーかっしぶ
+- char: ¤
+  readings:
+  - つうか
+  - たんい
+  - こくさいつうかきごう
+  description: 通貨記号
+- char: ₠
+  readings:
+  - つうか
+  - たんい
+  - おうしゅうつうかたんい
+  - えきゅー　きゅうゆーろ　えきゅーきごう　きゅうゆーろきごう
+  description: 通貨記号
+- char: ₡
+  readings:
+  - つうか
+  - たんい
+  - ころん
+  - ころんきごう
+  description: 通貨記号
+- char: ₢
+  readings:
+  - つうか
+  - たんい
+  - くるぜいろ
+  - くるぜいろきごう
+  description: 通貨記号
+- char: ₣
+  readings:
+  - つうか
+  - たんい
+  - ふらん
+  - ふらんきごう
+  description: 通貨記号
+- char: ₤
+  readings:
+  - つうか
+  - たんい
+  - りら
+  - りらきごう
+  description: 通貨記号
+- char: ₥
+  readings:
+  - つうか
+  - たんい
+  - みるきごう
+  description: 通貨記号
+- char: ₦
+  readings:
+  - つうか
+  - たんい
+  - ないら
+  - ないらきごう
+  description: 通貨記号
+- char: ₧
+  readings:
+  - つうか
+  - たんい
+  - ぺせた
+  - ぺせたきごう
+  description: 通貨記号
+- char: ₨
+  readings:
+  - つうか
+  - たんい
+  - るぴー
+  - るぴーきごう
+  description: 通貨記号
+- char: ₩
+  readings:
+  - つうか
+  - たんい
+  - うぉん
+  - うぉんきごう
+  description: 通貨記号
+- char: ₪
+  readings:
+  - つうか
+  - たんい
+  - しんしぇける
+  - しんしぇけるきごう
+  description: 通貨記号
+- char: ₫
+  readings:
+  - つうか
+  - たんい
+  - どん
+  - どんきごう
+  description: 通貨記号
+- char: ₭
+  readings:
+  - つうか
+  - たんい
+  - きーぷ
+  - きーぷきごう
+  description: 通貨記号
+- char: ₮
+  readings:
+  - つうか
+  - たんい
+  - どぐろぐ
+  - とぅぐるぐ
+  - とぅぐるく
+  - とぅぐりく
+  - どぐろぐきごう
+  - とぅぐるぐきごう
+  - とぅぐるくきごう
+  - とぅぐりくきごう
+  description: 通貨記号
+- char: ₯
+  readings:
+  - つうか
+  - たんい
+  - どらくま
+  - どらくまきごう
+  description: 通貨記号
+- char: ₰
+  readings:
+  - つうか
+  - たんい
+  - ぺにひ
+  - ぺにひきごう
+  description: 通貨記号
+- char: ₱
+  readings:
+  - つうか
+  - たんい
+  - ぺそ
+  - ぺそきごう
+  description: 通貨記号
+- char: ₲
+  readings:
+  - つうか
+  - たんい
+  - ぐあらにー
+  - ぐあらにーきごう
+  description: 通貨記号
+- char: ₳
+  readings:
+  - つうか
+  - たんい
+  - あうすとらる
+  - あうすとらるきごう
+  description: 通貨記号
+- char: ₴
+  readings:
+  - つうか
+  - たんい
+  - ぐりぶな
+  - ふりヴにゃ
+  - ふりぶにゃ
+  - ぐりぶなきごう
+  - ふりヴにゃきごう
+  - ふりぶにゃきごう
+  description: 通貨記号
+- char: ₵
+  readings:
+  - つうか
+  - たんい
+  - せでぃ
+  - せでぃきごう
+  description: 通貨記号
+- char: ₶
+  readings:
+  - つうか
+  - たんい
+  - りーぶる
+  - とぅーるりーぶる
+  description: 通貨記号
+- char: ₷
+  readings:
+  - つうか
+  - たんい
+  - すぺすみろ
+  description: 通貨記号
+- char: ₸
+  readings:
+  - つうか
+  - たんい
+  - てんげ
+  description: 通貨記号
+- char: ₹
+  readings:
+  - つうか
+  - たんい
+  - るぴー
+  - いんどるぴー
+  description: 通貨記号
+- char: ₺
+  readings:
+  - つうか
+  - たんい
+  - りら
+  - とるこりら
+  description: 通貨記号
+- char: ₻
+  readings:
+  - つうか
+  - たんい
+  - まるく
+  - のるうぇーまるく
+  description: 通貨記号
+- char: ₼
+  readings:
+  - つうか
+  - たんい
+  - まなと
+  - あぜるばいじゃんまなと
+  description: 通貨記号
+- char: ₽
+  readings:
+  - つうか
+  - たんい
+  - るーぶる
+  - ろしあるーぶる
+  description: 通貨記号
+- char: ₾
+  readings:
+  - つうか
+  - たんい
+  - らり
+  - じょーじあらり
+  description: 通貨記号
+- char: ₿
+  readings:
+  - つうか
+  - たんい
+  - びっとこいん
+  description: 通貨記号
+- char: ㌀
+  readings:
+  - あぱーと
+- char: ㌁
+  readings:
+  - あるふぁ
+- char: ㌂
+  readings:
+  - あんぺあ
+  description: 単位
+- char: ㌃
+  readings:
+  - あーる
+  - たんい
+  description: 単位
+- char: ㌄
+  readings:
+  - いにんぐ
+  - たんい
+  description: 単位
+- char: ㌅
+  readings:
+  - いんち
+  - たんい
+  description: 単位
+- char: ㌆
+  readings:
+  - うぉん
+  - たんい
+  description: 単位
+- char: ㌇
+  readings:
+  - えすくーど
+  - たんい
+  description: 単位
+- char: ㌈
+  readings:
+  - えーかー
+  - たんい
+  description: 単位
+- char: ㌉
+  readings:
+  - おんす
+  - たんい
+  description: 単位
+- char: ㌊
+  readings:
+  - おーむ
+  - たんい
+  description: 単位
+- char: ㌋
+  readings:
+  - かいり
+  - たんい
+  description: 単位
+- char: ㌌
+  readings:
+  - からっと
+  - たんい
+  description: 単位
+- char: ㌍
+  readings:
+  - かろりー
+  - たんい
+  description: 単位
+- char: ㌎
+  readings:
+  - がろん
+  - たんい
+  description: 単位
+- char: ㌏
+  readings:
+  - がんま
+  - たんい
+  description: 単位
+- char: ㌐
+  readings:
+  - ぎが
+  - たんい
+  description: 単位
+- char: ㌑
+  readings:
+  - ぎにー
+  - たんい
+  description: 単位
+- char: ㌒
+  readings:
+  - きゅりー
+  - たんい
+  description: 単位
+- char: ㌓
+  readings:
+  - ぎるだー
+  - たんい
+  description: 単位
+- char: ㌔
+  readings:
+  - きろ
+  - たんい
+  description: 単位
+- char: ㌕
+  readings:
+  - きろぐらむ
+  - たんい
+  description: 単位
+- char: ㌖
+  readings:
+  - きろめーとる
+  - たんい
+  description: 単位
+- char: ㌗
+  readings:
+  - きろわっと
+  - たんい
+  description: 単位
+- char: ㌘
+  readings:
+  - ぐらむ
+  - たんい
+  description: 単位
+- char: ㌙
+  readings:
+  - ぐらむとん
+  - たんい
+  description: 単位
+- char: ㌚
+  readings:
+  - くるぜいろ
+  - たんい
+  description: 単位
+- char: ㌛
+  readings:
+  - くろーね
+  - たんい
+  description: 単位
+- char: ㌜
+  readings:
+  - けーす
+  - たんい
+  description: 単位
+- char: ㌝
+  readings:
+  - こるな
+  - たんい
+  description: 単位
+- char: ㌞
+  readings:
+  - こーぽ
+- char: ㌟
+  readings:
+  - さいくる
+  - たんい
+  description: 単位
+- char: ㌠
+  readings:
+  - さんちーむ
+  - たんい
+  description: 単位
+- char: ㌡
+  readings:
+  - しりんぐ
+  - たんい
+  description: 単位
+- char: ㌢
+  readings:
+  - せんち
+  - たんい
+  description: 単位
+- char: ㌣
+  readings:
+  - せんと
+  - たんい
+  description: 単位
+- char: ㌤
+  readings:
+  - だーす
+  - たんい
+  description: 単位
+- char: ㌥
+  readings:
+  - でし
+  - たんい
+  description: 単位
+- char: ㌦
+  readings:
+  - どる
+  - たんい
+  description: 単位
+- char: ㌧
+  readings:
+  - とん
+  - たんい
+  description: 単位
+- char: ㌨
+  readings:
+  - なの
+  - たんい
+  description: 単位
+- char: ㌩
+  readings:
+  - のっと
+  - たんい
+  description: 単位
+- char: ㌪
+  readings:
+  - はいつ
+- char: ㌫
+  readings:
+  - ぱーせんと
+  - たんい
+  description: 単位
+- char: ㌬
+  readings:
+  - ぱーつ
+  - たんい
+  description: 単位
+- char: ㌭
+  readings:
+  - ばーれる
+  - たんい
+  description: 単位
+- char: ㌮
+  readings:
+  - ぴあすとる
+  - たんい
+  description: 単位
+- char: ㌯
+  readings:
+  - ぴくる
+  - たんい
+  description: 単位
+- char: ㌰
+  readings:
+  - ぴこ
+  - たんい
+  description: 単位
+- char: ㌱
+  readings:
+  - びる
+- char: ㌲
+  readings:
+  - ふぁらっど
+  - たんい
+  description: 単位
+- char: ㌳
+  readings:
+  - ふぃーと
+  - たんい
+  description: 単位
+- char: ㌴
+  readings:
+  - ぶっしぇる
+  - たんい
+  description: 単位
+- char: ㌵
+  readings:
+  - ふらん
+  - たんい
+  description: 単位
+- char: ㌶
+  readings:
+  - へくたーる
+  - たんい
+  description: 単位
+- char: ㌷
+  readings:
+  - ぺそ
+  - たんい
+  description: 単位
+- char: ㌸
+  readings:
+  - ぺにひ
+  - たんい
+  description: 単位
+- char: ㌹
+  readings:
+  - へるつ
+  - たんい
+  description: 単位
+- char: ㌺
+  readings:
+  - ぺんす
+  - たんい
+  description: 単位
+- char: ㌻
+  readings:
+  - ぺーじ
+  - たんい
+  description: 単位
+- char: ㌼
+  readings:
+  - べーた
+- char: ㌽
+  readings:
+  - ぽいんと
+  - たんい
+  description: 単位
+- char: ㌾
+  readings:
+  - ぼると
+  - たんい
+  description: 単位
+- char: ㌿
+  readings:
+  - ほん
+  - たんい
+  description: 単位
+- char: ㍀
+  readings:
+  - ぽんど
+  - たんい
+  description: 単位
+- char: ㍁
+  readings:
+  - ほーる
+- char: ㍂
+  readings:
+  - ほーん
+  - たんい
+  description: 単位
+- char: ㍃
+  readings:
+  - まいくろ
+  - たんい
+  description: 単位
+- char: ㍄
+  readings:
+  - まいる
+  - たんい
+  description: 単位
+- char: ㍅
+  readings:
+  - まっは
+  - たんい
+  description: 単位
+- char: ㍆
+  readings:
+  - まるく
+  - たんい
+  description: 単位
+- char: ㍇
+  readings:
+  - まんしょん
+- char: ㍈
+  readings:
+  - みくろん
+  - たんい
+  description: 単位
+- char: ㍉
+  readings:
+  - みり
+  - たんい
+  description: 単位
+- char: ㍊
+  readings:
+  - みりばーる
+  - たんい
+  description: 単位
+- char: ㍋
+  readings:
+  - めが
+  - たんい
+  description: 単位
+- char: ㍌
+  readings:
+  - めがとん
+  - たんい
+  description: 単位
+- char: ㍍
+  readings:
+  - めーとる
+  - たんい
+  description: 単位
+- char: ㍎
+  readings:
+  - やーど
+  - たんい
+  description: 単位
+- char: ㍏
+  readings:
+  - やーる
+  - たんい
+  description: 単位
+- char: ㍐
+  readings:
+  - ゆあん
+  - たんい
+  description: 単位
+- char: ㍑
+  readings:
+  - りっとる
+  - たんい
+  description: 単位
+- char: ㍒
+  readings:
+  - りら
+  - たんい
+  description: 単位
+- char: ㍓
+  readings:
+  - るぴー
+  - たんい
+  description: 単位
+- char: ㍔
+  readings:
+  - るーぶる
+  - たんい
+  description: 単位
+- char: ㍕
+  readings:
+  - れむ
+  - たんい
+  description: 単位
+- char: ㍖
+  readings:
+  - れんとげん
+  - たんい
+  description: 単位
+- char: ㍗
+  readings:
+  - わっと
+  - たんい
+  description: 単位
+- char: ↔
+  readings:
+  - やじるし
+  - ←→
+  - <->
+  - <ー>
+  description: 矢印
+- char: ↕
+  readings:
+  - やじるし
+  - ↑↓
+  - ↓↑
+  description: 矢印
+- char: ↖
+  readings:
+  - やじるし
+  - ←
+  - ↑
+  - ひだりうえ
+  - ひだりうえや
+  description: 矢印
+- char: ↗
+  readings:
+  - やじるし
+  - →
+  - ↑
+  - みぎうえ
+  - みぎうえや
+  description: 矢印
+- char: ↘
+  readings:
+  - やじるし
+  - →
+  - ↓
+  - みぎした
+  - みぎしたや
+  description: 矢印
+- char: ↙
+  readings:
+  - やじるし
+  - ←
+  - ↓
+  - ひだりした
+  - ひだりしたや
+  description: 矢印
+- char: ↩
+  readings:
+  - やじるし
+  - ←
+  description: 矢印
+- char: ↪
+  readings:
+  - やじるし
+  - →
+  description: 矢印
+- char: ↰
+  readings:
+  - やじるし
+  - ←
+  description: 矢印
+- char: ↱
+  readings:
+  - やじるし
+  - →
+  description: 矢印
+- char: ↲
+  readings:
+  - やじるし
+  - ←
+  description: 矢印
+- char: ↴
+  readings:
+  - やじるし
+  - ↓
+  description: 矢印
+- char: ↳
+  readings:
+  - やじるし
+  - →
+  description: 矢印
+- char: ↵
+  readings:
+  - やじるし
+  - ←
+  - えんたー
+  - りたーん
+  - かいぎょう
+  description: 矢印 改行記号
+- char: ↶
+  readings:
+  - やじるし
+  - ↓
+  description: 矢印
+- char: ↷
+  readings:
+  - やじるし
+  - ↓
+  description: 矢印
+- char: ↺
+  readings:
+  - やじるし
+  - →
+  - ↑
+  description: 矢印
+- char: ↻
+  readings:
+  - やじるし
+  - ←
+  - ↑
+  description: 矢印
+- char: ⤴
+  readings:
+  - やじるし
+  - ↑
+  description: 矢印
+- char: ⤵
+  readings:
+  - やじるし
+  - ↓
+  description: 矢印
+- char: ⇄
+  readings:
+  - やじるし
+  - →←
+  description: 矢印
+- char: ⇅
+  readings:
+  - やじるし
+  - ↑↓
+  description: 矢印
+- char: ⇆
+  readings:
+  - やじるし
+  - ←→
+  description: 矢印
+- char: ⇇
+  readings:
+  - やじるし
+  - ←
+  - ←←
+  description: 矢印
+- char: ⇈
+  readings:
+  - やじるし
+  - ↑
+  - ↑↑
+  description: 矢印
+- char: ⇉
+  readings:
+  - やじるし
+  - →
+  - →→
+  description: 矢印
+- char: ⇊
+  readings:
+  - やじるし
+  - ↓
+  - ↓↓
+  description: 矢印
+- char: ⇐
+  readings:
+  - やじるし
+  - ひだりや
+  - ひだり
+  - <=
+  - ←
+  description: 太矢印
+- char: ⇑
+  readings:
+  - やじるし
+  - うえや
+  - うえ
+  - ↑
+  description: 太矢印
+- char: ⇓
+  readings:
+  - やじるし
+  - したや
+  - した
+  - ↓
+  description: 太矢印
+- char: ⇕
+  readings:
+  - やじるし
+  - ↑↓
+  - ↓↑
+  description: 太矢印
+- char: ⇖
+  readings:
+  - やじるし
+  - ひだりうえ
+  - ひだりうえや
+  - ←
+  - ↑
+  description: 太矢印
+- char: ⇗
+  readings:
+  - やじるし
+  - みぎうえ
+  - みぎうえや
+  - →
+  - ↑
+  description: 太矢印
+- char: ⇘
+  readings:
+  - やじるし
+  - みぎした
+  - みぎしたや
+  - →
+  - ↓
+  description: 太矢印
+- char: ⇙
+  readings:
+  - やじるし
+  - ひだりした
+  - ひだりしたや
+  - ←
+  - ↓
+  description: 太矢印
+- char: ⇚
+  readings:
+  - やじるし
+  - ひだりや
+  - ひだり
+  - ←
+  description: 三重矢印
+- char: ⇛
+  readings:
+  - やじるし
+  - みぎや
+  - みぎ
+  - →
+  description: 三重矢印
+- char: ⇠
+  readings:
+  - やじるし
+  - ひだりや
+  - ひだり
+  - <...
+  - ←
+  description: 点線矢印
+- char: ⇡
+  readings:
+  - やじるし
+  - うえや
+  - うえ
+  - ↑
+  description: 点線矢印
+- char: ⇢
+  readings:
+  - やじるし
+  - みぎや
+  - みぎ
+  - ...>
+  - →
+  description: 点線矢印
+- char: ⇣
+  readings:
+  - やじるし
+  - したや
+  - した
+  - ↓
+  description: 点線矢印
+- char: ⇦
+  readings:
+  - やじるし
+  - ひだりや
+  - ひだり
+  - ←
+  description: 白抜き矢印
+- char: ⇧
+  readings:
+  - やじるし
+  - うえや
+  - うえ
+  - ↑
+  description: 白抜き矢印
+- char: ⇨
+  readings:
+  - やじるし
+  - みぎや
+  - みぎ
+  - →
+  description: 白抜き矢印
+- char: ⇩
+  readings:
+  - やじるし
+  - したや
+  - した
+  - ↓
+  description: 白抜き矢印
+- char: 〄
+  readings:
+  - きごう
+  - JIS
+  - じす
+  description: JISマーク
+- char: 〠
+  readings:
+  - きごう
+  - ゆうびん
+  description: 郵便記号
+- char: 〶
+  readings:
+  - きごう
+  - ゆうびん
+  description: 郵便記号
+- char: 〼
+  readings:
+  - ます
+  description: 枡記号
+- char: 〽
+  readings:
+  - いおりてん
+  - うた
+  description: 庵点 歌記号
+- char: (月)
+  readings:
+  - げつ
+  - げつよう
+  - げつようび
+  description: 月曜日
+- char: (火)
+  readings:
+  - か
+  - かよう
+  - かようび
+  description: 火曜日
+- char: (水)
+  readings:
+  - すい
+  - すいよう
+  - すいようび
+  description: 水曜日
+- char: (木)
+  readings:
+  - もく
+  - もくよう
+  - もくようび
+  description: 木曜日
+- char: (金)
+  readings:
+  - きん
+  - きんよう
+  - きんようび
+  description: 金曜日
+- char: (土)
+  readings:
+  - ど
+  - どよう
+  - どようび
+  description: 土曜日
+- char: (日)
+  readings:
+  - にち
+  - にちよう
+  - にちようび
+  description: 日曜日
+- char: ㈪
+  readings:
+  - げつよう
+  - げつようび
+  description: 月曜日
+- char: ㈫
+  readings:
+  - かよう
+  - かようび
+  description: 火曜日
+- char: ㈬
+  readings:
+  - すいよう
+  - すいようび
+  description: 水曜日
+- char: ㈭
+  readings:
+  - もくよう
+  - もくようび
+  description: 木曜日
+- char: ㈮
+  readings:
+  - きんよう
+  - きんようび
+  description: 金曜日
+- char: ㈯
+  readings:
+  - どよう
+  - どようび
+  description: 土曜日
+- char: ㈰
+  readings:
+  - にちよう
+  - にちようび
+  description: 日曜日
+- char: ㈷
+  readings:
+  - しゅくじつ
+  - かっこしゅく
+  description: 祝日
+- char: ㉁
+  readings:
+  - やすみ
+  - きゅうじつ
+  - かっこきゅう
+  description: (休)
+- char: ㈳
+  readings:
+  - しゃだんほうじん
+  - かっこしゃ
+  description: (社)
+- char: ㈴
+  readings:
+  - なまえ
+  - かっこめい
+  description: (名)
+- char: ㈵
+  readings:
+  - とくしゅほうじん
+  - かっことく
+  description: (特)
+- char: ㈶
+  readings:
+  - ざいだんほうじん
+  - かっこざい
+  description: (財)
+- char: ㈸
+  readings:
+  - ろうどうくみあい
+  - かっころう
+  description: (労)
+- char: ㈺
+  readings:
+  - よびだし
+  - かっこよび
+  description: (呼)
+- char: ㈻
+  readings:
+  - がっこうほうじん
+  - かっこがく
+  description: (学)
+- char: ㈼
+  readings:
+  - かんさほうじん
+  - かっこかん
+  description: (監)
+- char: ㈽
+  readings:
+  - かっこき
+  description: (企)
+- char: ㈾
+  readings:
+  - かっこし
+  description: (資)
+- char: ㈿
+  readings:
+  - かっこきょう
+  description: (協)
+- char: ㉀
+  readings:
+  - さいじつ
+  - かっこさい
+  description: (祭)
+- char: ㉂
+  readings:
+  - かっこじ
+  - かっこより
+  description: (自)
+- char: ㉃
+  readings:
+  - いたる
+  - かっこいたる
+  description: (至)
+- char: ㊙
+  readings:
+  - まるひ
+  description: 丸秘
+- char: ㊚
+  readings:
+  - まるおとこ
+  - おとこ
+  description: 丸男
+- char: ㊛
+  readings:
+  - まるおんな
+  - おんな
+  description: 丸女
+- char: ㊜
+  readings:
+  - まるてき
+  description: 丸適
+- char: ㊝
+  readings:
+  - まるゆう
+  description: 丸優
+- char: ㊞
+  readings:
+  - まるいん
+  - いんかん
+  description: 丸印
+- char: ㊟
+  readings:
+  - まるちゅう
+  description: 丸注
+- char: ㊠
+  readings:
+  - まるこう
+  description: 丸項
+- char: ㊡
+  readings:
+  - まるきゅう
+  description: 丸休
+- char: ㊢
+  readings:
+  - まるしゃ
+  description: 丸写
+- char: ㊣
+  readings:
+  - まるせい
+  description: 丸正
+- char: ㊩
+  readings:
+  - まるい
+  description: 丸医
+- char: ㊪
+  readings:
+  - まるしゅう
+  description: 丸宗
+- char: ㊫
+  readings:
+  - まるがく
+  description: 丸学
+- char: ㊬
+  readings:
+  - まるかん
+  description: 丸監
+- char: ㊭
+  readings:
+  - まるき
+  description: 丸企
+- char: ㊮
+  readings:
+  - まるし
+  description: 丸資
+- char: ㊯
+  readings:
+  - まるきょう
+  description: 丸協
+- char: ㊰
+  readings:
+  - まるよる
+  description: 丸夜
+- char: ㋐
+  readings:
+  - まるあ
+  description: 丸ア
+- char: ㋑
+  readings:
+  - まるい
+  description: 丸イ
+- char: ㋒
+  readings:
+  - まるう
+  description: 丸ウ
+- char: ㋓
+  readings:
+  - まるえ
+  description: 丸エ
+- char: ㋔
+  readings:
+  - まるお
+  description: 丸オ
+- char: ㋕
+  readings:
+  - まるか
+  description: 丸カ
+- char: ㋖
+  readings:
+  - まるき
+  description: 丸キ
+- char: ㋗
+  readings:
+  - まるく
+  description: 丸ク
+- char: ㋘
+  readings:
+  - まるけ
+  description: 丸ケ
+- char: ㋙
+  readings:
+  - まるこ
+  description: 丸コ
+- char: ㋚
+  readings:
+  - まるさ
+  description: 丸サ
+- char: ㋛
+  readings:
+  - まるし
+  description: 丸シ
+- char: ㋜
+  readings:
+  - まるす
+  description: 丸ス
+- char: ㋝
+  readings:
+  - まるせ
+  description: 丸セ
+- char: ㋞
+  readings:
+  - まるそ
+  description: 丸ソ
+- char: ㋟
+  readings:
+  - まるた
+  description: 丸タ
+- char: ㋠
+  readings:
+  - まるち
+  description: 丸チ
+- char: ㋡
+  readings:
+  - まるつ
+  description: 丸ツ
+- char: ㋢
+  readings:
+  - まるて
+  description: 丸テ
+- char: ㋣
+  readings:
+  - まると
+  description: 丸ト
+- char: ㋤
+  readings:
+  - まるな
+  description: 丸ナ
+- char: ㋥
+  readings:
+  - まるに
+  description: 丸ニ
+- char: ㋦
+  readings:
+  - まるぬ
+  description: 丸ヌ
+- char: ㋧
+  readings:
+  - まるね
+  description: 丸ネ
+- char: ㋨
+  readings:
+  - まるの
+  description: 丸ノ
+- char: ㋩
+  readings:
+  - まるは
+  description: 丸ハ
+- char: ㋪
+  readings:
+  - まるひ
+  description: 丸ヒ
+- char: ㋫
+  readings:
+  - まるふ
+  description: 丸フ
+- char: ㋬
+  readings:
+  - まるへ
+  description: 丸ヘ
+- char: ㋭
+  readings:
+  - まるほ
+  description: 丸ホ
+- char: ㋮
+  readings:
+  - まるま
+  description: 丸マ
+- char: ㋯
+  readings:
+  - まるみ
+  description: 丸ミ
+- char: ㋰
+  readings:
+  - まるむ
+  description: 丸ム
+- char: ㋱
+  readings:
+  - まるめ
+  description: 丸メ
+- char: ㋲
+  readings:
+  - まるも
+  description: 丸モ
+- char: ㋳
+  readings:
+  - まるや
+  description: 丸ヤ
+- char: ㋴
+  readings:
+  - まるゆ
+  description: 丸ユ
+- char: ㋵
+  readings:
+  - まるよ
+  description: 丸ヨ
+- char: ㋶
+  readings:
+  - まるら
+  description: 丸ラ
+- char: ㋷
+  readings:
+  - まるり
+  description: 丸リ
+- char: ㋸
+  readings:
+  - まるる
+  description: 丸ル
+- char: ㋹
+  readings:
+  - まるれ
+  description: 丸レ
+- char: ㋺
+  readings:
+  - まるろ
+  description: 丸ロ
+- char: ㋻
+  readings:
+  - まるわ
+  description: 丸ワ
+- char: ㋼
+  readings:
+  - まるうぃ
+  - まるゐ
+  description: 丸ヰ
+- char: ㋽
+  readings:
+  - まるうぇ
+  - まるゑ
+  description: 丸ヱ
+- char: ㋾
+  readings:
+  - まるを
+  description: 丸ヲ
+- char: ⁰
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき0
+  - うえつき0
+  - うえ0
+  description: 上付き文字
+- char: ¹
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき1
+  - うえつき1
+  - うえ1
+  description: 上付き文字
+- char: ²
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき2
+  - うえつき2
+  - うえ2
+  description: 上付き文字
+- char: ³
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき3
+  - うえつき3
+  - うえ3
+  description: 上付き文字
+- char: ⁴
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき4
+  - うえつき4
+  - うえ4
+  description: 上付き文字
+- char: ⁵
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき5
+  - うえつき5
+  - うえ5
+  description: 上付き文字
+- char: ⁶
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき6
+  - うえつき6
+  - うえ6
+  description: 上付き文字
+- char: ⁷
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき7
+  - うえつき7
+  - うえ7
+  description: 上付き文字
+- char: ⁸
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき8
+  - うえつき8
+  - うえ8
+  description: 上付き文字
+- char: ⁹
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき9
+  - うえつき9
+  - うえ9
+  description: 上付き文字
+- char: ⁺
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき+
+  - うえつき+
+  - うえ+
+  - +
+  description: 上付き文字
+- char: ⁻
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき-
+  - うえつき-
+  - うえ-
+  - '-'
+  description: 上付き文字
+- char: ⁼
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき=
+  - うえつき=
+  - うえ=
+  - =
+  description: 上付き文字
+- char: ⁽
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき(
+  - うえつき(
+  - うえ(
+  - (
+  description: 上付き文字
+- char: ⁾
+  readings:
+  - うわつき
+  - うえつき
+  - うわつき)
+  - うえつき)
+  - うえ)
+  - )
+  description: 上付き文字
+- char: ⁿ
+  readings:
+  - うわつき
+  - うえつき
+  - うわつきn
+  - うえつきn
+  - うえn
+  - うわつきN
+  - うえつきN
+  - うえN
+  - うわつきん
+  - うえつきん
+  - うえん
+  - n
+  description: 上付き文字
+- char: ₀
+  readings:
+  - したつき
+  - したつき0
+  - した0
+  description: 下付き文字
+- char: ₁
+  readings:
+  - したつき
+  - したつき1
+  - した1
+  description: 下付き文字
+- char: ₂
+  readings:
+  - したつき
+  - したつき2
+  - した2
+  description: 下付き文字
+- char: ₃
+  readings:
+  - したつき
+  - したつき3
+  - した3
+  description: 下付き文字
+- char: ₄
+  readings:
+  - したつき
+  - したつき4
+  - した4
+  description: 下付き文字
+- char: ₅
+  readings:
+  - したつき
+  - したつき5
+  - した5
+  description: 下付き文字
+- char: ₆
+  readings:
+  - したつき
+  - したつき6
+  - した6
+  description: 下付き文字
+- char: ₇
+  readings:
+  - したつき
+  - したつき7
+  - した7
+  description: 下付き文字
+- char: ₈
+  readings:
+  - したつき
+  - したつき8
+  - した8
+  description: 下付き文字
+- char: ₉
+  readings:
+  - したつき
+  - したつき9
+  - した9
+  description: 下付き文字
+- char: ₊
+  readings:
+  - したつき
+  - したつき+
+  - した+
+  - +
+  description: 下付き文字
+- char: ₋
+  readings:
+  - したつき
+  - したつき-
+  - した-
+  - '-'
+  description: 下付き文字
+- char: ₌
+  readings:
+  - したつき
+  - したつき=
+  - した=
+  - =
+  description: 下付き文字
+- char: ₍
+  readings:
+  - したつき
+  - したつき(
+  - した(
+  - (
+  description: 下付き文字
+- char: ₎
+  readings:
+  - したつき
+  - したつき)
+  - した)
+  - )
+  description: 下付き文字
+- char: ₐ
+  readings:
+  - したつき
+  - したつきa
+  - したつきあ
+  - したつきA
+  - したa
+  - したあ
+  - したA
+  - a
+  description: 下付き文字
+- char: ₑ
+  readings:
+  - したつき
+  - したつきe
+  - したつきえ
+  - したつきE
+  - したe
+  - したえ
+  - したE
+  - e
+  description: 下付き文字
+- char: ₒ
+  readings:
+  - したつき
+  - したつきo
+  - したつきお
+  - したつきO
+  - したo
+  - したお
+  - したO
+  - o
+  description: 下付き文字
+- char: ₓ
+  readings:
+  - したつき
+  - したつきx
+  - したつきX
+  - したx
+  - したX
+  - x
+  description: 下付き文字
+- char: ₔ
+  readings:
+  - したつき
+  - したつきe
+  - したつきえ
+  - したつきE
+  - したe
+  - したえ
+  - したE
+  - e
+  description: 下付き文字
+- char: ✁
+  readings:
+  - きごう
+  - はさみ
+  description: はさみ
+- char: ✂
+  readings:
+  - きごう
+  - はさみ
+  description: はさみ
+- char: ✃
+  readings:
+  - きごう
+  - はさみ
+  description: はさみ
+- char: ✄
+  readings:
+  - きごう
+  - はさみ
+  description: はさみ
+- char: ✆
+  readings:
+  - きごう
+  - でんわ
+  description: 電話
+- char: ✇
+  readings:
+  - きごう
+  - てーぷ
+  - てーぷどらいぶ
+  description: テープドライブ
+- char: ✈
+  readings:
+  - きごう
+  - ひこうき
+  description: 飛行機
+- char: ✉
+  readings:
+  - きごう
+  - ふうとう
+  description: 封筒
+- char: ✌
+  readings:
+  - きごう
+  - ぴーす
+  - ぶい
+  description: ピース
+- char: ✍
+  readings:
+  - きごう
+  - てがき
+  - めも
+  description: 手書き
+- char: ✎
+  readings:
+  - きごう
+  - えんぴつ
+  description: 鉛筆
+- char: ✏
+  readings:
+  - きごう
+  - えんぴつ
+  description: 鉛筆
+- char: ✐
+  readings:
+  - きごう
+  - えんぴつ
+  description: 鉛筆
+- char: ✑
+  readings:
+  - きごう
+  - ぺん
+  - ぺんさき
+  - まんねんひつ
+  description: ペン先
+- char: ✒
+  readings:
+  - きごう
+  - ぺん
+  - ぺんさき
+  - まんねんひつ
+  description: ペン先
+- char: ✕
+  readings:
+  - きごう
+  - ばつ
+  - ぺけ
+  - かける
+  description: 乗算記号
+- char: ✖
+  readings:
+  - きごう
+  - ばつ
+  - ぺけ
+  - かける
+  description: 乗算記号
+- char: ✗
+  readings:
+  - きごう
+  - ばつ
+  - ぺけ
+  description: バツマーク
+- char: ✘
+  readings:
+  - きごう
+  - ばつ
+  - ぺけ
+  description: バツマーク
+- char: ✙
+  readings:
+  - きごう
+  - くろす
+  - じゅうじか
+  - じゅうじ
+  description: 十字架
+- char: ✚
+  readings:
+  - きごう
+  - くろす
+  - じゅうじか
+  - じゅうじ
+  description: 十字架
+- char: ✛
+  readings:
+  - きごう
+  - くろす
+  - じゅうじか
+  - じゅうじ
+  description: 十字架
+- char: ✜
+  readings:
+  - きごう
+  - くろす
+  - じゅうじか
+  - じゅうじ
+  description: 十字架
+- char: ✝
+  readings:
+  - きごう
+  - くろす
+  - じゅうじか
+  - じゅうじ
+  description: 十字架
+- char: ✞
+  readings:
+  - きごう
+  - くろす
+  - じゅうじか
+  - じゅうじ
+  description: 十字架
+- char: ✟
+  readings:
+  - きごう
+  - くろす
+  - じゅうじか
+  - じゅうじ
+  description: 十字架
+- char: ✠
+  readings:
+  - きごう
+  - くろす
+  - じゅうじか
+  - じゅうじ
+  - まるたじゅうじ
+  description: マルタ十字
+- char: ✡
+  readings:
+  - きごう
+  - ほし
+  - だびで
+  - だびでのほし
+  - ろくぼうせい
+  description: ダビデの星
+- char: ✢
+  readings:
+  - きごう
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✣
+  readings:
+  - きごう
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✤
+  readings:
+  - きごう
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✥
+  readings:
+  - きごう
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✦
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✧
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✩
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✪
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✫
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✬
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✭
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✮
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✯
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✰
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ✱
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✲
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✳
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✴
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✵
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✶
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✷
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✸
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✹
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✺
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✻
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✼
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✽
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ✾
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  - はな
+  description: 花
+- char: ✿
+  readings:
+  - きごう
+  - はな
+  description: 花
+- char: ❀
+  readings:
+  - きごう
+  - はな
+  description: 花
+- char: ❁
+  readings:
+  - きごう
+  - はな
+  description: 花
+- char: ❂
+  readings:
+  - きごう
+  - ほし
+  description: 星
+- char: ❃
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ❄
+  readings:
+  - きごう
+  - ゆき
+  description: 雪
+- char: ❅
+  readings:
+  - きごう
+  - ゆき
+  description: 雪
+- char: ❆
+  readings:
+  - きごう
+  - ゆき
+  description: 雪
+- char: ❇
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ❈
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ❉
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ❊
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ❋
+  readings:
+  - きごう
+  - ほし
+  - あすたりすく
+  - あすてりすく
+  description: アスタリスク
+- char: ❍
+  readings:
+  - きごう
+  - まる
+  - ずけい
+  description: 丸
+- char: ❏
+  readings:
+  - きごう
+  - しかく
+  - ずけい
+  description: 四角
+- char: ❐
+  readings:
+  - きごう
+  - しかく
+  - ずけい
+  description: 四角
+- char: ❑
+  readings:
+  - きごう
+  - しかく
+  - ずけい
+  description: 四角
+- char: ❒
+  readings:
+  - きごう
+  - しかく
+  - ずけい
+  description: 四角
+- char: ❖
+  readings:
+  - きごう
+  - ひし
+  - ひしがた
+  - ずけい
+  description: ダイヤモンド
+- char: ❘
+  readings:
+  - きごう
+  - たてぼう
+  - たてせん
+  - '|'
+  description: 縦棒
+- char: ❙
+  readings:
+  - きごう
+  - たてぼう
+  - たてせん
+  - '|'
+  description: 縦棒
+- char: ❚
+  readings:
+  - きごう
+  - たてぼう
+  - たてせん
+  - '|'
+  description: 縦棒
+- char: ❛
+  readings:
+  - きごう
+  - くぉーと
+  - ''''
+  description: シングルクォート
+- char: ❜
+  readings:
+  - きごう
+  - あぽすとろふぃ
+  - くぉーと
+  - こんま
+  - かんま
+  - ''''
+  description: シングルクォート
+- char: ❝
+  readings:
+  - きごう
+  - だぶるくおーと
+  - だぶるくおーてーしょん
+  - くぉーと
+  - だぶるくぉーてしょん
+  - '"'
+  description: ダブルクォート
+- char: ❞
+  readings:
+  - きごう
+  - だぶるくおーと
+  - だぶるくおーてーしょん
+  - くぉーと
+  - だぶるくぉーてしょん
+  - '"'
+  description: ダブルクォート
+- char: ❡
+  readings:
+  - きごう
+  - だんらく
+  - せくしょん
+  description: 段落記号
+- char: ❢
+  readings:
+  - きごう
+  - かんたんふ
+  - '!'
+  - ！
+  - えくすくらめーしょん
+  - びっくり
+  description: 感嘆符
+- char: ❣
+  readings:
+  - きごう
+  - かんたんふ
+  - '!'
+  - ！
+  - えくすくらめーしょん
+  - びっくり
+  description: 感嘆符
+- char: ❤
+  readings:
+  - きごう
+  - はーと
+  description: ハート
+- char: ❥
+  readings:
+  - きごう
+  - はーと
+  description: ハート
+- char: ❦
+  readings:
+  - きごう
+  - はーと
+  description: ハート
+- char: ❧
+  readings:
+  - きごう
+  - はーと
+  description: ハート
+- char: ❶
+  readings:
+  - きごう
+  - まる1
+  - まるいち
+  description: 丸数字
+- char: ❷
+  readings:
+  - きごう
+  - まる2
+  - まるに
+  description: 丸数字
+- char: ❸
+  readings:
+  - きごう
+  - まる3
+  - まるさん
+  description: 丸数字
+- char: ❹
+  readings:
+  - きごう
+  - まる4
+  - まるよん
+  - まるし
+  description: 丸数字
+- char: ❺
+  readings:
+  - きごう
+  - まる5
+  - まるご
+  description: 丸数字
+- char: ❻
+  readings:
+  - きごう
+  - まる6
+  - まるろく
+  description: 丸数字
+- char: ❼
+  readings:
+  - きごう
+  - まる7
+  - まるなな
+  - まるしち
+  description: 丸数字
+- char: ❽
+  readings:
+  - きごう
+  - まる8
+  - まるはち
+  description: 丸数字
+- char: ❾
+  readings:
+  - きごう
+  - まる9
+  - まるきゅう
+  - まるく
+  description: 丸数字
+- char: ❿
+  readings:
+  - きごう
+  - まる10
+  - まるじゅう
+  description: 丸数字
+- char: ➀
+  readings:
+  - きごう
+  - まる1
+  - まるいち
+  description: 丸数字
+- char: ➁
+  readings:
+  - きごう
+  - まる2
+  - まるに
+  description: 丸数字
+- char: ➂
+  readings:
+  - きごう
+  - まる3
+  - まるさん
+  description: 丸数字
+- char: ➃
+  readings:
+  - きごう
+  - まる4
+  - まるよん
+  - まるし
+  description: 丸数字
+- char: ➄
+  readings:
+  - きごう
+  - まる5
+  - まるご
+  description: 丸数字
+- char: ➅
+  readings:
+  - きごう
+  - まる6
+  - まるろく
+  description: 丸数字
+- char: ➆
+  readings:
+  - きごう
+  - まる7
+  - まるなな
+  - まるしち
+  description: 丸数字
+- char: ➇
+  readings:
+  - きごう
+  - まる8
+  - まるはち
+  description: 丸数字
+- char: ➈
+  readings:
+  - きごう
+  - まる9
+  - まるきゅう
+  - まるく
+  description: 丸数字
+- char: ➉
+  readings:
+  - きごう
+  - まる10
+  - まるじゅう
+  description: 丸数字
+- char: ➊
+  readings:
+  - きごう
+  - まる1
+  - まるいち
+  description: 丸数字
+- char: ➋
+  readings:
+  - きごう
+  - まる2
+  - まるに
+  description: 丸数字
+- char: ➌
+  readings:
+  - きごう
+  - まる3
+  - まるさん
+  description: 丸数字
+- char: ➍
+  readings:
+  - きごう
+  - まる4
+  - まるよん
+  - まるし
+  description: 丸数字
+- char: ➎
+  readings:
+  - きごう
+  - まる5
+  - まるご
+  description: 丸数字
+- char: ➏
+  readings:
+  - きごう
+  - まる6
+  - まるろく
+  description: 丸数字
+- char: ➐
+  readings:
+  - きごう
+  - まる7
+  - まるなな
+  - まるしち
+  description: 丸数字
+- char: ➑
+  readings:
+  - きごう
+  - まる8
+  - まるはち
+  description: 丸数字
+- char: ➒
+  readings:
+  - きごう
+  - まる9
+  - まるきゅう
+  - まるく
+  description: 丸数字
+- char: ➓
+  readings:
+  - きごう
+  - まる10
+  - まるじゅう
+  description: 丸数字
+- char: ➔
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➘
+  readings:
+  - きごう
+  - やじるし
+  - みぎした
+  description: 右下矢印
+- char: ➙
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➚
+  readings:
+  - きごう
+  - やじるし
+  - みぎうえ
+  description: 右上矢印
+- char: ➛
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➜
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➝
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➞
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➟
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➠
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➡
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➢
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➣
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➤
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➥
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➦
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➧
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➨
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➩
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➪
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➫
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➬
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➭
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➮
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➯
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➱
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➲
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➳
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➴
+  readings:
+  - きごう
+  - やじるし
+  - みぎした
+  description: 右下矢印
+- char: ➵
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➶
+  readings:
+  - きごう
+  - やじるし
+  - みぎうえ
+  description: 右上矢印
+- char: ➷
+  readings:
+  - きごう
+  - やじるし
+  - みぎした
+  description: 右下矢印
+- char: ➸
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➹
+  readings:
+  - きごう
+  - やじるし
+  - みぎうえ
+  description: 右上矢印
+- char: ➺
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➻
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➼
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➽
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: ➾
+  readings:
+  - きごう
+  - やじるし
+  - みぎ
+  description: 右矢印
+- char: (笑)
+  readings:
+  - わら
+  description: 笑
+- char: w
+  readings:
+  - わら
+  description: 笑
+- char: www
+  readings:
+  - わら
+  - くさ
+  description: 笑
+- char: (泣)
+  readings:
+  - なく
+  - なき
+  description: 泣
+- char: (汗)
+  readings:
+  - あせ
+  description: 汗
+- char: 乙
+  readings:
+  - ぶしゅ
+  - おつにょう
+  - つりばり
+  description: 部首
+- char: 乚
+  readings:
+  - ぶしゅ
+  - おつ
+  - おつにょう
+  - つりばり
+  description: 部首
+- char: 丨
+  readings:
+  - ぶしゅ
+  - いちぼう
+  - たて
+  - たてぼう
+  - こん
+  - '|'
+  description: 部首
+- char: 丶
+  readings:
+  - ぶしゅ
+  - てん
+  description: 部首
+- char: 丿
+  readings:
+  - ぶしゅ
+  - の
+  description: 部首
+- char: 亅
+  readings:
+  - ぶしゅ
+  - はねぼう
+  - かぎ
+  description: 部首
+- char: 二
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 亠
+  readings:
+  - ぶしゅ
+  - なべぶた
+  description: 部首
+- char: 人
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 亻
+  readings:
+  - ぶしゅ
+  - にんべん
+  description: 部首
+- char: 𠆢
+  readings:
+  - ぶしゅ
+  - ひとがしら
+  - ひとやね
+  description: 部首
+- char: 儿
+  readings:
+  - ぶしゅ
+  - にんにょう
+  - ひとあし
+  description: 部首
+- char: 入
+  readings:
+  - ぶしゅ
+  - いる
+  - いりがしら
+  - いりやね
+  description: 部首
+- char: 八
+  readings:
+  - ぶしゅ
+  - はちがしら
+  description: 部首
+- char: 冖
+  readings:
+  - ぶしゅ
+  - わかんむり
+  - べきかんむり
+  description: 部首
+- char: 冂
+  readings:
+  - ぶしゅ
+  - けいがまえ
+  - どうがまえ
+  description: 部首
+- char: 冫
+  readings:
+  - ぶしゅ
+  - にすい
+  description: 部首
+- char: 几
+  readings:
+  - ぶしゅ
+  - つくえ
+  - きにょう
+  - かぜがまえ
+  description: 部首
+- char: 凵
+  readings:
+  - ぶしゅ
+  - かんにょう
+  - うけばこ
+  description: 部首
+- char: 刀
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 刂
+  readings:
+  - ぶしゅ
+  - りっとう
+  description: 部首
+- char: 力
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 勹
+  readings:
+  - ぶしゅ
+  - つつみがまえ
+  description: 部首
+- char: 匕
+  readings:
+  - ぶしゅ
+  - ひ
+  - さじ
+  - さじのひ
+  description: 部首
+- char: 匚
+  readings:
+  - ぶしゅ
+  - はこがまえ
+  description: 部首
+- char: 匸
+  readings:
+  - ぶしゅ
+  - かくしがまえ
+  description: 部首
+- char: 十
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 卜
+  readings:
+  - ぶしゅ
+  - ぼくのと
+  description: 部首
+- char: 卩
+  readings:
+  - ぶしゅ
+  - ふしづくり
+  - まげわりふ
+  description: 部首
+- char: ⺋
+  readings:
+  - ぶしゅ
+  - ふしづくり
+  - まげわりふ
+  description: 部首
+- char: 厂
+  readings:
+  - ぶしゅ
+  - がんだれ
+  description: 部首
+- char: 厶
+  readings:
+  - ぶしゅ
+  - む
+  description: 部首
+- char: 又
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 口
+  readings:
+  - ぶしゅ
+  - くちへん
+  description: 部首
+- char: 囗
+  readings:
+  - ぶしゅ
+  - くにがまえ
+  description: 部首
+- char: 土
+  readings:
+  - ぶしゅ
+  - つちへん
+  description: 部首
+- char: 士
+  readings:
+  - ぶしゅ
+  - さむらい
+  - さむらいかんむり
+  description: 部首
+- char: 夂
+  readings:
+  - ぶしゅ
+  - ふゆがしら
+  description: 部首
+- char: 夊
+  readings:
+  - ぶしゅ
+  - すいにょう
+  - すいにゅう
+  - なつあし
+  description: 部首
+- char: 夕
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 大
+  readings:
+  - ぶしゅ
+  - だいがしら
+  description: 部首
+- char: 女
+  readings:
+  - ぶしゅ
+  - おんなへん
+  description: 部首
+- char: 子
+  readings:
+  - ぶしゅ
+  - こども
+  - こどもへん
+  description: 部首
+- char: 宀
+  readings:
+  - ぶしゅ
+  - うかんむり
+  description: 部首
+- char: 寸
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 小
+  readings:
+  - ぶしゅ
+  - しょうがしら
+  - なおがしら
+  description: 部首
+- char: 尢
+  readings:
+  - ぶしゅ
+  - まげあし
+  - だいのまげあし
+  - おうにょう
+  description: 部首
+- char: 尣
+  readings:
+  - ぶしゅ
+  - まげあし
+  - だいのまげあし
+  - おうにょう
+  description: 部首
+- char: 尸
+  readings:
+  - ぶしゅ
+  - かばねだれ
+  description: 部首
+- char: 屮
+  readings:
+  - ぶしゅ
+  - てつ
+  - めばえ
+  description: 部首
+- char: 山
+  readings:
+  - ぶしゅ
+  - やまへん
+  description: 部首
+- char: 川
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 巛
+  readings:
+  - ぶしゅ
+  - まがりがわ
+  - さんぽがわ
+  description: 部首
+- char: 工
+  readings:
+  - ぶしゅ
+  - たくみへん
+  description: 部首
+- char: 己
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 巳
+  readings:
+  - ぶしゅ
+  - おのれ
+  description: 部首
+- char: 已
+  readings:
+  - ぶしゅ
+  - おのれ
+  description: 部首
+- char: 巾
+  readings:
+  - ぶしゅ
+  - はばへん
+  description: 部首
+- char: 干
+  readings:
+  - ぶしゅ
+  - ほす
+  - かん
+  - いちじゅう
+  description: 部首
+- char: 幺
+  readings:
+  - ぶしゅ
+  - いとがしら
+  description: 部首
+- char: 广
+  readings:
+  - ぶしゅ
+  - まだれ
+  description: 部首
+- char: 廴
+  readings:
+  - ぶしゅ
+  - えんにょう
+  description: 部首
+- char: 廾
+  readings:
+  - ぶしゅ
+  - こまぬき
+  description: 部首
+- char: 弋
+  readings:
+  - ぶしゅ
+  - しきがまえ
+  - よく
+  description: 部首
+- char: 弓
+  readings:
+  - ぶしゅ
+  - ゆみへん
+  description: 部首
+- char: 彐
+  readings:
+  - ぶしゅ
+  - けいがしら
+  - いのこがしら
+  description: 部首
+- char: 彑
+  readings:
+  - ぶしゅ
+  - けいがしら
+  - いのこがしら
+  description: 部首
+- char: 彡
+  readings:
+  - ぶしゅ
+  - さんづくり
+  - かみかざり
+  - さん
+  - せん
+  description: 部首
+- char: 彳
+  readings:
+  - ぶしゅ
+  - ぎょうにんべん
+  description: 部首
+- char: 心
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 忄
+  readings:
+  - ぶしゅ
+  - りっしんべん
+  description: 部首
+- char: 㣺
+  readings:
+  - ぶしゅ
+  - したごころ
+  description: 部首
+- char: 戈
+  readings:
+  - ぶしゅ
+  - ほこがまえ
+  - ほこづくり
+  description: 部首
+- char: 戸
+  readings:
+  - ぶしゅ
+  - とだれ
+  description: 部首
+- char: 手
+  readings:
+  - ぶしゅ
+  - てへん
+  description: 部首
+- char: 扌
+  readings:
+  - ぶしゅ
+  - て
+  - てへん
+  description: 部首
+- char: 支
+  readings:
+  - ぶしゅ
+  - しにょう
+  - えだにょう
+  description: 部首
+- char: 攴
+  readings:
+  - ぶしゅ
+  - ぼくづくり，ぼくにょう，ぼんにょう
+  description: 部首
+- char: 攵
+  readings:
+  - ぶしゅ
+  - ぼくづくり，ぼくにょう，ぼんにょう
+  description: 部首
+- char: 文
+  readings:
+  - ぶしゅ
+  - ぶんにょう
+  description: 部首
+- char: 斗
+  readings:
+  - ぶしゅ
+  - ます
+  - とます
+  description: 部首
+- char: 斤
+  readings:
+  - ぶしゅ
+  - おの
+  - おのづくり
+  description: 部首
+- char: 方
+  readings:
+  - ぶしゅ
+  - かたへん
+  - ほうへん
+  description: 部首
+- char: 无
+  readings:
+  - ぶしゅ
+  - む
+  - むにょう
+  - すでのつくり
+  description: 部首
+- char: 旡
+  readings:
+  - ぶしゅ
+  - む
+  - むにょう
+  - すでのつくり
+  description: 部首
+- char: 日
+  readings:
+  - ぶしゅ
+  - ひへん
+  description: 部首
+- char: 曰
+  readings:
+  - ぶしゅ
+  - ひらび
+  - いわく
+  description: 部首
+- char: 木
+  readings:
+  - ぶしゅ
+  - きへん
+  description: 部首
+- char: 欠
+  readings:
+  - ぶしゅ
+  - あくび
+  - かける
+  description: 部首
+- char: 止
+  readings:
+  - ぶしゅ
+  - とめる
+  - とめへん
+  description: 部首
+- char: 歹
+  readings:
+  - ぶしゅ
+  - かばね
+  - かばねへん
+  description: 部首
+- char: 殳
+  readings:
+  - ぶしゅ
+  - ほこ
+  - ほこづくり
+  - るまた
+  description: 部首
+- char: 毋
+  readings:
+  - ぶしゅ
+  - なかれ
+  description: 部首
+- char: 毌
+  readings:
+  - ぶしゅ
+  - なかれ
+  description: 部首
+- char: 比
+  readings:
+  - ぶしゅ
+  - ならびひ
+  - くらべる
+  description: 部首
+- char: 毛
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 氏
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 气
+  readings:
+  - ぶしゅ
+  - きがまえ
+  description: 部首
+- char: 水
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 氵
+  readings:
+  - ぶしゅ
+  - さんずい
+  description: 部首
+- char: 氺
+  readings:
+  - ぶしゅ
+  - したみず
+  description: 部首
+- char: 火
+  readings:
+  - ぶしゅ
+  - ひへん
+  description: 部首
+- char: 灬
+  readings:
+  - ぶしゅ
+  - れんが
+  - れっか
+  description: 部首
+- char: 爪
+  readings:
+  - ぶしゅ
+  - そうにょう
+  description: 部首
+- char: 爫
+  readings:
+  - ぶしゅ
+  - つめかんむり
+  description: 部首
+- char: 父
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 爻
+  readings:
+  - ぶしゅ
+  - こう
+  description: 部首
+- char: 爿
+  readings:
+  - ぶしゅ
+  - しょうへん
+  description: 部首
+- char: 片
+  readings:
+  - ぶしゅ
+  - かたへん
+  description: 部首
+- char: 牙
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 牛
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 牜
+  readings:
+  - ぶしゅ
+  - うしへん
+  description: 部首
+- char: 犬
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 犭
+  readings:
+  - ぶしゅ
+  - けものへん
+  description: 部首
+- char: 玄
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 玉
+  readings:
+  - ぶしゅ
+  - たまへん
+  - ぎょくへん
+  description: 部首
+- char: 王
+  readings:
+  - ぶしゅ
+  - たま
+  - たまへん
+  - ぎょくへん
+  description: 部首
+- char: 玊
+  readings:
+  - ぶしゅ
+  - たま
+  - たまへん
+  - ぎょくへん
+  description: 部首
+- char: 瓜
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 瓦
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 甘
+  readings:
+  - ぶしゅ
+  - あまい
+  - かん
+  description: 部首
+- char: 生
+  readings:
+  - ぶしゅ
+  - いきる
+  - うまれる
+  description: 部首
+- char: 用
+  readings:
+  - ぶしゅ
+  - もちいる
+  description: 部首
+- char: 甩
+  readings:
+  - ぶしゅ
+  - もちいる
+  - よう
+  description: 部首
+- char: 疋
+  readings:
+  - ぶしゅ
+  - ひき
+  description: 部首
+- char: 𤴔
+  readings:
+  - ぶしゅ
+  - ひき
+  description: 部首
+- char: 辵
+  readings:
+  - ぶしゅ
+  - しんにょう
+  - しんにゅう
+  description: 部首
+- char: 辶
+  readings:
+  - ぶしゅ
+  - しんにょう
+  - しんにゅう
+  description: 部首
+- char: 疒
+  readings:
+  - ぶしゅ
+  - やまいだれ
+  description: 部首
+- char: 邑
+  readings:
+  - ぶしゅ
+  - おおざと
+  description: 部首
+- char: 癶
+  readings:
+  - ぶしゅ
+  - はつがしら
+  description: 部首
+- char: 白
+  readings:
+  - ぶしゅ
+  - しろへん
+  description: 部首
+- char: 皮
+  readings:
+  - ぶしゅ
+  - けがわ
+  - ひのかわ
+  description: 部首
+- char: 酉
+  readings:
+  - ぶしゅ
+  - とりへん
+  - ひよみのとり
+  description: 部首
+- char: 皿
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 釆
+  readings:
+  - ぶしゅ
+  - のごめ
+  - のごめへん
+  description: 部首
+- char: 辰
+  readings:
+  - ぶしゅ
+  - しんのたつ
+  description: 部首
+- char: 目
+  readings:
+  - ぶしゅ
+  - めへん
+  description: 部首
+- char: 矛
+  readings:
+  - ぶしゅ
+  - ほこへん
+  description: 部首
+- char: 矢
+  readings:
+  - ぶしゅ
+  - やへん
+  description: 部首
+- char: 石
+  readings:
+  - ぶしゅ
+  - いしへん
+  description: 部首
+- char: 示
+  readings:
+  - ぶしゅ
+  - しめす
+  - しめすへん
+  - ねへん
+  description: 部首
+- char: 礻
+  readings:
+  - ぶしゅ
+  - しめす
+  - しめすへん
+  - ねへん
+  description: 部首
+- char: 禸
+  readings:
+  - ぶしゅ
+  - ぐうのあし
+  description: 部首
+- char: 禾
+  readings:
+  - ぶしゅ
+  - のぎへん
+  description: 部首
+- char: 穴
+  readings:
+  - ぶしゅ
+  - あなかんむり
+  description: 部首
+- char: 立
+  readings:
+  - ぶしゅ
+  - たつへん
+  description: 部首
+- char: 竹
+  readings:
+  - ぶしゅ
+  - たけかんむり
+  description: 部首
+- char: ⺮
+  readings:
+  - ぶしゅ
+  - たけかんむり
+  description: 部首
+- char: 米
+  readings:
+  - ぶしゅ
+  - こめへん
+  description: 部首
+- char: 糸
+  readings:
+  - ぶしゅ
+  - いとへん
+  description: 部首
+- char: 糹
+  readings:
+  - ぶしゅ
+  - いと
+  - いとへん
+  description: 部首
+- char: 缶
+  readings:
+  - ぶしゅ
+  - ほとぎ
+  - ほとぎへん
+  description: 部首
+- char: 网
+  readings:
+  - ぶしゅ
+  - あみがしら
+  - よんがしら
+  - あみめ
+  description: 部首
+- char: 罒
+  readings:
+  - ぶしゅ
+  - あみがしら
+  - よんがしら
+  - あみめ
+  - め
+  description: 部首
+- char: 罓
+  readings:
+  - ぶしゅ
+  - あみがしら
+  - よんがしら
+  - あみめ
+  description: 部首
+- char: 𦉰
+  readings:
+  - ぶしゅ
+  - あみがしら
+  - よんがしら
+  - あみめ
+  description: 部首
+- char: 㓁
+  readings:
+  - ぶしゅ
+  - あみがしら
+  - よんがしら
+  - あみめ
+  description: 部首
+- char: 羊
+  readings:
+  - ぶしゅ
+  - ひつじへん
+  description: 部首
+- char: 𦍌
+  readings:
+  - ぶしゅ
+  - ひつじ
+  - ひつじへん
+  description: 部首
+- char: 羽
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 老
+  readings:
+  - ぶしゅ
+  - おいがしら
+  - おいかんむり
+  description: 部首
+- char: 耂
+  readings:
+  - ぶしゅ
+  - おいがしら
+  - おいかんむり
+  description: 部首
+- char: 而
+  readings:
+  - ぶしゅ
+  - しこうして
+  description: 部首
+- char: 耒
+  readings:
+  - ぶしゅ
+  - すきへん
+  - らいすき
+  description: 部首
+- char: 耳
+  readings:
+  - ぶしゅ
+  - みみへん
+  description: 部首
+- char: 聿
+  readings:
+  - ぶしゅ
+  - ふでづくり
+  description: 部首
+- char: 肀
+  readings:
+  - ぶしゅ
+  - ふでづくり
+  description: 部首
+- char: 𦘒
+  readings:
+  - ぶしゅ
+  - ふでづくり
+  description: 部首
+- char: 肉
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 月
+  readings:
+  - ぶしゅ
+  - にく
+  - にくづき
+  - つきへん
+  description: 部首
+- char: 臣
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 自
+  readings:
+  - ぶしゅ
+  - みずから
+  description: 部首
+- char: 至
+  readings:
+  - ぶしゅ
+  - いたるへん
+  description: 部首
+- char: 臼
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 𦥑
+  readings:
+  - ぶしゅ
+  - うす
+  description: 部首
+- char: 舌
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 舛
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 舟
+  readings:
+  - ぶしゅ
+  - ふねへん
+  description: 部首
+- char: 艮
+  readings:
+  - ぶしゅ
+  - こんづくり
+  - こん
+  - ねづくり
+  description: 部首
+- char: 色
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 艸
+  readings:
+  - ぶしゅ
+  - くさかんむり
+  description: 部首
+- char: 艹
+  readings:
+  - ぶしゅ
+  - くさかんむり
+  description: 部首
+- char: 虍
+  readings:
+  - ぶしゅ
+  - とらがしら
+  description: 部首
+- char: 虫
+  readings:
+  - ぶしゅ
+  - むしへん
+  description: 部首
+- char: 血
+  readings:
+  - ぶしゅ
+  - ちへん
+  description: 部首
+- char: 行
+  readings:
+  - ぶしゅ
+  - ぎょうがまえ
+  - ゆきがまえ
+  description: 部首
+- char: 衣
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 衤
+  readings:
+  - ぶしゅ
+  - ころもへん
+  description: 部首
+- char: 襾
+  readings:
+  - ぶしゅ
+  - にし
+  description: 部首
+- char: 覀
+  readings:
+  - ぶしゅ
+  - にし
+  description: 部首
+- char: 西
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 見
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 角
+  readings:
+  - ぶしゅ
+  - つのへん
+  description: 部首
+- char: 言
+  readings:
+  - ぶしゅ
+  - ごんべん
+  description: 部首
+- char: 訁
+  readings:
+  - ぶしゅ
+  - ごんべん
+  description: 部首
+- char: 谷
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 豆
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 豕
+  readings:
+  - ぶしゅ
+  - いのこへん
+  description: 部首
+- char: 豸
+  readings:
+  - ぶしゅ
+  - むじなへん
+  description: 部首
+- char: 貝
+  readings:
+  - ぶしゅ
+  - かいへん
+  description: 部首
+- char: 赤
+  readings:
+  - ぶしゅ
+  - あかへん
+  description: 部首
+- char: 走
+  readings:
+  - ぶしゅ
+  - はしる
+  - そうにょう
+  description: 部首
+- char: 足
+  readings:
+  - ぶしゅ
+  - あしへん
+  description: 部首
+- char: 𧾷
+  readings:
+  - ぶしゅ
+  - あし
+  - あしへん
+  description: 部首
+- char: 身
+  readings:
+  - ぶしゅ
+  - みへん
+  description: 部首
+- char: 車
+  readings:
+  - ぶしゅ
+  - くるまへん
+  description: 部首
+- char: 辛
+  readings:
+  - ぶしゅ
+  - からい
+  - しん
+  description: 部首
+- char: 里
+  readings:
+  - ぶしゅ
+  - さとへん
+  description: 部首
+- char: 金
+  readings:
+  - ぶしゅ
+  - かねへん
+  description: 部首
+- char: 釒
+  readings:
+  - ぶしゅ
+  - かね
+  - かねへん
+  description: 部首
+- char: 長
+  readings:
+  - ぶしゅ
+  - ながい
+  description: 部首
+- char: 镸
+  readings:
+  - ぶしゅ
+  - ながい
+  description: 部首
+- char: 門
+  readings:
+  - ぶしゅ
+  - もんがまえ
+  - かどがまえ
+  description: 部首
+- char: 阜
+  readings:
+  - ぶしゅ
+  - こざとへん
+  description: 部首
+- char: 阝
+  readings:
+  - ぶしゅ
+  - こざとへん
+  - おおざと
+  description: 部首
+- char: 隶
+  readings:
+  - ぶしゅ
+  - れいづくり
+  description: 部首
+- char: 隹
+  readings:
+  - ぶしゅ
+  - ふるとり
+  description: 部首
+- char: 雨
+  readings:
+  - ぶしゅ
+  - あめかんむり
+  description: 部首
+- char: 靑
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 青
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 非
+  readings:
+  - ぶしゅ
+  - あらず
+  description: 部首
+- char: 面
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 革
+  readings:
+  - ぶしゅ
+  - かわへん
+  - つくりがわ
+  description: 部首
+- char: 韋
+  readings:
+  - ぶしゅ
+  - なめしがわ
+  description: 部首
+- char: 韭
+  readings:
+  - ぶしゅ
+  - にら
+  description: 部首
+- char: 音
+  readings:
+  - ぶしゅ
+  - おとへん
+  description: 部首
+- char: 頁
+  readings:
+  - ぶしゅ
+  - おおがい
+  description: 部首
+- char: 風
+  readings:
+  - ぶしゅ
+  - ふうにょう
+  description: 部首
+- char: 飛
+  readings:
+  - ぶしゅ
+  - とぶ
+  description: 部首
+- char: 食
+  readings:
+  - ぶしゅ
+  - しょくへん
+  description: 部首
+- char: 𩙿
+  readings:
+  - ぶしゅ
+  - しょくへん
+  description: 部首
+- char: 飠
+  readings:
+  - ぶしゅ
+  - しょくへん
+  description: 部首
+- char: 首
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 香
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 馬
+  readings:
+  - ぶしゅ
+  - うまへん
+  description: 部首
+- char: 骨
+  readings:
+  - ぶしゅ
+  - ほねへん
+  description: 部首
+- char: 高
+  readings:
+  - ぶしゅ
+  - たかい
+  description: 部首
+- char: 髟
+  readings:
+  - ぶしゅ
+  - かみがしら
+  description: 部首
+- char: 鬥
+  readings:
+  - ぶしゅ
+  - たたかいがまえ
+  - とうがまえ
+  description: 部首
+- char: 鬯
+  readings:
+  - ぶしゅ
+  - ちょう
+  - においざけ
+  description: 部首
+- char: 鬲
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 鬼
+  readings:
+  - ぶしゅ
+  - きにょう
+  description: 部首
+- char: 魚
+  readings:
+  - ぶしゅ
+  - うおへん
+  description: 部首
+- char: 鳥
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 鹵
+  readings:
+  - ぶしゅ
+  - ろ
+  - しお
+  description: 部首
+- char: 鹿
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 麥
+  readings:
+  - ぶしゅ
+  - ばくにょう
+  description: 部首
+- char: 麦
+  readings:
+  - ぶしゅ
+  - ばくにょう
+  description: 部首
+- char: 麻
+  readings:
+  - ぶしゅ
+  - あさかんむり
+  description: 部首
+- char: 黃
+  readings:
+  - ぶしゅ
+  - き
+  description: 部首
+- char: 黄
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 黍
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 黑
+  readings:
+  - ぶしゅ
+  - くろ
+  description: 部首
+- char: 黒
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 黹
+  readings:
+  - ぶしゅ
+  - ち
+  - ぬいとり
+  - ふつへん
+  description: 部首
+- char: 黽
+  readings:
+  - ぶしゅ
+  - べんあし
+  - おおがえる
+  description: 部首
+- char: 鼎
+  readings:
+  - ぶしゅ
+  - てい
+  description: 部首
+- char: 鼓
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 鼠
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 鼻
+  readings:
+  - ぶしゅ
+  - はなへん
+  description: 部首
+- char: 齊
+  readings:
+  - ぶしゅ
+  - せい
+  description: 部首
+- char: 斉
+  readings:
+  - ぶしゅ
+  - せい
+  description: 部首
+- char: 齒
+  readings:
+  - ぶしゅ
+  - は
+  - はへん
+  description: 部首
+- char: 歯
+  readings:
+  - ぶしゅ
+  - はへん
+  description: 部首
+- char: 龍
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 竜
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 龜
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 亀
+  readings:
+  - ぶしゅ
+  description: 部首
+- char: 龠
+  readings:
+  - ぶしゅ
+  - やく
+  - やくのふえ
+  description: 部首
+- char: 𓃗
+  readings:
+  - ひえろぐりふ
+  - うま
+  description: ヒエログリフ 馬
+- char: 𓃟
+  readings:
+  - ひえろぐりふ
+  - ぶた
+  description: ヒエログリフ 豚
+- char: 𓃠
+  readings:
+  - ひえろぐりふ
+  - ねこ
+  description: ヒエログリフ 猫
+- char: 𓃡
+  readings:
+  - ひえろぐりふ
+  - いぬ
+  description: ヒエログリフ 犬
+- char: 𓃬
+  readings:
+  - ひえろぐりふ
+  - らいおん
+  description: ヒエログリフ ライオン
+- char: 𓃭
+  readings:
+  - ひえろぐりふ
+  - らいおん
+  description: ヒエログリフ ライオン
+- char: 𓃰
+  readings:
+  - ひえろぐりふ
+  - ぞう
+  description: ヒエログリフ 象
+- char: 𓃱
+  readings:
+  - ひえろぐりふ
+  - きりん
+  description: ヒエログリフ キリン
+- char: 𓃹
+  readings:
+  - ひえろぐりふ
+  - うさぎ
+  - のうさぎ
+  description: ヒエログリフ ウサギ
+- char: 𓅓
+  readings:
+  - ひえろぐりふ
+  - ふくろう
+  description: ヒエログリフ ふくろう
+- char: 𓆉
+  readings:
+  - ひえろぐりふ
+  - かめ
+  description: ヒエログリフ カメ
+- char: 𓆏
+  readings:
+  - ひえろぐりふ
+  - かえる
+  description: ヒエログリフ カエル
+- char: 𓆛
+  readings:
+  - ひえろぐりふ
+  - さかな
+  - てぃらぴあ
+  description: ヒエログリフ 魚
+- char: 𓆜
+  readings:
+  - ひえろぐりふ
+  - さかな
+  - ばーべる
+  description: ヒエログリフ 魚
+- char: 𓆝
+  readings:
+  - ひえろぐりふ
+  - さかな
+  - ぼら
+  description: ヒエログリフ 魚
+- char: 𓆞
+  readings:
+  - ひえろぐりふ
+  - さかな
+  - えれふぁんとのーずふぃっしゅ
+  description: ヒエログリフ 魚
+- char: 𓆟
+  readings:
+  - ひえろぐりふ
+  - さかな
+  description: ヒエログリフ 魚
+- char: 𓆡
+  readings:
+  - ひえろぐりふ
+  - さかな
+  - ふぐ
+  description: ヒエログリフ 魚
+- char: 濵
+  readings:
+  - まゆはま
+  description: 濱の異体字
+- char: 髙
+  readings:
+  - はしごだか
+  description: 高の異体字
+- char: 﨑
+  readings:
+  - たつさき
+  description: 崎の異体字
+- char: 𠮷
+  readings:
+  - つちよし
+  description: 吉の異体字
+- char: ㇰ
+  readings:
+  - あいぬ
+  - く
+  description: アイヌ語カナ
+- char: ㇱ
+  readings:
+  - あいぬ
+  - し
+  description: アイヌ語カナ
+- char: ㇲ
+  readings:
+  - あいぬ
+  - す
+  description: アイヌ語カナ
+- char: ㇳ
+  readings:
+  - あいぬ
+  - と
+  description: アイヌ語カナ
+- char: ㇴ
+  readings:
+  - あいぬ
+  - ぬ
+  description: アイヌ語カナ
+- char: ㇵ
+  readings:
+  - あいぬ
+  - は
+  description: アイヌ語カナ
+- char: ㇶ
+  readings:
+  - あいぬ
+  - ひ
+  description: アイヌ語カナ
+- char: ㇷ
+  readings:
+  - あいぬ
+  - ふ
+  description: アイヌ語カナ
+- char: ㇸ
+  readings:
+  - あいぬ
+  - へ
+  description: アイヌ語カナ
+- char: ㇹ
+  readings:
+  - あいぬ
+  - ほ
+  description: アイヌ語カナ
+- char: ㇺ
+  readings:
+  - あいぬ
+  - む
+  description: アイヌ語カナ
+- char: ㇻ
+  readings:
+  - あいぬ
+  - ら
+  description: アイヌ語カナ
+- char: ㇼ
+  readings:
+  - あいぬ
+  - り
+  description: アイヌ語カナ
+- char: ㇽ
+  readings:
+  - あいぬ
+  - る
+  description: アイヌ語カナ
+- char: ㇾ
+  readings:
+  - あいぬ
+  - れ
+  description: アイヌ語カナ
+- char: ㇿ
+  readings:
+  - あいぬ
+  - ろ
+  description: アイヌ語カナ
+- char: ㇷ゚
+  readings:
+  - あいぬ
+  - ぷ
+  description: アイヌ語カナ
+- char: セ゚
+  readings:
+  - あいぬ
+  - せ
+  description: アイヌ語カナ
+- char: ツ゚
+  readings:
+  - あいぬ
+  - つ
+  description: アイヌ語カナ
+- char: ト゚
+  readings:
+  - あいぬ
+  - と
+  description: アイヌ語カナ
+- char: 𛀀
+  readings:
+  - へんたいがな
+  - え
+  description: 変体仮名
+- char: 𛀁
+  readings:
+  - へんたいがな
+  - いぇ
+  - え
+  description: 江の変体仮名
+- char: 𛀂
+  readings:
+  - へんたいがな
+  - あ
+  description: 安の変体仮名
+- char: 𛀃
+  readings:
+  - へんたいがな
+  - あ
+  description: 愛の変体仮名
+- char: 𛀄
+  readings:
+  - へんたいがな
+  - あ
+  description: 阿の変体仮名
+- char: 𛀅
+  readings:
+  - へんたいがな
+  - あ
+  - を
+  description: 惡の変体仮名
+- char: 𛀆
+  readings:
+  - へんたいがな
+  - い
+  description: 以の変体仮名
+- char: 𛀇
+  readings:
+  - へんたいがな
+  - い
+  description: 伊の変体仮名
+- char: 𛀈
+  readings:
+  - へんたいがな
+  - い
+  description: 意の変体仮名
+- char: 𛀉
+  readings:
+  - へんたいがな
+  - い
+  description: 移の変体仮名
+- char: 𛀊
+  readings:
+  - へんたいがな
+  - う
+  description: 宇の変体仮名
+- char: 𛀋
+  readings:
+  - へんたいがな
+  - う
+  description: 宇の変体仮名
+- char: 𛀌
+  readings:
+  - へんたいがな
+  - う
+  description: 憂の変体仮名
+- char: 𛀍
+  readings:
+  - へんたいがな
+  - う
+  description: 有の変体仮名
+- char: 𛀎
+  readings:
+  - へんたいがな
+  - う
+  description: 雲の変体仮名
+- char: 𛀏
+  readings:
+  - へんたいがな
+  - え
+  description: 盈の変体仮名
+- char: 𛀐
+  readings:
+  - へんたいがな
+  - え
+  description: 縁の変体仮名
+- char: 𛀑
+  readings:
+  - へんたいがな
+  - え
+  description: 衣の変体仮名
+- char: 𛀒
+  readings:
+  - へんたいがな
+  - え
+  description: 衣の変体仮名
+- char: 𛀓
+  readings:
+  - へんたいがな
+  - え
+  description: 要の変体仮名
+- char: 𛀔
+  readings:
+  - へんたいがな
+  - お
+  description: 於の変体仮名
+- char: 𛀕
+  readings:
+  - へんたいがな
+  - お
+  description: 於の変体仮名
+- char: 𛀖
+  readings:
+  - へんたいがな
+  - お
+  description: 隱の変体仮名
+- char: 𛀗
+  readings:
+  - へんたいがな
+  - か
+  description: 佳の変体仮名
+- char: 𛀘
+  readings:
+  - へんたいがな
+  - か
+  description: 加の変体仮名
+- char: 𛀙
+  readings:
+  - へんたいがな
+  - か
+  description: 可の変体仮名
+- char: 𛀚
+  readings:
+  - へんたいがな
+  - か
+  description: 可の変体仮名
+- char: 𛀛
+  readings:
+  - へんたいがな
+  - か
+  description: 嘉の変体仮名
+- char: 𛀜
+  readings:
+  - へんたいがな
+  - か
+  description: 我の変体仮名
+- char: 𛀝
+  readings:
+  - へんたいがな
+  - か
+  description: 歟の変体仮名
+- char: 𛀞
+  readings:
+  - へんたいがな
+  - か
+  description: 賀の変体仮名
+- char: 𛀟
+  readings:
+  - へんたいがな
+  - か
+  description: 閑の変体仮名
+- char: 𛀠
+  readings:
+  - へんたいがな
+  - か
+  description: 香の変体仮名
+- char: 𛀡
+  readings:
+  - へんたいがな
+  - か
+  description: 駕の変体仮名
+- char: 𛀢
+  readings:
+  - へんたいがな
+  - か
+  - け
+  description: 家の変体仮名
+- char: 𛀣
+  readings:
+  - へんたいがな
+  - き
+  description: 喜の変体仮名
+- char: 𛀤
+  readings:
+  - へんたいがな
+  - き
+  description: 幾の変体仮名
+- char: 𛀥
+  readings:
+  - へんたいがな
+  - き
+  description: 幾の変体仮名
+- char: 𛀦
+  readings:
+  - へんたいがな
+  - き
+  description: 支の変体仮名
+- char: 𛀧
+  readings:
+  - へんたいがな
+  - き
+  description: 木の変体仮名
+- char: 𛀨
+  readings:
+  - へんたいがな
+  - き
+  description: 祈の変体仮名
+- char: 𛀩
+  readings:
+  - へんたいがな
+  - き
+  description: 貴の変体仮名
+- char: 𛀪
+  readings:
+  - へんたいがな
+  - き
+  description: 起の変体仮名
+- char: 𛀫
+  readings:
+  - へんたいがな
+  - く
+  description: 久の変体仮名
+- char: 𛀬
+  readings:
+  - へんたいがな
+  - く
+  description: 久の変体仮名
+- char: 𛀭
+  readings:
+  - へんたいがな
+  - く
+  description: 九の変体仮名
+- char: 𛀮
+  readings:
+  - へんたいがな
+  - く
+  description: 供の変体仮名
+- char: 𛀯
+  readings:
+  - へんたいがな
+  - く
+  description: 倶の変体仮名
+- char: 𛀰
+  readings:
+  - へんたいがな
+  - く
+  description: 具の変体仮名
+- char: 𛀱
+  readings:
+  - へんたいがな
+  - く
+  description: 求の変体仮名
+- char: 𛀲
+  readings:
+  - へんたいがな
+  - け
+  description: 介の変体仮名
+- char: 𛀳
+  readings:
+  - へんたいがな
+  - け
+  description: 介の変体仮名
+- char: 𛀴
+  readings:
+  - へんたいがな
+  - け
+  description: 希の変体仮名
+- char: 𛀵
+  readings:
+  - へんたいがな
+  - け
+  description: 氣の変体仮名
+- char: 𛀶
+  readings:
+  - へんたいがな
+  - け
+  description: 計の変体仮名
+- char: 𛀷
+  readings:
+  - へんたいがな
+  - け
+  description: 遣の変体仮名
+- char: 𛀸
+  readings:
+  - へんたいがな
+  - こ
+  description: 古の変体仮名
+- char: 𛀹
+  readings:
+  - へんたいがな
+  - こ
+  description: 故の変体仮名
+- char: 𛀺
+  readings:
+  - へんたいがな
+  - こ
+  description: 許の変体仮名
+- char: 𛀻
+  readings:
+  - へんたいがな
+  - こ
+  - き
+  description: 期の変体仮名
+- char: 𛀼
+  readings:
+  - へんたいがな
+  - さ
+  description: 乍の変体仮名
+- char: 𛀽
+  readings:
+  - へんたいがな
+  - さ
+  description: 佐の変体仮名
+- char: 𛀾
+  readings:
+  - へんたいがな
+  - さ
+  description: 佐の変体仮名
+- char: 𛀿
+  readings:
+  - へんたいがな
+  - さ
+  description: 左の変体仮名
+- char: 𛁀
+  readings:
+  - へんたいがな
+  - さ
+  description: 差の変体仮名
+- char: 𛁁
+  readings:
+  - へんたいがな
+  - さ
+  description: 散の変体仮名
+- char: 𛁂
+  readings:
+  - へんたいがな
+  - さ
+  description: 斜の変体仮名
+- char: 𛁃
+  readings:
+  - へんたいがな
+  - さ
+  description: 沙の変体仮名
+- char: 𛁄
+  readings:
+  - へんたいがな
+  - し
+  description: 之の変体仮名
+- char: 𛁅
+  readings:
+  - へんたいがな
+  - し
+  description: 之の変体仮名
+- char: 𛁆
+  readings:
+  - へんたいがな
+  - し
+  description: 事の変体仮名
+- char: 𛁇
+  readings:
+  - へんたいがな
+  - し
+  description: 四の変体仮名
+- char: 𛁈
+  readings:
+  - へんたいがな
+  - し
+  description: 志の変体仮名
+- char: 𛁉
+  readings:
+  - へんたいがな
+  - し
+  description: 新の変体仮名
+- char: 𛁊
+  readings:
+  - へんたいがな
+  - す
+  description: 受の変体仮名
+- char: 𛁋
+  readings:
+  - へんたいがな
+  - す
+  description: 壽の変体仮名
+- char: 𛁌
+  readings:
+  - へんたいがな
+  - す
+  description: 數の変体仮名
+- char: 𛁍
+  readings:
+  - へんたいがな
+  - す
+  description: 數の変体仮名
+- char: 𛁎
+  readings:
+  - へんたいがな
+  - す
+  description: 春の変体仮名
+- char: 𛁏
+  readings:
+  - へんたいがな
+  - す
+  description: 春の変体仮名
+- char: 𛁐
+  readings:
+  - へんたいがな
+  - す
+  description: 須の変体仮名
+- char: 𛁑
+  readings:
+  - へんたいがな
+  - す
+  description: 須の変体仮名
+- char: 𛁒
+  readings:
+  - へんたいがな
+  - せ
+  description: 世の変体仮名
+- char: 𛁓
+  readings:
+  - へんたいがな
+  - せ
+  description: 世の変体仮名
+- char: 𛁔
+  readings:
+  - へんたいがな
+  - せ
+  description: 世の変体仮名
+- char: 𛁕
+  readings:
+  - へんたいがな
+  - せ
+  description: 勢の変体仮名
+- char: 𛁖
+  readings:
+  - へんたいがな
+  - せ
+  description: 聲の変体仮名
+- char: 𛁗
+  readings:
+  - へんたいがな
+  - そ
+  description: 所の変体仮名
+- char: 𛁘
+  readings:
+  - へんたいがな
+  - そ
+  description: 所の変体仮名
+- char: 𛁙
+  readings:
+  - へんたいがな
+  - そ
+  description: 曾の変体仮名
+- char: 𛁚
+  readings:
+  - へんたいがな
+  - そ
+  description: 曾の変体仮名
+- char: 𛁛
+  readings:
+  - へんたいがな
+  - そ
+  description: 楚の変体仮名
+- char: 𛁜
+  readings:
+  - へんたいがな
+  - そ
+  description: 蘇の変体仮名
+- char: 𛁝
+  readings:
+  - へんたいがな
+  - そ
+  description: 處の変体仮名
+- char: 𛁞
+  readings:
+  - へんたいがな
+  - た
+  description: 堂の変体仮名
+- char: 𛁟
+  readings:
+  - へんたいがな
+  - た
+  description: 多の変体仮名
+- char: 𛁠
+  readings:
+  - へんたいがな
+  - た
+  description: 多の変体仮名
+- char: 𛁡
+  readings:
+  - へんたいがな
+  - た
+  description: 當の変体仮名
+- char: 𛁢
+  readings:
+  - へんたいがな
+  - ち
+  description: 千の変体仮名
+- char: 𛁣
+  readings:
+  - へんたいがな
+  - ち
+  description: 地の変体仮名
+- char: 𛁤
+  readings:
+  - へんたいがな
+  - ち
+  description: 智の変体仮名
+- char: 𛁥
+  readings:
+  - へんたいがな
+  - ち
+  description: 知の変体仮名
+- char: 𛁦
+  readings:
+  - へんたいがな
+  - ち
+  description: 知の変体仮名
+- char: 𛁧
+  readings:
+  - へんたいがな
+  - ち
+  description: 致の変体仮名
+- char: 𛁨
+  readings:
+  - へんたいがな
+  - ち
+  description: 遲の変体仮名
+- char: 𛁩
+  readings:
+  - へんたいがな
+  - つ
+  description: 川の変体仮名
+- char: 𛁪
+  readings:
+  - へんたいがな
+  - つ
+  description: 川の変体仮名
+- char: 𛁫
+  readings:
+  - へんたいがな
+  - つ
+  description: 津の変体仮名
+- char: 𛁬
+  readings:
+  - へんたいがな
+  - つ
+  description: 都の変体仮名
+- char: 𛁭
+  readings:
+  - へんたいがな
+  - つ
+  - と
+  description: 徒の変体仮名
+- char: 𛁮
+  readings:
+  - へんたいがな
+  - て
+  description: 亭の変体仮名
+- char: 𛁯
+  readings:
+  - へんたいがな
+  - て
+  description: 低の変体仮名
+- char: 𛁰
+  readings:
+  - へんたいがな
+  - て
+  description: 傳の変体仮名
+- char: 𛁱
+  readings:
+  - へんたいがな
+  - て
+  description: 天の変体仮名
+- char: 𛁲
+  readings:
+  - へんたいがな
+  - て
+  description: 天の変体仮名
+- char: 𛁳
+  readings:
+  - へんたいがな
+  - て
+  description: 天の変体仮名
+- char: 𛁴
+  readings:
+  - へんたいがな
+  - て
+  description: 帝の変体仮名
+- char: 𛁵
+  readings:
+  - へんたいがな
+  - て
+  description: 弖の変体仮名
+- char: 𛁶
+  readings:
+  - へんたいがな
+  - て
+  description: 轉の変体仮名
+- char: 𛁷
+  readings:
+  - へんたいがな
+  - と
+  description: 土の変体仮名
+- char: 𛁸
+  readings:
+  - へんたいがな
+  - と
+  description: 度の変体仮名
+- char: 𛁹
+  readings:
+  - へんたいがな
+  - と
+  description: 東の変体仮名
+- char: 𛁺
+  readings:
+  - へんたいがな
+  - と
+  description: 登の変体仮名
+- char: 𛁻
+  readings:
+  - へんたいがな
+  - と
+  description: 登の変体仮名
+- char: 𛁼
+  readings:
+  - へんたいがな
+  - と
+  description: 砥の変体仮名
+- char: 𛁽
+  readings:
+  - へんたいがな
+  - と
+  - ら
+  description: 等の変体仮名
+- char: 𛁾
+  readings:
+  - へんたいがな
+  - な
+  description: 南の変体仮名
+- char: 𛁿
+  readings:
+  - へんたいがな
+  - な
+  description: 名の変体仮名
+- char: 𛂀
+  readings:
+  - へんたいがな
+  - な
+  description: 奈の変体仮名
+- char: 𛂁
+  readings:
+  - へんたいがな
+  - な
+  description: 奈の変体仮名
+- char: 𛂂
+  readings:
+  - へんたいがな
+  - な
+  description: 奈の変体仮名
+- char: 𛂃
+  readings:
+  - へんたいがな
+  - な
+  description: 菜の変体仮名
+- char: 𛂄
+  readings:
+  - へんたいがな
+  - な
+  description: 那の変体仮名
+- char: 𛂅
+  readings:
+  - へんたいがな
+  - な
+  description: 那の変体仮名
+- char: 𛂆
+  readings:
+  - へんたいがな
+  - な
+  description: 難の変体仮名
+- char: 𛂇
+  readings:
+  - へんたいがな
+  - に
+  description: 丹の変体仮名
+- char: 𛂈
+  readings:
+  - へんたいがな
+  - に
+  description: 二の変体仮名
+- char: 𛂉
+  readings:
+  - へんたいがな
+  - に
+  description: 仁の変体仮名
+- char: 𛂊
+  readings:
+  - へんたいがな
+  - に
+  description: 兒の変体仮名
+- char: 𛂋
+  readings:
+  - へんたいがな
+  - に
+  description: 爾の変体仮名
+- char: 𛂌
+  readings:
+  - へんたいがな
+  - に
+  description: 爾の変体仮名
+- char: 𛂍
+  readings:
+  - へんたいがな
+  - に
+  description: 耳の変体仮名
+- char: 𛂎
+  readings:
+  - へんたいがな
+  - に
+  - て
+  description: 而の変体仮名
+- char: 𛂏
+  readings:
+  - へんたいがな
+  - ぬ
+  description: 努の変体仮名
+- char: 𛂐
+  readings:
+  - へんたいがな
+  - ぬ
+  description: 奴の変体仮名
+- char: 𛂑
+  readings:
+  - へんたいがな
+  - ぬ
+  description: 怒の変体仮名
+- char: 𛂒
+  readings:
+  - へんたいがな
+  - ね
+  description: 年の変体仮名
+- char: 𛂓
+  readings:
+  - へんたいがな
+  - ね
+  description: 年の変体仮名
+- char: 𛂔
+  readings:
+  - へんたいがな
+  - ね
+  description: 年の変体仮名
+- char: 𛂕
+  readings:
+  - へんたいがな
+  - ね
+  description: 根の変体仮名
+- char: 𛂖
+  readings:
+  - へんたいがな
+  - ね
+  description: 熱の変体仮名
+- char: 𛂗
+  readings:
+  - へんたいがな
+  - ね
+  description: 禰の変体仮名
+- char: 𛂘
+  readings:
+  - へんたいがな
+  - ね
+  - こ
+  description: 子の変体仮名
+- char: 𛂙
+  readings:
+  - へんたいがな
+  - の
+  description: 乃の変体仮名
+- char: 𛂚
+  readings:
+  - へんたいがな
+  - の
+  description: 濃の変体仮名
+- char: 𛂛
+  readings:
+  - へんたいがな
+  - の
+  description: 能の変体仮名
+- char: 𛂜
+  readings:
+  - へんたいがな
+  - の
+  description: 能の変体仮名
+- char: 𛂝
+  readings:
+  - へんたいがな
+  - の
+  description: 農の変体仮名
+- char: 𛂞
+  readings:
+  - へんたいがな
+  - は
+  description: 八の変体仮名
+- char: 𛂟
+  readings:
+  - へんたいがな
+  - は
+  description: 半の変体仮名
+- char: 𛂠
+  readings:
+  - へんたいがな
+  - は
+  description: 婆の変体仮名
+- char: 𛂡
+  readings:
+  - へんたいがな
+  - は
+  description: 波の変体仮名
+- char: 𛂢
+  readings:
+  - へんたいがな
+  - は
+  description: 盤の変体仮名
+- char: 𛂣
+  readings:
+  - へんたいがな
+  - は
+  description: 盤の変体仮名
+- char: 𛂤
+  readings:
+  - へんたいがな
+  - は
+  description: 破の変体仮名
+- char: 𛂥
+  readings:
+  - へんたいがな
+  - は
+  description: 者の変体仮名
+- char: 𛂦
+  readings:
+  - へんたいがな
+  - は
+  description: 者の変体仮名
+- char: 𛂧
+  readings:
+  - へんたいがな
+  - は
+  description: 葉の変体仮名
+- char: 𛂨
+  readings:
+  - へんたいがな
+  - は
+  description: 頗の変体仮名
+- char: 𛂩
+  readings:
+  - へんたいがな
+  - ひ
+  description: 悲の変体仮名
+- char: 𛂪
+  readings:
+  - へんたいがな
+  - ひ
+  description: 日の変体仮名
+- char: 𛂫
+  readings:
+  - へんたいがな
+  - ひ
+  description: 比の変体仮名
+- char: 𛂬
+  readings:
+  - へんたいがな
+  - ひ
+  description: 避の変体仮名
+- char: 𛂭
+  readings:
+  - へんたいがな
+  - ひ
+  description: 非の変体仮名
+- char: 𛂮
+  readings:
+  - へんたいがな
+  - ひ
+  description: 飛の変体仮名
+- char: 𛂯
+  readings:
+  - へんたいがな
+  - ひ
+  description: 飛の変体仮名
+- char: 𛂰
+  readings:
+  - へんたいがな
+  - ふ
+  description: 不の変体仮名
+- char: 𛂱
+  readings:
+  - へんたいがな
+  - ふ
+  description: 婦の変体仮名
+- char: 𛂲
+  readings:
+  - へんたいがな
+  - ふ
+  description: 布の変体仮名
+- char: 𛂳
+  readings:
+  - へんたいがな
+  - へ
+  description: 倍の変体仮名
+- char: 𛂴
+  readings:
+  - へんたいがな
+  - へ
+  description: 弊の変体仮名
+- char: 𛂵
+  readings:
+  - へんたいがな
+  - へ
+  description: 弊の変体仮名
+- char: 𛂶
+  readings:
+  - へんたいがな
+  - へ
+  description: 遍の変体仮名
+- char: 𛂷
+  readings:
+  - へんたいがな
+  - へ
+  description: 邊の変体仮名
+- char: 𛂸
+  readings:
+  - へんたいがな
+  - へ
+  description: 邊の変体仮名
+- char: 𛂹
+  readings:
+  - へんたいがな
+  - へ
+  description: 部の変体仮名
+- char: 𛂺
+  readings:
+  - へんたいがな
+  - ほ
+  description: 保の変体仮名
+- char: 𛂻
+  readings:
+  - へんたいがな
+  - ほ
+  description: 保の変体仮名
+- char: 𛂼
+  readings:
+  - へんたいがな
+  - ほ
+  description: 報の変体仮名
+- char: 𛂽
+  readings:
+  - へんたいがな
+  - ほ
+  description: 奉の変体仮名
+- char: 𛂾
+  readings:
+  - へんたいがな
+  - ほ
+  description: 寶の変体仮名
+- char: 𛂿
+  readings:
+  - へんたいがな
+  - ほ
+  description: 本の変体仮名
+- char: 𛃀
+  readings:
+  - へんたいがな
+  - ほ
+  description: 本の変体仮名
+- char: 𛃁
+  readings:
+  - へんたいがな
+  - ほ
+  description: 豐の変体仮名
+- char: 𛃂
+  readings:
+  - へんたいがな
+  - ま
+  description: 万の変体仮名
+- char: 𛃃
+  readings:
+  - へんたいがな
+  - ま
+  description: 末の変体仮名
+- char: 𛃄
+  readings:
+  - へんたいがな
+  - ま
+  description: 末の変体仮名
+- char: 𛃅
+  readings:
+  - へんたいがな
+  - ま
+  description: 滿の変体仮名
+- char: 𛃆
+  readings:
+  - へんたいがな
+  - ま
+  description: 滿の変体仮名
+- char: 𛃇
+  readings:
+  - へんたいがな
+  - ま
+  description: 萬の変体仮名
+- char: 𛃈
+  readings:
+  - へんたいがな
+  - ま
+  description: 麻の変体仮名
+- char: 𛃉
+  readings:
+  - へんたいがな
+  - み
+  description: 三の変体仮名
+- char: 𛃊
+  readings:
+  - へんたいがな
+  - み
+  description: 微の変体仮名
+- char: 𛃋
+  readings:
+  - へんたいがな
+  - み
+  description: 美の変体仮名
+- char: 𛃌
+  readings:
+  - へんたいがな
+  - み
+  description: 美の変体仮名
+- char: 𛃍
+  readings:
+  - へんたいがな
+  - み
+  description: 美の変体仮名
+- char: 𛃎
+  readings:
+  - へんたいがな
+  - み
+  description: 見の変体仮名
+- char: 𛃏
+  readings:
+  - へんたいがな
+  - み
+  description: 身の変体仮名
+- char: 𛃐
+  readings:
+  - へんたいがな
+  - む
+  description: 武の変体仮名
+- char: 𛃑
+  readings:
+  - へんたいがな
+  - む
+  description: 無の変体仮名
+- char: 𛃒
+  readings:
+  - へんたいがな
+  - む
+  description: 牟の変体仮名
+- char: 𛃓
+  readings:
+  - へんたいがな
+  - む
+  description: 舞の変体仮名
+- char: 𛃔
+  readings:
+  - へんたいがな
+  - め
+  description: 免の変体仮名
+- char: 𛃕
+  readings:
+  - へんたいがな
+  - め
+  description: 面の変体仮名
+- char: 𛃖
+  readings:
+  - へんたいがな
+  - め
+  - ま
+  description: 馬の変体仮名
+- char: 𛃗
+  readings:
+  - へんたいがな
+  - も
+  description: 母の変体仮名
+- char: 𛃘
+  readings:
+  - へんたいがな
+  - も
+  description: 毛の変体仮名
+- char: 𛃙
+  readings:
+  - へんたいがな
+  - も
+  description: 毛の変体仮名
+- char: 𛃚
+  readings:
+  - へんたいがな
+  - も
+  description: 毛の変体仮名
+- char: 𛃛
+  readings:
+  - へんたいがな
+  - も
+  description: 茂の変体仮名
+- char: 𛃜
+  readings:
+  - へんたいがな
+  - も
+  description: 裳の変体仮名
+- char: 𛃝
+  readings:
+  - へんたいがな
+  - や
+  description: 也の変体仮名
+- char: 𛃞
+  readings:
+  - へんたいがな
+  - や
+  description: 也の変体仮名
+- char: 𛃟
+  readings:
+  - へんたいがな
+  - や
+  description: 屋の変体仮名
+- char: 𛃠
+  readings:
+  - へんたいがな
+  - や
+  description: 耶の変体仮名
+- char: 𛃡
+  readings:
+  - へんたいがな
+  - や
+  description: 耶の変体仮名
+- char: 𛃢
+  readings:
+  - へんたいがな
+  - や
+  - よ
+  description: 夜の変体仮名
+- char: 𛃣
+  readings:
+  - へんたいがな
+  - ゆ
+  description: 游の変体仮名
+- char: 𛃤
+  readings:
+  - へんたいがな
+  - ゆ
+  description: 由の変体仮名
+- char: 𛃥
+  readings:
+  - へんたいがな
+  - ゆ
+  description: 由の変体仮名
+- char: 𛃦
+  readings:
+  - へんたいがな
+  - ゆ
+  description: 遊の変体仮名
+- char: 𛃧
+  readings:
+  - へんたいがな
+  - よ
+  description: 代の変体仮名
+- char: 𛃨
+  readings:
+  - へんたいがな
+  - よ
+  description: 余の変体仮名
+- char: 𛃩
+  readings:
+  - へんたいがな
+  - よ
+  description: 與の変体仮名
+- char: 𛃪
+  readings:
+  - へんたいがな
+  - よ
+  description: 與の変体仮名
+- char: 𛃫
+  readings:
+  - へんたいがな
+  - よ
+  description: 與の変体仮名
+- char: 𛃬
+  readings:
+  - へんたいがな
+  - よ
+  description: 餘の変体仮名
+- char: 𛃭
+  readings:
+  - へんたいがな
+  - ら
+  description: 羅の変体仮名
+- char: 𛃮
+  readings:
+  - へんたいがな
+  - ら
+  description: 良の変体仮名
+- char: 𛃯
+  readings:
+  - へんたいがな
+  - ら
+  description: 良の変体仮名
+- char: 𛃰
+  readings:
+  - へんたいがな
+  - ら
+  description: 良の変体仮名
+- char: 𛃱
+  readings:
+  - へんたいがな
+  - り
+  description: 利の変体仮名
+- char: 𛃲
+  readings:
+  - へんたいがな
+  - り
+  description: 利の変体仮名
+- char: 𛃳
+  readings:
+  - へんたいがな
+  - り
+  description: 李の変体仮名
+- char: 𛃴
+  readings:
+  - へんたいがな
+  - り
+  description: 梨の変体仮名
+- char: 𛃵
+  readings:
+  - へんたいがな
+  - り
+  description: 理の変体仮名
+- char: 𛃶
+  readings:
+  - へんたいがな
+  - り
+  description: 里の変体仮名
+- char: 𛃷
+  readings:
+  - へんたいがな
+  - り
+  description: 離の変体仮名
+- char: 𛃸
+  readings:
+  - へんたいがな
+  - る
+  description: 流の変体仮名
+- char: 𛃹
+  readings:
+  - へんたいがな
+  - る
+  description: 留の変体仮名
+- char: 𛃺
+  readings:
+  - へんたいがな
+  - る
+  description: 留の変体仮名
+- char: 𛃻
+  readings:
+  - へんたいがな
+  - る
+  description: 留の変体仮名
+- char: 𛃼
+  readings:
+  - へんたいがな
+  - る
+  description: 累の変体仮名
+- char: 𛃽
+  readings:
+  - へんたいがな
+  - る
+  description: 類の変体仮名
+- char: 𛃾
+  readings:
+  - へんたいがな
+  - れ
+  description: 禮の変体仮名
+- char: 𛃿
+  readings:
+  - へんたいがな
+  - れ
+  description: 禮の変体仮名
+- char: 𛄀
+  readings:
+  - へんたいがな
+  - れ
+  description: 連の変体仮名
+- char: 𛄁
+  readings:
+  - へんたいがな
+  - れ
+  description: 麗の変体仮名
+- char: 𛄂
+  readings:
+  - へんたいがな
+  - ろ
+  description: 呂の変体仮名
+- char: 𛄃
+  readings:
+  - へんたいがな
+  - ろ
+  description: 呂の変体仮名
+- char: 𛄄
+  readings:
+  - へんたいがな
+  - ろ
+  description: 婁の変体仮名
+- char: 𛄅
+  readings:
+  - へんたいがな
+  - ろ
+  description: 樓の変体仮名
+- char: 𛄆
+  readings:
+  - へんたいがな
+  - ろ
+  description: 路の変体仮名
+- char: 𛄇
+  readings:
+  - へんたいがな
+  - ろ
+  description: 露の変体仮名
+- char: 𛄈
+  readings:
+  - へんたいがな
+  - わ
+  description: 倭の変体仮名
+- char: 𛄉
+  readings:
+  - へんたいがな
+  - わ
+  description: 和の変体仮名
+- char: 𛄊
+  readings:
+  - へんたいがな
+  - わ
+  description: 和の変体仮名
+- char: 𛄋
+  readings:
+  - へんたいがな
+  - わ
+  description: 王の変体仮名
+- char: 𛄌
+  readings:
+  - へんたいがな
+  - わ
+  description: 王の変体仮名
+- char: 𛄍
+  readings:
+  - へんたいがな
+  - ゐ
+  - うぃ
+  description: 井の変体仮名
+- char: 𛄎
+  readings:
+  - へんたいがな
+  - ゐ
+  - うぃ
+  description: 井の変体仮名
+- char: 𛄏
+  readings:
+  - へんたいがな
+  - ゐ
+  - うぃ
+  description: 居の変体仮名
+- char: 𛄐
+  readings:
+  - へんたいがな
+  - ゐ
+  - うぃ
+  description: 爲の変体仮名
+- char: 𛄑
+  readings:
+  - へんたいがな
+  - ゐ
+  - うぃ
+  description: 遺の変体仮名
+- char: 𛄒
+  readings:
+  - へんたいがな
+  - ゑ
+  - うぇ
+  description: 惠の変体仮名
+- char: 𛄓
+  readings:
+  - へんたいがな
+  - ゑ
+  - うぇ
+  description: 衞の変体仮名
+- char: 𛄔
+  readings:
+  - へんたいがな
+  - ゑ
+  - うぇ
+  description: 衞の変体仮名
+- char: 𛄕
+  readings:
+  - へんたいがな
+  - ゑ
+  - うぇ
+  description: 衞の変体仮名
+- char: 𛄖
+  readings:
+  - へんたいがな
+  - を
+  description: 乎の変体仮名
+- char: 𛄗
+  readings:
+  - へんたいがな
+  - を
+  description: 乎の変体仮名
+- char: 𛄘
+  readings:
+  - へんたいがな
+  - を
+  description: 尾の変体仮名
+- char: 𛄙
+  readings:
+  - へんたいがな
+  - を
+  description: 緒の変体仮名
+- char: 𛄚
+  readings:
+  - へんたいがな
+  - を
+  description: 越の変体仮名
+- char: 𛄛
+  readings:
+  - へんたいがな
+  - を
+  description: 遠の変体仮名
+- char: 𛄜
+  readings:
+  - へんたいがな
+  - を
+  description: 遠の変体仮名
+- char: 𛄝
+  readings:
+  - へんたいがな
+  - ん
+  - む
+  - も
+  description: 无の変体仮名
+- char: 𛄞
+  readings:
+  - へんたいがな
+  - ん
+  - む
+  - も
+  description: 无の変体仮名
+- char: 𛄟
+  readings:
+  - へんたいがな
+  - う
+  description: 汙の変体仮名
+- char: 𛄠
+  readings:
+  - へんたいがな
+  - い
+  description: 変体仮名
+- char: 𛄡
+  readings:
+  - へんたいがな
+  - いぇ
+  - え
+  description: 変体仮名
+- char: 𛄢
+  readings:
+  - へんたいがな
+  - う
+  description: 汙の変体仮名
+- char: あ゙
+  readings:
+  - あ
+  - あ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ぁ゙
+  readings:
+  - あ
+  - あ"
+  - ぁ
+  - ぁ"
+  - だくてん
+  description: 濁点付き仮名
+- char: い゙
+  readings:
+  - い
+  - い"
+  - だくてん
+  description: 濁点付き仮名
+- char: ぃ゙
+  readings:
+  - い
+  - い"
+  - ぃ
+  - ぃ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ぅ゙
+  readings:
+  - う
+  - う"
+  - ゔ
+  - ぅ
+  - ぅ"
+  - だくてん
+  description: 濁点付き仮名
+- char: え゙
+  readings:
+  - え
+  - え"
+  - だくてん
+  description: 濁点付き仮名
+- char: ぇ゙
+  readings:
+  - え
+  - え"
+  - ぇ
+  - ぇ"
+  - だくてん
+  description: 濁点付き仮名
+- char: お゙
+  readings:
+  - お
+  - お"
+  - だくてん
+  description: 濁点付き仮名
+- char: ぉ゙
+  readings:
+  - お
+  - お"
+  - ぉ
+  - ぉ"
+  - だくてん
+  description: 濁点付き仮名
+- char: っ゙
+  readings:
+  - づ
+  - っ
+  - っ"
+  - だくてん
+  description: 濁点付き仮名
+- char: な゙
+  readings:
+  - な
+  - な"
+  - だくてん
+  description: 濁点付き仮名
+- char: に゙
+  readings:
+  - に
+  - に"
+  - だくてん
+  description: 濁点付き仮名
+- char: ぬ゙
+  readings:
+  - ぬ
+  - ぬ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ね゙
+  readings:
+  - ね
+  - ね"
+  - だくてん
+  description: 濁点付き仮名
+- char: の゙
+  readings:
+  - の
+  - の"
+  - だくてん
+  description: 濁点付き仮名
+- char: ま゙
+  readings:
+  - ま
+  - ま"
+  - だくてん
+  description: 濁点付き仮名
+- char: み゙
+  readings:
+  - み
+  - み"
+  - だくてん
+  description: 濁点付き仮名
+- char: む゙
+  readings:
+  - む
+  - む"
+  - だくてん
+  description: 濁点付き仮名
+- char: め゙
+  readings:
+  - め
+  - め"
+  - だくてん
+  description: 濁点付き仮名
+- char: も゙
+  readings:
+  - も
+  - も"
+  - だくてん
+  description: 濁点付き仮名
+- char: や゙
+  readings:
+  - や
+  - や"
+  - だくてん
+  description: 濁点付き仮名
+- char: ゃ゙
+  readings:
+  - や
+  - や"
+  - ゃ
+  - ゃ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ゆ゙
+  readings:
+  - ゆ
+  - ゆ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ゅ゙
+  readings:
+  - ゆ
+  - ゆ"
+  - ゅ
+  - ゅ"
+  - だくてん
+  description: 濁点付き仮名
+- char: よ゙
+  readings:
+  - よ
+  - よ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ょ゙
+  readings:
+  - よ
+  - よ"
+  - ょ
+  - ょ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ら゙
+  readings:
+  - ら
+  - ら"
+  - だくてん
+  description: 濁点付き仮名
+- char: り゙
+  readings:
+  - り
+  - り"
+  - だくてん
+  description: 濁点付き仮名
+- char: る゙
+  readings:
+  - る
+  - る"
+  - だくてん
+  description: 濁点付き仮名
+- char: れ゙
+  readings:
+  - れ
+  - れ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ろ゙
+  readings:
+  - ろ
+  - ろ"
+  - だくてん
+  description: 濁点付き仮名
+- char: わ゙
+  readings:
+  - わ
+  - わ"
+  - ゔぁ
+  - だくてん
+  description: 濁点付き仮名
+- char: ゐ゙
+  readings:
+  - ゐ
+  - ゐ"
+  - うぃ
+  - ゔぃ
+  - い
+  - い"
+  - だくてん
+  description: 濁点付き仮名
+- char: ゑ゙
+  readings:
+  - ゑ
+  - ゑ"
+  - うぇ
+  - ゔぇ
+  - え
+  - え"
+  - だくてん
+  description: 濁点付き仮名
+- char: を゙
+  readings:
+  - を
+  - を"
+  - ゔぉ
+  - だくてん
+  description: 濁点付き仮名
+- char: ん゙
+  readings:
+  - ん
+  - ん"
+  - だくてん
+  description: 濁点付き仮名
+- char: ア゙
+  readings:
+  - あ
+  - あ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ァ゙
+  readings:
+  - あ
+  - あ"
+  - ぁ
+  - ぁ"
+  - だくてん
+  description: 濁点付き仮名
+- char: イ゙
+  readings:
+  - い
+  - い"
+  - だくてん
+  description: 濁点付き仮名
+- char: ィ゙
+  readings:
+  - い
+  - い"
+  - ぃ
+  - ぃ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ゥ゙
+  readings:
+  - う
+  - う"
+  - ぅ
+  - ぅ"
+  - だくてん
+  description: 濁点付き仮名
+- char: エ゙
+  readings:
+  - え
+  - え"
+  - だくてん
+  description: 濁点付き仮名
+- char: ェ゙
+  readings:
+  - え
+  - え"
+  - ぇ
+  - ぇ"
+  - だくてん
+  description: 濁点付き仮名
+- char: オ゙
+  readings:
+  - お
+  - お"
+  - だくてん
+  description: 濁点付き仮名
+- char: ォ゙
+  readings:
+  - お
+  - お"
+  - ぉ
+  - ぉ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ッ゙
+  readings:
+  - づ
+  - っ
+  - っ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ナ゙
+  readings:
+  - な
+  - な"
+  - だくてん
+  description: 濁点付き仮名
+- char: ニ゙
+  readings:
+  - に
+  - に"
+  - だくてん
+  description: 濁点付き仮名
+- char: ヌ゙
+  readings:
+  - ぬ
+  - ぬ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ネ゙
+  readings:
+  - ね
+  - ね"
+  - だくてん
+  description: 濁点付き仮名
+- char: ノ゙
+  readings:
+  - の
+  - の"
+  - だくてん
+  description: 濁点付き仮名
+- char: マ゙
+  readings:
+  - ま
+  - ま"
+  - だくてん
+  description: 濁点付き仮名
+- char: ミ゙
+  readings:
+  - み
+  - み"
+  - だくてん
+  description: 濁点付き仮名
+- char: ム゙
+  readings:
+  - む
+  - む"
+  - だくてん
+  description: 濁点付き仮名
+- char: メ゙
+  readings:
+  - め
+  - め"
+  - だくてん
+  description: 濁点付き仮名
+- char: モ゙
+  readings:
+  - も
+  - も"
+  - だくてん
+  description: 濁点付き仮名
+- char: ヤ゙
+  readings:
+  - や
+  - や"
+  - だくてん
+  description: 濁点付き仮名
+- char: ャ゙
+  readings:
+  - や
+  - や"
+  - ゃ
+  - ゃ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ユ゙
+  readings:
+  - ゆ
+  - ゆ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ュ゙
+  readings:
+  - ゆ
+  - ゆ"
+  - ゅ
+  - ゅ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ヨ゙
+  readings:
+  - よ
+  - よ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ョ゙
+  readings:
+  - よ
+  - よ"
+  - ょ
+  - ょ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ラ゙
+  readings:
+  - ら
+  - ら"
+  - だくてん
+  description: 濁点付き仮名
+- char: リ゙
+  readings:
+  - り
+  - り"
+  - だくてん
+  description: 濁点付き仮名
+- char: ル゙
+  readings:
+  - る
+  - る"
+  - だくてん
+  description: 濁点付き仮名
+- char: レ゙
+  readings:
+  - れ
+  - れ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ロ゙
+  readings:
+  - ろ
+  - ろ"
+  - だくてん
+  description: 濁点付き仮名
+- char: ヷ
+  readings:
+  - わ
+  - わ"
+  - ゔぁ
+  - だくてん
+  description: 濁点付き仮名
+- char: ヸ
+  readings:
+  - ゐ
+  - ゐ"
+  - うぃ
+  - ゔぃ
+  - い
+  - い"
+  - だくてん
+  description: 濁点付き仮名
+- char: ヹ
+  readings:
+  - ゑ
+  - ゑ"
+  - うぇ
+  - ゔぇ
+  - え
+  - え"
+  - だくてん
+  description: 濁点付き仮名
+- char: ヺ
+  readings:
+  - を
+  - を"
+  - ゔぉ
+  - だくてん
+  description: 濁点付き仮名
+- char: ン゙
+  readings:
+  - ん
+  - ん"
+  - だくてん
+  description: 濁点付き仮名
+- char: か゚
+  readings:
+  - びだくおん
+  - か
+  - が
+  description: 鼻濁音
+- char: き゚
+  readings:
+  - びだくおん
+  - き
+  - ぎ
+  description: 鼻濁音
+- char: く゚
+  readings:
+  - びだくおん
+  - く
+  - ぐ
+  description: 鼻濁音
+- char: け゚
+  readings:
+  - びだくおん
+  - け
+  - げ
+  description: 鼻濁音
+- char: こ゚
+  readings:
+  - びだくおん
+  - こ
+  - ご
+  description: 鼻濁音
+- char: カ゚
+  readings:
+  - びだくおん
+  - か
+  - が
+  description: 鼻濁音
+- char: キ゚
+  readings:
+  - びだくおん
+  - き
+  - ぎ
+  description: 鼻濁音
+- char: ク゚
+  readings:
+  - びだくおん
+  - く
+  - ぐ
+  description: 鼻濁音
+- char: ケ゚
+  readings:
+  - びだくおん
+  - け
+  - げ
+  description: 鼻濁音
+- char: コ゚
+  readings:
+  - びだくおん
+  - こ
+  - ご
+  description: 鼻濁音

--- a/karukan-engine/src/kana.rs
+++ b/karukan-engine/src/kana.rs
@@ -18,6 +18,22 @@ pub fn normalize_nfkc(text: &str) -> String {
     text.nfkc().collect()
 }
 
+/// True if the text contains any hiragana or katakana **letter**.
+///
+/// Used to distinguish "real" reading inputs (kana the model can convert)
+/// from symbol-only or alphabet-only inputs that would only produce
+/// hallucinated model output.
+///
+/// Only actual kana letters count — punctuation that lives in the katakana
+/// block (U+30A0 double hyphen, U+30FB middle dot `・`, U+30FC prolonged
+/// mark `ー`, iteration marks U+30FD–U+30FE) is intentionally excluded.
+/// Otherwise typing just `・` or `ー` would let the model run on a
+/// punctuation-only reading and hallucinate.
+pub fn contains_kana(text: &str) -> bool {
+    text.chars()
+        .any(|c| matches!(c, '\u{3041}'..='\u{3096}' | '\u{30A1}'..='\u{30FA}'))
+}
+
 /// Convert hiragana to katakana
 pub fn hiragana_to_katakana(text: &str) -> String {
     text.chars()
@@ -40,9 +56,229 @@ pub fn katakana_to_hiragana(text: &str) -> String {
         .collect()
 }
 
+/// Map a single full-width katakana char to its half-width form.
+///
+/// Voiced/semi-voiced characters expand to two chars (base + dakuten/handakuten).
+/// Returns the original char as a single-char string for non-katakana input.
+fn katakana_char_to_half(c: char) -> String {
+    match c {
+        // Sokuon, small kana
+        'ァ' => "ｧ".into(),
+        'ィ' => "ｨ".into(),
+        'ゥ' => "ｩ".into(),
+        'ェ' => "ｪ".into(),
+        'ォ' => "ｫ".into(),
+        'ッ' => "ｯ".into(),
+        'ャ' => "ｬ".into(),
+        'ュ' => "ｭ".into(),
+        'ョ' => "ｮ".into(),
+        // a-row through wo
+        'ア' => "ｱ".into(),
+        'イ' => "ｲ".into(),
+        'ウ' => "ｳ".into(),
+        'エ' => "ｴ".into(),
+        'オ' => "ｵ".into(),
+        'カ' => "ｶ".into(),
+        'キ' => "ｷ".into(),
+        'ク' => "ｸ".into(),
+        'ケ' => "ｹ".into(),
+        'コ' => "ｺ".into(),
+        'サ' => "ｻ".into(),
+        'シ' => "ｼ".into(),
+        'ス' => "ｽ".into(),
+        'セ' => "ｾ".into(),
+        'ソ' => "ｿ".into(),
+        'タ' => "ﾀ".into(),
+        'チ' => "ﾁ".into(),
+        'ツ' => "ﾂ".into(),
+        'テ' => "ﾃ".into(),
+        'ト' => "ﾄ".into(),
+        'ナ' => "ﾅ".into(),
+        'ニ' => "ﾆ".into(),
+        'ヌ' => "ﾇ".into(),
+        'ネ' => "ﾈ".into(),
+        'ノ' => "ﾉ".into(),
+        'ハ' => "ﾊ".into(),
+        'ヒ' => "ﾋ".into(),
+        'フ' => "ﾌ".into(),
+        'ヘ' => "ﾍ".into(),
+        'ホ' => "ﾎ".into(),
+        'マ' => "ﾏ".into(),
+        'ミ' => "ﾐ".into(),
+        'ム' => "ﾑ".into(),
+        'メ' => "ﾒ".into(),
+        'モ' => "ﾓ".into(),
+        'ヤ' => "ﾔ".into(),
+        'ユ' => "ﾕ".into(),
+        'ヨ' => "ﾖ".into(),
+        'ラ' => "ﾗ".into(),
+        'リ' => "ﾘ".into(),
+        'ル' => "ﾙ".into(),
+        'レ' => "ﾚ".into(),
+        'ロ' => "ﾛ".into(),
+        'ワ' => "ﾜ".into(),
+        'ヲ' => "ｦ".into(),
+        'ン' => "ﾝ".into(),
+        // Voiced (dakuten) — expand to base + ﾞ
+        'ガ' => "ｶﾞ".into(),
+        'ギ' => "ｷﾞ".into(),
+        'グ' => "ｸﾞ".into(),
+        'ゲ' => "ｹﾞ".into(),
+        'ゴ' => "ｺﾞ".into(),
+        'ザ' => "ｻﾞ".into(),
+        'ジ' => "ｼﾞ".into(),
+        'ズ' => "ｽﾞ".into(),
+        'ゼ' => "ｾﾞ".into(),
+        'ゾ' => "ｿﾞ".into(),
+        'ダ' => "ﾀﾞ".into(),
+        'ヂ' => "ﾁﾞ".into(),
+        'ヅ' => "ﾂﾞ".into(),
+        'デ' => "ﾃﾞ".into(),
+        'ド' => "ﾄﾞ".into(),
+        'バ' => "ﾊﾞ".into(),
+        'ビ' => "ﾋﾞ".into(),
+        'ブ' => "ﾌﾞ".into(),
+        'ベ' => "ﾍﾞ".into(),
+        'ボ' => "ﾎﾞ".into(),
+        'ヴ' => "ｳﾞ".into(),
+        // Semi-voiced (handakuten) — expand to base + ﾟ
+        'パ' => "ﾊﾟ".into(),
+        'ピ' => "ﾋﾟ".into(),
+        'プ' => "ﾌﾟ".into(),
+        'ペ' => "ﾍﾟ".into(),
+        'ポ' => "ﾎﾟ".into(),
+        // Long sound, punctuation
+        'ー' => "ｰ".into(),
+        '・' => "･".into(),
+        '。' => "｡".into(),
+        '、' => "､".into(),
+        '「' => "｢".into(),
+        '」' => "｣".into(),
+        // Standalone dakuten / handakuten
+        '゛' => "ﾞ".into(),
+        '゜' => "ﾟ".into(),
+        _ => c.to_string(),
+    }
+}
+
+/// True if every character is a hiragana letter (U+3041–U+3096).
+///
+/// Used to decide whether a candidate deserves the mozc-style `[全]ひらがな`
+/// width-form annotation. Empty strings return false.
+pub fn is_pure_hiragana(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|c| matches!(c, '\u{3041}'..='\u{3096}'))
+}
+
+/// True if every character is a full-width katakana letter (U+30A1–U+30FA,
+/// plus the prolonged sound mark U+30FC).
+///
+/// Used to decide whether a candidate deserves the mozc-style `[全]カタカナ`
+/// width-form annotation. Empty strings return false.
+pub fn is_pure_full_katakana(text: &str) -> bool {
+    !text.is_empty()
+        && text
+            .chars()
+            .all(|c| matches!(c, '\u{30A1}'..='\u{30FA}' | '\u{30FC}'))
+}
+
+/// Convert full-width katakana to half-width katakana.
+///
+/// Voiced characters expand into two half-width characters (base + ﾞ/ﾟ).
+/// Non-katakana characters pass through unchanged.
+pub fn katakana_to_half_width(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        out.push_str(&katakana_char_to_half(c));
+    }
+    out
+}
+
+/// Convert hiragana to half-width katakana.
+///
+/// Equivalent to `katakana_to_half_width(hiragana_to_katakana(text))`.
+pub fn hiragana_to_half_katakana(text: &str) -> String {
+    katakana_to_half_width(&hiragana_to_katakana(text))
+}
+
+/// Map a half-width ASCII alphanumeric character (digit / Latin letter) to
+/// its full-width form (e.g. `a` → `ａ`, `Z` → `Ｚ`, `5` → `５`). All other
+/// characters pass through unchanged.
+pub fn ascii_to_fullwidth_char(c: char) -> char {
+    match c {
+        '0'..='9' => char::from_u32(c as u32 - 0x30 + 0xFF10).unwrap_or(c),
+        'A'..='Z' => char::from_u32(c as u32 - 0x41 + 0xFF21).unwrap_or(c),
+        'a'..='z' => char::from_u32(c as u32 - 0x61 + 0xFF41).unwrap_or(c),
+        _ => c,
+    }
+}
+
+/// Map a full-width ASCII alphanumeric character to its half-width form
+/// (e.g. `ａ` → `a`, `Ｚ` → `Z`, `５` → `5`). All other characters pass
+/// through unchanged.
+pub fn fullwidth_to_ascii_char(c: char) -> char {
+    match c {
+        '\u{FF10}'..='\u{FF19}' => char::from_u32(c as u32 - 0xFF10 + 0x30).unwrap_or(c),
+        '\u{FF21}'..='\u{FF3A}' => char::from_u32(c as u32 - 0xFF21 + 0x41).unwrap_or(c),
+        '\u{FF41}'..='\u{FF5A}' => char::from_u32(c as u32 - 0xFF41 + 0x61).unwrap_or(c),
+        _ => c,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_contains_kana() {
+        // Real kana letters → true
+        assert!(contains_kana("あ"));
+        assert!(contains_kana("ア"));
+        assert!(contains_kana("ヴ")); // U+30F4 in U+30A1..=U+30FA
+        assert!(contains_kana("コーヒー"));
+        assert!(contains_kana("カ・ド")); // mixed kana + middle dot still has kana
+
+        // Punctuation in the katakana block — NOT kana.
+        // Without this exclusion, typing just `・` or `ー` would let the
+        // model run on a punctuation-only reading and hallucinate.
+        assert!(!contains_kana("・"));
+        assert!(!contains_kana("ー"));
+        assert!(!contains_kana("ヽ"));
+        assert!(!contains_kana("ヾ"));
+
+        // Other non-kana inputs.
+        assert!(!contains_kana(""));
+        assert!(!contains_kana("123"));
+        assert!(!contains_kana("「」"));
+        assert!(!contains_kana("漢字")); // kanji, not kana
+        assert!(!contains_kana("abc"));
+    }
+
+    #[test]
+    fn test_is_pure_hiragana() {
+        assert!(is_pure_hiragana("あ"));
+        assert!(is_pure_hiragana("あいうえお"));
+        assert!(is_pure_hiragana("がっこう"));
+
+        assert!(!is_pure_hiragana(""));
+        assert!(!is_pure_hiragana("ア")); // katakana
+        assert!(!is_pure_hiragana("あア")); // mixed
+        assert!(!is_pure_hiragana("あ漢"));
+        assert!(!is_pure_hiragana("ーあ")); // prolonged mark is katakana block
+    }
+
+    #[test]
+    fn test_is_pure_full_katakana() {
+        assert!(is_pure_full_katakana("ア"));
+        assert!(is_pure_full_katakana("アイウエオ"));
+        assert!(is_pure_full_katakana("コーヒー")); // includes prolonged mark
+        assert!(is_pure_full_katakana("ヴ"));
+
+        assert!(!is_pure_full_katakana(""));
+        assert!(!is_pure_full_katakana("あ")); // hiragana
+        assert!(!is_pure_full_katakana("ｱ")); // half-width
+        assert!(!is_pure_full_katakana("ア漢"));
+        assert!(!is_pure_full_katakana("・")); // middle dot not a kana letter
+    }
 
     #[test]
     fn test_hiragana_to_katakana() {
@@ -70,6 +306,64 @@ mod tests {
         let katakana = hiragana_to_katakana(original);
         let back = katakana_to_hiragana(&katakana);
         assert_eq!(original, back);
+    }
+
+    #[test]
+    fn test_katakana_to_half_width() {
+        assert_eq!(katakana_to_half_width("アイウエオ"), "ｱｲｳｴｵ");
+        assert_eq!(katakana_to_half_width("カキクケコ"), "ｶｷｸｹｺ");
+        assert_eq!(katakana_to_half_width("ガッコウ"), "ｶﾞｯｺｳ");
+        assert_eq!(katakana_to_half_width("パピプペポ"), "ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ");
+        assert_eq!(katakana_to_half_width("キャキュキョ"), "ｷｬｷｭｷｮ");
+        assert_eq!(katakana_to_half_width("コーヒー"), "ｺｰﾋｰ");
+        assert_eq!(katakana_to_half_width("ヴ"), "ｳﾞ");
+        // Punctuation
+        assert_eq!(katakana_to_half_width("「アイウ」"), "｢ｱｲｳ｣");
+        // Pass through non-katakana
+        assert_eq!(katakana_to_half_width("abc"), "abc");
+        assert_eq!(katakana_to_half_width("漢字"), "漢字");
+    }
+
+    #[test]
+    fn test_hiragana_to_half_katakana() {
+        assert_eq!(hiragana_to_half_katakana("あ"), "ｱ");
+        assert_eq!(hiragana_to_half_katakana("がっこう"), "ｶﾞｯｺｳ");
+        assert_eq!(hiragana_to_half_katakana("ぱぴぷぺぽ"), "ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ");
+    }
+
+    #[test]
+    fn test_ascii_to_fullwidth_char() {
+        // Digits
+        assert_eq!(ascii_to_fullwidth_char('0'), '０');
+        assert_eq!(ascii_to_fullwidth_char('9'), '９');
+        // Uppercase letters
+        assert_eq!(ascii_to_fullwidth_char('A'), 'Ａ');
+        assert_eq!(ascii_to_fullwidth_char('Z'), 'Ｚ');
+        // Lowercase letters
+        assert_eq!(ascii_to_fullwidth_char('a'), 'ａ');
+        assert_eq!(ascii_to_fullwidth_char('z'), 'ｚ');
+        // Pass-through for non-ASCII-alphanumerics
+        assert_eq!(ascii_to_fullwidth_char(' '), ' ');
+        assert_eq!(ascii_to_fullwidth_char('!'), '!');
+        assert_eq!(ascii_to_fullwidth_char('あ'), 'あ');
+        assert_eq!(ascii_to_fullwidth_char('Ａ'), 'Ａ');
+    }
+
+    #[test]
+    fn test_fullwidth_to_ascii_char() {
+        // Digits
+        assert_eq!(fullwidth_to_ascii_char('０'), '0');
+        assert_eq!(fullwidth_to_ascii_char('９'), '9');
+        // Uppercase letters
+        assert_eq!(fullwidth_to_ascii_char('Ａ'), 'A');
+        assert_eq!(fullwidth_to_ascii_char('Ｚ'), 'Z');
+        // Lowercase letters
+        assert_eq!(fullwidth_to_ascii_char('ａ'), 'a');
+        assert_eq!(fullwidth_to_ascii_char('ｚ'), 'z');
+        // Pass-through
+        assert_eq!(fullwidth_to_ascii_char('a'), 'a');
+        assert_eq!(fullwidth_to_ascii_char('あ'), 'あ');
+        assert_eq!(fullwidth_to_ascii_char('！'), '！'); // not part of ASCII alphanumerics
     }
 
     #[test]

--- a/karukan-engine/src/lib.rs
+++ b/karukan-engine/src/lib.rs
@@ -2,10 +2,18 @@ pub mod dict;
 pub mod kana;
 pub mod kanji;
 pub mod learning;
+pub mod rewriter;
 pub mod romaji;
 
 pub use dict::{Candidate as DictCandidate, DictEntry, Dictionary, LookupResult};
-pub use kana::{hiragana_to_katakana, katakana_to_hiragana, normalize_nfkc};
+pub use kana::{
+    contains_kana, hiragana_to_katakana, is_pure_full_katakana, is_pure_hiragana,
+    katakana_to_hiragana, normalize_nfkc,
+};
 pub use kanji::{Backend, KanaKanjiConverter};
 pub use learning::LearningCache;
+pub use rewriter::{
+    AlphabetRewriter, HalfWidthKatakanaRewriter, RewriteOutput, Rewriter, RewriterChain,
+    SymbolRewriter, description as symbol_description,
+};
 pub use romaji::{BackspaceResult, ConversionEvent, RomajiConverter};

--- a/karukan-engine/src/rewriter/alphabet.rs
+++ b/karukan-engine/src/rewriter/alphabet.rs
@@ -1,0 +1,162 @@
+//! Alphabet width/case rewriter — for ASCII or full-width alphabetic input,
+//! emit the four canonical forms: half-width lower/upper, full-width lower/upper.
+//!
+//! Examples:
+//! - `abc` → `ABC`, `ａｂｃ`, `ＡＢＣ`
+//! - `ABC` → `abc`, `ａｂｃ`, `ＡＢＣ`
+//! - `Hello` → `hello`, `HELLO`, `ｈｅｌｌｏ`, `ＨＥＬＬＯ`, `Ｈｅｌｌｏ` (… minus self)
+//!
+//! Each variant carries a description tagged with mozc's width markers
+//! (`[半]` / `[全]`) plus 大文字/小文字, e.g. `ＡＢＣ` → `[全]英大文字`.
+
+use crate::kana::{ascii_to_fullwidth_char, fullwidth_to_ascii_char};
+
+use super::{RewriteOutput, Rewriter};
+
+/// Rewriter that produces width/case variants for alphabetic input.
+pub struct AlphabetRewriter;
+
+fn is_alpha_char(c: char) -> bool {
+    c.is_ascii_alphabetic()
+        || ('\u{FF21}'..='\u{FF3A}').contains(&c)  // Ａ-Ｚ
+        || ('\u{FF41}'..='\u{FF5A}').contains(&c) // ａ-ｚ
+}
+
+fn is_pure_alpha(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(is_alpha_char)
+}
+
+#[derive(Clone, Copy)]
+enum Width {
+    Half,
+    Full,
+}
+
+#[derive(Clone, Copy)]
+enum Case {
+    Lower,
+    Upper,
+}
+
+/// Build one variant + its mozc-style description.
+fn build_variant(original: &str, width: Width, case: Case) -> (String, &'static str) {
+    let half: String = original.chars().map(fullwidth_to_ascii_char).collect();
+    let cased = match case {
+        Case::Lower => half.to_ascii_lowercase(),
+        Case::Upper => half.to_ascii_uppercase(),
+    };
+    let text = match width {
+        Width::Half => cased,
+        Width::Full => cased.chars().map(ascii_to_fullwidth_char).collect(),
+    };
+    let desc = match (width, case) {
+        (Width::Half, Case::Lower) => "[半]英小文字",
+        (Width::Half, Case::Upper) => "[半]英大文字",
+        (Width::Full, Case::Lower) => "[全]英小文字",
+        (Width::Full, Case::Upper) => "[全]英大文字",
+    };
+    (text, desc)
+}
+
+impl Rewriter for AlphabetRewriter {
+    fn name(&self) -> &'static str {
+        "alphabet"
+    }
+
+    fn rewrite(&self, candidate: &str) -> Vec<RewriteOutput> {
+        if !is_pure_alpha(candidate) {
+            return Vec::new();
+        }
+
+        let mut out: Vec<RewriteOutput> = Vec::new();
+        for &(width, case) in &[
+            (Width::Half, Case::Lower),
+            (Width::Half, Case::Upper),
+            (Width::Full, Case::Lower),
+            (Width::Full, Case::Upper),
+        ] {
+            let (text, desc) = build_variant(candidate, width, case);
+            if text != candidate && !out.iter().any(|(t, _)| t == &text) {
+                out.push((text, Some(desc.to_string())));
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rewriter::test_util::{desc, texts};
+
+    #[test]
+    fn empty_returns_empty() {
+        assert!(AlphabetRewriter.rewrite("").is_empty());
+    }
+
+    #[test]
+    fn non_alpha_returns_empty() {
+        assert!(AlphabetRewriter.rewrite("123").is_empty());
+        assert!(AlphabetRewriter.rewrite("abc1").is_empty()); // mixed digits
+        assert!(AlphabetRewriter.rewrite("hello world").is_empty()); // space
+        assert!(AlphabetRewriter.rewrite("あ").is_empty());
+        assert!(AlphabetRewriter.rewrite("競技").is_empty());
+    }
+
+    #[test]
+    fn lowercase_emits_three_variants() {
+        let out = AlphabetRewriter.rewrite("abc");
+        let t = texts(&out);
+        assert!(t.contains(&"ABC".to_string()));
+        assert!(t.contains(&"ａｂｃ".to_string()));
+        assert!(t.contains(&"ＡＢＣ".to_string()));
+        assert!(!t.iter().any(|s| s == "abc")); // self excluded
+    }
+
+    #[test]
+    fn uppercase_emits_three_variants() {
+        let out = AlphabetRewriter.rewrite("ABC");
+        let t = texts(&out);
+        assert!(t.contains(&"abc".to_string()));
+        assert!(t.contains(&"ａｂｃ".to_string()));
+        assert!(t.contains(&"ＡＢＣ".to_string()));
+        assert!(!t.iter().any(|s| s == "ABC"));
+    }
+
+    #[test]
+    fn fullwidth_lowercase_emits_three_variants() {
+        let out = AlphabetRewriter.rewrite("ａｂｃ");
+        let t = texts(&out);
+        assert!(t.contains(&"abc".to_string()));
+        assert!(t.contains(&"ABC".to_string()));
+        assert!(t.contains(&"ＡＢＣ".to_string()));
+        assert!(!t.iter().any(|s| s == "ａｂｃ"));
+    }
+
+    #[test]
+    fn mixed_case_emits_all_four_canonical_forms() {
+        // `AbC` itself isn't one of the four canonical forms, so all four
+        // appear as variants.
+        let t = texts(&AlphabetRewriter.rewrite("AbC"));
+        assert!(t.contains(&"abc".to_string()));
+        assert!(t.contains(&"ABC".to_string()));
+        assert!(t.contains(&"ａｂｃ".to_string()));
+        assert!(t.contains(&"ＡＢＣ".to_string()));
+    }
+
+    #[test]
+    fn descriptions_match_width_and_case() {
+        let out = AlphabetRewriter.rewrite("abc");
+        assert_eq!(desc(&out, "ABC"), Some("[半]英大文字".to_string()));
+        assert_eq!(desc(&out, "ａｂｃ"), Some("[全]英小文字".to_string()));
+        assert_eq!(desc(&out, "ＡＢＣ"), Some("[全]英大文字".to_string()));
+    }
+
+    #[test]
+    fn single_letter_works() {
+        let t = texts(&AlphabetRewriter.rewrite("a"));
+        assert!(t.contains(&"A".to_string()));
+        assert!(t.contains(&"ａ".to_string()));
+        assert!(t.contains(&"Ａ".to_string()));
+    }
+}

--- a/karukan-engine/src/rewriter/half_katakana.rs
+++ b/karukan-engine/src/rewriter/half_katakana.rs
@@ -1,0 +1,152 @@
+//! Katakana form rewriter — produces full-width and half-width katakana variants.
+//!
+//! Only applies to candidates that consist entirely of hiragana or full-width
+//! katakana (i.e. the reading itself / pure-kana fallbacks). Model output
+//! candidates that mix kanji with kana are NOT rewritten — converting
+//! `愛してる` into `愛ｼﾃﾙ` would be nonsense.
+//!
+//! For a pure-kana candidate, this rewriter emits:
+//! - The full-width katakana form (only if the candidate has hiragana)
+//! - The half-width katakana form (only if it differs from the candidate)
+//!
+//! Variants identical to the original or to each other are not emitted.
+//!
+//! Each emitted variant carries a mozc-style width annotation
+//! (`[全]カタカナ` / `[半]カタカナ`) so the candidate window can label them.
+
+use crate::kana::{hiragana_to_katakana, katakana_to_half_width};
+
+use super::{RewriteOutput, Rewriter};
+
+/// Annotation shown on full-width katakana variants.
+const FULL_KATAKANA_DESC: &str = "[全]カタカナ";
+
+/// Annotation shown on half-width katakana variants.
+const HALF_KATAKANA_DESC: &str = "[半]カタカナ";
+
+/// Rewriter that produces full-width and half-width katakana variants.
+pub struct HalfWidthKatakanaRewriter;
+
+fn contains_hiragana(text: &str) -> bool {
+    text.chars().any(|c| matches!(c, '\u{3041}'..='\u{3096}'))
+}
+
+/// True if every character is in the hiragana or katakana block (including
+/// the prolonged sound mark, sokuon, dakuten/handakuten, and small kana).
+fn is_pure_kana(text: &str) -> bool {
+    text.chars()
+        .all(|c| matches!(c, '\u{3041}'..='\u{3096}' | '\u{30A0}'..='\u{30FF}'))
+}
+
+impl Rewriter for HalfWidthKatakanaRewriter {
+    fn name(&self) -> &'static str {
+        "katakana_form"
+    }
+
+    fn rewrite(&self, candidate: &str) -> Vec<RewriteOutput> {
+        if candidate.is_empty() || !is_pure_kana(candidate) {
+            return Vec::new();
+        }
+
+        let mut out: Vec<RewriteOutput> = Vec::new();
+
+        // Full-width katakana (only if candidate contains hiragana)
+        let full_kata = if contains_hiragana(candidate) {
+            let v = hiragana_to_katakana(candidate);
+            if v != candidate {
+                out.push((v.clone(), Some(FULL_KATAKANA_DESC.to_string())));
+                v
+            } else {
+                candidate.to_string()
+            }
+        } else {
+            candidate.to_string()
+        };
+
+        // Half-width katakana
+        let half = katakana_to_half_width(&full_kata);
+        if half != candidate && !out.iter().any(|(s, _)| s == &half) {
+            out.push((half, Some(HALF_KATAKANA_DESC.to_string())));
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rewriter::test_util::{desc, texts};
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let r = HalfWidthKatakanaRewriter;
+        assert!(r.rewrite("").is_empty());
+    }
+
+    #[test]
+    fn pure_kanji_returns_empty() {
+        let r = HalfWidthKatakanaRewriter;
+        assert!(r.rewrite("競技").is_empty());
+    }
+
+    #[test]
+    fn pure_ascii_returns_empty() {
+        let r = HalfWidthKatakanaRewriter;
+        assert!(r.rewrite("abc").is_empty());
+    }
+
+    #[test]
+    fn hiragana_emits_full_and_half() {
+        let r = HalfWidthKatakanaRewriter;
+        assert_eq!(
+            texts(&r.rewrite("あいう")),
+            vec!["アイウ".to_string(), "ｱｲｳ".to_string()]
+        );
+    }
+
+    #[test]
+    fn full_katakana_emits_half_only() {
+        let r = HalfWidthKatakanaRewriter;
+        assert_eq!(texts(&r.rewrite("アイウ")), vec!["ｱｲｳ".to_string()]);
+    }
+
+    #[test]
+    fn voiced_dakuten_expands() {
+        let r = HalfWidthKatakanaRewriter;
+        assert_eq!(
+            texts(&r.rewrite("がっこう")),
+            vec!["ガッコウ".to_string(), "ｶﾞｯｺｳ".to_string()]
+        );
+    }
+
+    #[test]
+    fn mixed_kanji_kana_returns_empty() {
+        let r = HalfWidthKatakanaRewriter;
+        // Mixed kanji + kana inputs (typical model output) must NOT be rewritten:
+        // turning `愛してる` into `愛ｼﾃﾙ` is nonsense.
+        assert!(r.rewrite("競技プログラミング").is_empty());
+        assert!(r.rewrite("愛してる").is_empty());
+        assert!(r.rewrite("漢字あ").is_empty());
+    }
+
+    #[test]
+    fn does_not_emit_self() {
+        let r = HalfWidthKatakanaRewriter;
+        let out = r.rewrite("ｱｲｳ");
+        assert!(!out.iter().any(|(s, _)| s == "ｱｲｳ"));
+    }
+
+    #[test]
+    fn descriptions_match_width_form() {
+        // Mozc-style width annotations: full-width katakana → `[全]カタカナ`,
+        // half-width katakana → `[半]カタカナ`.
+        let r = HalfWidthKatakanaRewriter;
+        let out = r.rewrite("あいう");
+        assert_eq!(desc(&out, "アイウ"), Some(FULL_KATAKANA_DESC.to_string()));
+        assert_eq!(desc(&out, "ｱｲｳ"), Some(HALF_KATAKANA_DESC.to_string()));
+
+        let out = r.rewrite("アイウ");
+        assert_eq!(desc(&out, "ｱｲｳ"), Some(HALF_KATAKANA_DESC.to_string()));
+    }
+}

--- a/karukan-engine/src/rewriter/mod.rs
+++ b/karukan-engine/src/rewriter/mod.rs
@@ -1,0 +1,140 @@
+//! Candidate rewriters: produce additional variants from existing conversion candidates.
+//!
+//! Algorithms, tables and descriptions in this module are Rust re-implementations
+//! of Mozc's rewriter logic (`NumberRewriter`, `SymbolRewriter`, `NumberUtil`,
+//! width/case helpers). See `THIRD_PARTY_LICENSES` at the repo root for the
+//! upstream BSD-3-Clause notice.
+//!
+//! A `Rewriter` takes a single candidate string and returns zero or more
+//! `(variant, description)` pairs. The description is shown as the candidate's
+//! annotation in the candidate window (e.g. `…` -> "三点リーダ"); rewriters
+//! that don't have a meaningful description return `None`.
+//!
+//! Rewriters do not perform their own kana-kanji conversion; they only
+//! transform/decorate already-converted candidates (e.g. wrapping with brackets,
+//! converting full-width katakana to half-width).
+//!
+//! The chain (`RewriterChain`) applies all registered rewriters to the input
+//! candidate list and returns flat variants. Caller (IMEEngine) is responsible
+//! for deduplication and ordering.
+
+mod alphabet;
+mod half_katakana;
+mod number;
+mod symbol;
+
+pub use alphabet::AlphabetRewriter;
+pub use half_katakana::HalfWidthKatakanaRewriter;
+pub use number::NumberRewriter;
+pub use symbol::{SymbolRewriter, description};
+
+/// One result of rewriting: the variant text and an optional description used
+/// as the candidate's annotation (e.g. `三点リーダ` for `…`).
+pub type RewriteOutput = (String, Option<String>);
+
+/// A rewriter takes one candidate and produces variants.
+pub trait Rewriter: Send + Sync {
+    /// Stable identifier for logging/debugging.
+    fn name(&self) -> &'static str;
+
+    /// Produce variants from a single candidate. The original candidate is not
+    /// included in the result. Each result is paired with an optional
+    /// description used as the candidate annotation.
+    fn rewrite(&self, candidate: &str) -> Vec<RewriteOutput>;
+}
+
+/// A chain of rewriters applied in registration order.
+#[derive(Default)]
+pub struct RewriterChain {
+    rewriters: Vec<Box<dyn Rewriter>>,
+}
+
+impl RewriterChain {
+    /// Create an empty chain.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a rewriter at the end of the chain.
+    pub fn add(&mut self, rewriter: Box<dyn Rewriter>) {
+        self.rewriters.push(rewriter);
+    }
+
+    /// Build the default chain used by the IME: half-width katakana and symbol
+    /// variants.
+    pub fn default_chain() -> Self {
+        let mut chain = Self::new();
+        chain.add(Box::new(HalfWidthKatakanaRewriter));
+        chain.add(Box::new(AlphabetRewriter));
+        chain.add(Box::new(SymbolRewriter));
+        chain.add(Box::new(NumberRewriter));
+        chain
+    }
+
+    /// Apply all rewriters to each candidate. Returns variants in registration
+    /// order. Caller must deduplicate and merge with the original candidate
+    /// list.
+    pub fn rewrite_all(&self, candidates: &[String]) -> Vec<RewriteOutput> {
+        let mut out = Vec::new();
+        for cand in candidates {
+            for rewriter in &self.rewriters {
+                out.extend(rewriter.rewrite(cand));
+            }
+        }
+        out
+    }
+}
+
+/// Shared test helpers for inspecting `RewriteOutput` slices.
+///
+/// Pulled out of the per-rewriter test modules so each one doesn't have to
+/// re-implement the same `(text, description)` accessors.
+#[cfg(test)]
+pub(crate) mod test_util {
+    use super::RewriteOutput;
+
+    /// Collect just the variant texts from a `rewrite()` result.
+    pub fn texts(out: &[RewriteOutput]) -> Vec<String> {
+        out.iter().map(|(t, _)| t.clone()).collect()
+    }
+
+    /// Find the description attached to a specific variant text.
+    pub fn desc(out: &[RewriteOutput], text: &str) -> Option<String> {
+        out.iter()
+            .find(|(t, _)| t == text)
+            .and_then(|(_, d)| d.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct UpcaseRewriter;
+    impl Rewriter for UpcaseRewriter {
+        fn name(&self) -> &'static str {
+            "upcase"
+        }
+        fn rewrite(&self, candidate: &str) -> Vec<RewriteOutput> {
+            vec![(candidate.to_uppercase(), None)]
+        }
+    }
+
+    #[test]
+    fn empty_chain_returns_empty() {
+        let chain = RewriterChain::new();
+        let out = chain.rewrite_all(&["a".to_string(), "b".to_string()]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn chain_applies_all_rewriters() {
+        let mut chain = RewriterChain::new();
+        chain.add(Box::new(UpcaseRewriter));
+        let out = chain.rewrite_all(&["abc".to_string(), "def".to_string()]);
+        assert_eq!(
+            out,
+            vec![("ABC".to_string(), None), ("DEF".to_string(), None),]
+        );
+    }
+}

--- a/karukan-engine/src/rewriter/number.rs
+++ b/karukan-engine/src/rewriter/number.rs
@@ -1,0 +1,370 @@
+//! Number rewriter — expand a numeric candidate into related styles.
+//!
+//! For a halfwidth or fullwidth arabic candidate, emit: the width pair
+//! (`123` ↔ `１２３`), kanji (`百二十三`), daiji (`壱百弐拾参`), roman
+//! (`Ⅰ-Ⅻ` / `ⅰ-ⅻ`), circled (`①-㊿`), and radix (`0x…` / `0…` / `0b…`).
+//! Each variant carries the per-style description shown as the candidate's
+//! right-side comment.
+//!
+//! Inputs must be pure decimal digits — mixed text like `20世紀` is left
+//! alone.
+
+use super::{RewriteOutput, Rewriter};
+use crate::kana::{ascii_to_fullwidth_char, fullwidth_to_ascii_char};
+
+// ---------- tables ----------
+//
+// `*_DIGITS[d]` is the glyph for digit `d` (0..=9). For kanji/daiji, the
+// `d == 0` slot is never read by the algorithm — the all-zero case is
+// handled separately via `*_ZERO`.
+//
+// `*_RANKS[pos]` is the suffix for position `pos` within a 4-digit segment
+// (0=ones, 1=tens, 2=hundreds, 3=thousands).
+//
+// `*_BIG_RANKS[i]` is the suffix between 4-digit segments counted from the
+// least-significant side (0=ones segment with no suffix, 1=万, 2=億, …).
+// Length 7 caps the kanji form at 10^28 − 1.
+//
+// `ROMAN_*` and `CIRCLED` are value-indexed: `table[n]` is the glyph for
+// value `n`. An empty slot means "no glyph for this value" — e.g. there
+// is no roman numeral for 0, so `ROMAN_*[0]` is `""`.
+
+const KANJI_DIGITS: [&str; 10] = ["〇", "一", "二", "三", "四", "五", "六", "七", "八", "九"];
+const OLD_KANJI_DIGITS: [&str; 10] = ["零", "壱", "弐", "参", "四", "五", "六", "七", "八", "九"];
+const KANJI_RANKS: [&str; 4] = ["", "十", "百", "千"];
+const OLD_KANJI_RANKS: [&str; 4] = ["", "拾", "百", "阡"];
+const KANJI_BIG_RANKS: [&str; 7] = ["", "万", "億", "兆", "京", "垓", "秭"];
+const OLD_KANJI_BIG_RANKS: [&str; 7] = ["", "萬", "億", "兆", "京", "垓", "秭"];
+const KANJI_ZERO: &str = "〇";
+const OLD_KANJI_ZERO: &str = "零";
+
+const ROMAN_CAPITAL: [&str; 13] = [
+    "", "Ⅰ", "Ⅱ", "Ⅲ", "Ⅳ", "Ⅴ", "Ⅵ", "Ⅶ", "Ⅷ", "Ⅸ", "Ⅹ", "Ⅺ", "Ⅻ",
+];
+const ROMAN_SMALL: [&str; 13] = [
+    "", "ⅰ", "ⅱ", "ⅲ", "ⅳ", "ⅴ", "ⅵ", "ⅶ", "ⅷ", "ⅸ", "ⅹ", "ⅺ", "ⅻ",
+];
+const CIRCLED: [&str; 51] = [
+    "⓪", "①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩", "⑪", "⑫", "⑬", "⑭", "⑮", "⑯", "⑰", "⑱",
+    "⑲", "⑳", "㉑", "㉒", "㉓", "㉔", "㉕", "㉖", "㉗", "㉘", "㉙", "㉚", "㉛", "㉜", "㉝", "㉞",
+    "㉟", "㊱", "㊲", "㊳", "㊴", "㊵", "㊶", "㊷", "㊸", "㊹", "㊺", "㊻", "㊼", "㊽", "㊾", "㊿",
+];
+
+const DESC_NUMBER: &str = "数字";
+const DESC_KANJI: &str = "漢数字";
+const DESC_OLD_KANJI: &str = "大字";
+const DESC_ROMAN_CAPITAL: &str = "ローマ数字(大文字)";
+const DESC_ROMAN_SMALL: &str = "ローマ数字(小文字)";
+const DESC_CIRCLED: &str = "丸数字";
+const DESC_HEX: &str = "16進数";
+const DESC_OCT: &str = "8進数";
+const DESC_BIN: &str = "2進数";
+
+// ---------- input gates ----------
+
+/// True iff every character is a halfwidth (`0-9`) or fullwidth (`０-９`)
+/// decimal digit, and the string is non-empty.
+fn is_pure_digit(text: &str) -> bool {
+    !text.is_empty()
+        && text
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('\u{FF10}'..='\u{FF19}').contains(&c))
+}
+
+fn to_halfwidth(text: &str) -> String {
+    text.chars().map(fullwidth_to_ascii_char).collect()
+}
+
+fn to_fullwidth(text: &str) -> String {
+    text.chars().map(ascii_to_fullwidth_char).collect()
+}
+
+// ---------- kanji rendering ----------
+
+/// Split a digit string into 4-digit big-rank segments, least-significant
+/// first: `"1234567890"` → `["7890", "3456", "12"]`.
+fn split_big_ranks(digits: &str) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let bytes = digits.as_bytes();
+    let mut end = bytes.len();
+    while end > 0 {
+        let start = end.saturating_sub(4);
+        segments.push(std::str::from_utf8(&bytes[start..end]).expect("ASCII digits"));
+        end = start;
+    }
+    segments
+}
+
+/// Render one 4-digit segment as positional kanji (`"1234"` → `"千二百三十四"`).
+/// Standard style drops a leading `一` before 十百千; daiji always keeps `壱`.
+fn render_kanji_segment(segment: &str, digits: &[&str], ranks: &[&str], old_kanji: bool) -> String {
+    let len = segment.len();
+    let mut out = String::new();
+    for (i, b) in segment.bytes().enumerate() {
+        let d = (b - b'0') as usize;
+        if d == 0 {
+            continue;
+        }
+        let pos = len - 1 - i;
+        let keep_one = old_kanji || pos == 0 || d != 1;
+        if keep_one {
+            out.push_str(digits[d]);
+        }
+        out.push_str(ranks[pos]);
+    }
+    out
+}
+
+/// Full kanji form. All-zero input picks the style-specific glyph:
+/// `〇` for standard, `零` for daiji. Returns `None` if the input has more
+/// big-rank segments than the table can name.
+fn to_kanji(digits: &str, old_kanji: bool) -> Option<String> {
+    let trimmed = digits.trim_start_matches('0');
+    let (digit_table, rank_table, big_rank_table, zero): (&[&str], &[&str], &[&str], &str) =
+        if old_kanji {
+            (
+                &OLD_KANJI_DIGITS,
+                &OLD_KANJI_RANKS,
+                &OLD_KANJI_BIG_RANKS,
+                OLD_KANJI_ZERO,
+            )
+        } else {
+            (&KANJI_DIGITS, &KANJI_RANKS, &KANJI_BIG_RANKS, KANJI_ZERO)
+        };
+    if trimmed.is_empty() {
+        return Some(zero.to_string());
+    }
+    let segments = split_big_ranks(trimmed);
+    if segments.len() > big_rank_table.len() {
+        return None;
+    }
+    let mut out = String::new();
+    for (i, seg) in segments.iter().enumerate().rev() {
+        let body = render_kanji_segment(seg, digit_table, rank_table, old_kanji);
+        if !body.is_empty() {
+            out.push_str(&body);
+            out.push_str(big_rank_table[i]);
+        }
+    }
+    Some(if out.is_empty() {
+        zero.to_string()
+    } else {
+        out
+    })
+}
+
+/// Value-indexed lookup. Returns the index iff `table[n]` exists and is
+/// non-empty (empty slots are treated as "no glyph for this value").
+fn lookup_index(n: u64, table: &[&str]) -> Option<usize> {
+    let i = n as usize;
+    (i < table.len() && !table[i].is_empty()).then_some(i)
+}
+
+// ---------- rewriter ----------
+
+#[derive(Default)]
+pub struct NumberRewriter;
+
+impl NumberRewriter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Rewriter for NumberRewriter {
+    fn name(&self) -> &'static str {
+        "number"
+    }
+
+    fn rewrite(&self, candidate: &str) -> Vec<RewriteOutput> {
+        if !is_pure_digit(candidate) {
+            return Vec::new();
+        }
+        let half = to_halfwidth(candidate);
+        let full = to_fullwidth(candidate);
+        let n = half.parse::<u64>().ok();
+
+        let mut out: Vec<RewriteOutput> = Vec::new();
+        let mut push = |text: String, desc: &'static str| {
+            if text != candidate && !out.iter().any(|(t, _)| t == &text) {
+                out.push((text, Some(desc.to_string())));
+            }
+        };
+
+        // width pair (数字)
+        push(half.clone(), DESC_NUMBER);
+        push(full, DESC_NUMBER);
+
+        // kanji (漢数字)
+        if let Some(s) = to_kanji(&half, false) {
+            push(s, DESC_KANJI);
+        }
+
+        // old kanji / daiji (大字)
+        if let Some(s) = to_kanji(&half, true) {
+            push(s, DESC_OLD_KANJI);
+        }
+
+        // roman (Ⅰ-Ⅻ / ⅰ-ⅻ), 1..=12
+        if let Some(n) = n
+            && let Some(i) = lookup_index(n, &ROMAN_CAPITAL)
+        {
+            push(ROMAN_CAPITAL[i].to_string(), DESC_ROMAN_CAPITAL);
+            push(ROMAN_SMALL[i].to_string(), DESC_ROMAN_SMALL);
+        }
+
+        // circled (⓪-㊿), 0..=50
+        if let Some(n) = n
+            && let Some(i) = lookup_index(n, &CIRCLED)
+        {
+            push(CIRCLED[i].to_string(), DESC_CIRCLED);
+        }
+
+        // radix — gated on u64 fit
+        if let Some(n) = n {
+            push(format!("0x{:x}", n), DESC_HEX);
+            push(format!("0{:o}", n), DESC_OCT);
+            push(format!("0b{:b}", n), DESC_BIN);
+        }
+
+        out
+    }
+}
+
+// ---------- tests ----------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rewriter::test_util::{desc, texts};
+
+    #[test]
+    fn empty_or_non_digit_returns_empty() {
+        let r = NumberRewriter::new();
+        assert!(r.rewrite("").is_empty());
+        assert!(r.rewrite("abc").is_empty());
+        assert!(r.rewrite("あ").is_empty());
+        assert!(r.rewrite("1a").is_empty());
+        assert!(r.rewrite("1.5").is_empty()); // decimals not supported
+    }
+
+    #[test]
+    fn width_pair() {
+        let r = NumberRewriter::new();
+        assert!(texts(&r.rewrite("123")).contains(&"１２３".to_string()));
+        assert!(texts(&r.rewrite("１２３")).contains(&"123".to_string()));
+    }
+
+    #[test]
+    fn kanji_basic() {
+        let r = NumberRewriter::new();
+        // standard kanji 〇 vs daiji 零 for all-zero input
+        let t = texts(&r.rewrite("0"));
+        assert!(t.contains(&"〇".to_string()));
+        assert!(t.contains(&"零".to_string()));
+        assert!(texts(&r.rewrite("1")).contains(&"一".to_string()));
+        // leading `一` suppressed before 十百千
+        assert!(texts(&r.rewrite("10")).contains(&"十".to_string()));
+        assert!(texts(&r.rewrite("11")).contains(&"十一".to_string()));
+        assert!(texts(&r.rewrite("100")).contains(&"百".to_string()));
+    }
+
+    #[test]
+    fn kanji_big_ranks() {
+        let r = NumberRewriter::new();
+        assert!(texts(&r.rewrite("10000")).contains(&"一万".to_string()));
+        assert!(texts(&r.rewrite("1234")).contains(&"千二百三十四".to_string()));
+        assert!(
+            texts(&r.rewrite("12345678")).contains(&"千二百三十四万五千六百七十八".to_string())
+        );
+        // inner zero ranks are skipped (no `〇万` for 10001)
+        assert!(texts(&r.rewrite("10001")).contains(&"一万一".to_string()));
+    }
+
+    #[test]
+    fn zero_glyph_per_style() {
+        let out = NumberRewriter::new().rewrite("0");
+        assert_eq!(desc(&out, "〇"), Some("漢数字".to_string()));
+        assert_eq!(desc(&out, "零"), Some("大字".to_string()));
+        for input in ["00", "000", "0000"] {
+            let t = texts(&NumberRewriter::new().rewrite(input));
+            assert!(t.contains(&"〇".to_string()));
+            assert!(t.contains(&"零".to_string()));
+        }
+    }
+
+    #[test]
+    fn old_kanji_keeps_leading_one() {
+        let r = NumberRewriter::new();
+        assert!(texts(&r.rewrite("10")).contains(&"壱拾".to_string()));
+        assert!(texts(&r.rewrite("100")).contains(&"壱百".to_string()));
+        assert!(texts(&r.rewrite("1000")).contains(&"壱阡".to_string()));
+        assert!(texts(&r.rewrite("10000")).contains(&"壱萬".to_string()));
+    }
+
+    #[test]
+    fn roman_only_for_1_through_12() {
+        let r = NumberRewriter::new();
+        assert!(texts(&r.rewrite("1")).contains(&"Ⅰ".to_string()));
+        assert!(texts(&r.rewrite("1")).contains(&"ⅰ".to_string()));
+        assert!(texts(&r.rewrite("12")).contains(&"Ⅻ".to_string()));
+        let t = texts(&r.rewrite("13"));
+        assert!(!t.iter().any(|s| s == "Ⅻ" || s == "ⅻ"));
+    }
+
+    #[test]
+    fn circled_for_0_through_50() {
+        let r = NumberRewriter::new();
+        assert!(texts(&r.rewrite("0")).contains(&"⓪".to_string()));
+        assert!(texts(&r.rewrite("1")).contains(&"①".to_string()));
+        assert!(texts(&r.rewrite("20")).contains(&"⑳".to_string()));
+        assert!(texts(&r.rewrite("50")).contains(&"㊿".to_string()));
+        assert!(!texts(&r.rewrite("51")).iter().any(|s| s == "㊿"));
+    }
+
+    #[test]
+    fn radix() {
+        let r = NumberRewriter::new();
+        let t = texts(&r.rewrite("1234"));
+        assert!(t.contains(&"0x4d2".to_string()));
+        assert!(t.contains(&"02322".to_string()));
+        assert!(t.contains(&"0b10011010010".to_string()));
+    }
+
+    #[test]
+    fn descriptions_match_mozc() {
+        let r = NumberRewriter::new();
+        let out = r.rewrite("1234");
+        assert_eq!(desc(&out, "千二百三十四"), Some("漢数字".to_string()));
+        assert_eq!(desc(&out, "壱阡弐百参拾四"), Some("大字".to_string()));
+        assert_eq!(desc(&out, "0x4d2"), Some("16進数".to_string()));
+        assert_eq!(desc(&out, "02322"), Some("8進数".to_string()));
+        assert_eq!(desc(&out, "0b10011010010"), Some("2進数".to_string()));
+
+        let out = r.rewrite("12");
+        assert_eq!(desc(&out, "Ⅻ"), Some("ローマ数字(大文字)".to_string()));
+        assert_eq!(desc(&out, "ⅻ"), Some("ローマ数字(小文字)".to_string()));
+        assert_eq!(desc(&out, "⑫"), Some("丸数字".to_string()));
+    }
+
+    #[test]
+    fn does_not_emit_self() {
+        let r = NumberRewriter::new();
+        for input in ["1", "123", "1234", "12345"] {
+            let t = texts(&r.rewrite(input));
+            assert!(
+                !t.iter().any(|s| s == input),
+                "{} in its own variants",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn very_large_number_skips_radix() {
+        let r = NumberRewriter::new();
+        let t = texts(&r.rewrite("99999999999999999999")); // 20 digits, > u64::MAX
+        assert!(!t.iter().any(|s| s.starts_with("0x")));
+        assert!(!t.iter().any(|s| s.starts_with("0b")));
+    }
+}

--- a/karukan-engine/src/rewriter/symbol.rs
+++ b/karukan-engine/src/rewriter/symbol.rs
@@ -1,0 +1,485 @@
+//! Symbol rewriter — given a typed symbol or hiragana reading, emit related
+//! symbol candidates.
+//!
+//! [`SymbolRewriter`] handles two complementary jobs:
+//!
+//! 1. **Variant chain** — a typed symbol expands to related symbols
+//!    (e.g. `「` → `『`, `【`, `（`, ...).
+//! 2. **Reading lookup** — a hiragana reading expands to matching symbols
+//!    (e.g. `かぎかっこ` → `「」`, `『』`), parity with mozc's symbol_rewriter.
+//!
+//! All data lives in `karukan-engine/data/symbols.yml` (loaded once via
+//! `LazyLock`) under three sections:
+//!
+//! - `descriptions:` — hand-curated overrides for the symbol → description
+//!   table. Only entries that are *not* already present (with the same
+//!   description) in `entries:` need to live here; today this is just the
+//!   single-bracket forms (`「`, `」`, `『`, `』`, ...) which mozc keeps
+//!   under non-kana readings only.
+//! - `variants:` — hand-curated variant chains driving job (1).
+//! - `entries:` — auto-generated from `mozc/src/data/symbol/symbol.tsv` by
+//!   `scripts/symbols_porter.py`, driving job (2). Re-running the porter
+//!   overwrites only this section. Includes ASCII readings (e.g. `<` →
+//!   `〈`/`＜`/`≦`/`←`) for mozc parity.
+//!
+//! At load time the per-entry `description` from `entries:` is folded into
+//! the table behind [`description`], with the curated `descriptions:`
+//! section overriding when both define a value for the same symbol.
+//!
+//! ```yaml
+//! descriptions:
+//!   。: 句点
+//!   …: 三点リーダ
+//! variants:
+//!   - key: 「
+//!     chain: [『, 【, 〔, （, ...]
+//! entries:
+//!   - char: "「」"
+//!     readings: [かっこ, かぎかっこ]
+//!     description: かぎ括弧
+//! ```
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use serde::Deserialize;
+
+use crate::kana::{ascii_to_fullwidth_char, fullwidth_to_ascii_char};
+
+use super::{RewriteOutput, Rewriter};
+
+const SYMBOLS_YAML: &str = include_str!("../../data/symbols.yml");
+
+#[derive(Deserialize)]
+struct VariantEntry {
+    key: String,
+    chain: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct SymbolEntry {
+    char: String,
+    readings: Vec<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SymbolFile {
+    descriptions: HashMap<String, String>,
+    variants: Vec<VariantEntry>,
+    entries: Vec<SymbolEntry>,
+}
+
+/// One symbol candidate for a given reading. Internal: the rewriter is the
+/// only consumer.
+#[derive(Debug, Clone)]
+struct SymbolCandidate {
+    /// The symbol text (e.g. `「」`).
+    char: String,
+    /// Description from mozc (e.g. `かぎ括弧`), if any.
+    description: Option<String>,
+}
+
+struct SymbolTable {
+    descriptions: HashMap<String, String>,
+    variants: HashMap<String, Vec<String>>,
+    /// Reverse index: reading → symbol candidates, in source-file order.
+    by_reading: HashMap<String, Vec<SymbolCandidate>>,
+}
+
+static SYMBOL_TABLE: LazyLock<SymbolTable> = LazyLock::new(|| {
+    let file: SymbolFile =
+        serde_yaml::from_str(SYMBOLS_YAML).expect("symbols.yml must be valid YAML");
+    let variants = file
+        .variants
+        .into_iter()
+        .map(|e| (e.key, e.chain))
+        .collect();
+
+    // Build the char → description table: seed from `entries` (mozc-derived),
+    // then let `descriptions` (hand-curated) override. The curated section
+    // therefore only needs entries that aren't already in `entries`, or that
+    // need a different label than mozc provides (e.g. single-bracket forms
+    // like `「` → "始めかぎ括弧" that mozc keeps under non-kana readings and
+    // are filtered out of our `entries` section).
+    let mut descriptions: HashMap<String, String> = HashMap::new();
+    let mut by_reading: HashMap<String, Vec<SymbolCandidate>> = HashMap::new();
+    for entry in file.entries {
+        if let Some(desc) = &entry.description {
+            descriptions
+                .entry(entry.char.clone())
+                .or_insert_with(|| desc.clone());
+        }
+        for reading in &entry.readings {
+            let bucket = by_reading.entry(reading.clone()).or_default();
+            // Dedupe by char within a reading bucket — multiple mozc rows can
+            // map the same reading/char pair via different POS values.
+            if !bucket.iter().any(|c| c.char == entry.char) {
+                bucket.push(SymbolCandidate {
+                    char: entry.char.clone(),
+                    description: entry.description.clone(),
+                });
+            }
+        }
+    }
+    descriptions.extend(file.descriptions);
+
+    SymbolTable {
+        descriptions,
+        variants,
+        by_reading,
+    }
+});
+
+/// Look up the Japanese description for a symbol (e.g. `。` → "句点").
+/// Returns `None` if the text isn't a known symbol in the table.
+pub fn description(text: &str) -> Option<&'static str> {
+    SYMBOL_TABLE.descriptions.get(text).map(|s| s.as_str())
+}
+
+/// Rewriter that returns related symbols for a typed symbol or hiragana
+/// reading. See the module docstring for the two lookup paths.
+#[derive(Default)]
+pub struct SymbolRewriter;
+
+impl SymbolRewriter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// True if every character is an ASCII digit or full-width digit (and the
+/// string is non-empty). Used to gate digit-only width-pair generation so
+/// arbitrary candidates with stray digits aren't expanded.
+fn is_pure_digit(text: &str) -> bool {
+    !text.is_empty()
+        && text
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('\u{FF10}'..='\u{FF19}').contains(&c))
+}
+
+/// For a digit-only string, return the all-full-width and all-half-width forms
+/// that differ from the input. Supports arbitrary length (e.g. `123` → `１２３`,
+/// `１２` → `12`).
+fn digit_width_variants(candidate: &str) -> Vec<String> {
+    if !is_pure_digit(candidate) {
+        return Vec::new();
+    }
+    let full: String = candidate.chars().map(ascii_to_fullwidth_char).collect();
+    let half: String = candidate.chars().map(fullwidth_to_ascii_char).collect();
+    let mut out = Vec::new();
+    if full != candidate {
+        out.push(full);
+    }
+    if half != candidate && !out.iter().any(|s| s == &half) {
+        out.push(half);
+    }
+    out
+}
+
+impl Rewriter for SymbolRewriter {
+    fn name(&self) -> &'static str {
+        "symbol"
+    }
+
+    fn rewrite(&self, candidate: &str) -> Vec<RewriteOutput> {
+        if candidate.is_empty() {
+            return Vec::new();
+        }
+        let mut out: Vec<RewriteOutput> = Vec::new();
+        let push_unique = |s: String, desc: Option<String>, out: &mut Vec<RewriteOutput>| {
+            if s != candidate && !out.iter().any(|(t, _)| t == &s) {
+                // Prefer the description that was supplied (e.g. mozc's
+                // per-row description for a reading→symbol entry); fall
+                // back to the global symbol description table for variant
+                // chains that don't carry their own.
+                let final_desc = desc.or_else(|| SYMBOL_TABLE.descriptions.get(&s).cloned());
+                out.push((s, final_desc));
+            }
+        };
+
+        // Variant chain: typed symbol → related symbols
+        // (e.g. `「` → `『`, `【`, `（`, ...).
+        if let Some(chain) = SYMBOL_TABLE.variants.get(candidate) {
+            for v in chain {
+                push_unique(v.clone(), None, &mut out);
+            }
+        }
+
+        // Reading lookup: hiragana reading → symbol candidates from mozc's
+        // symbol.tsv (e.g. `かぎかっこ` → `「」`, `『』`, ...).
+        if let Some(syms) = SYMBOL_TABLE.by_reading.get(candidate) {
+            for sym in syms {
+                push_unique(sym.char.clone(), sym.description.clone(), &mut out);
+            }
+        }
+
+        for v in digit_width_variants(candidate) {
+            push_unique(v, None, &mut out);
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rewriter::test_util::{desc, texts};
+
+    #[test]
+    fn open_kagi_returns_other_open_brackets() {
+        let r = SymbolRewriter::new();
+        let out = texts(&r.rewrite("「"));
+        assert!(out.contains(&"『".to_string()));
+        assert!(out.contains(&"【".to_string()));
+        assert!(out.contains(&"（".to_string()));
+        assert!(out.contains(&"〔".to_string()));
+    }
+
+    #[test]
+    fn close_kagi_returns_other_close_brackets() {
+        let r = SymbolRewriter::new();
+        let out = texts(&r.rewrite("」"));
+        assert!(out.contains(&"』".to_string()));
+        assert!(out.contains(&"】".to_string()));
+        assert!(out.contains(&"）".to_string()));
+    }
+
+    #[test]
+    fn comma_returns_variants() {
+        let r = SymbolRewriter::new();
+        let out = texts(&r.rewrite("、"));
+        assert!(out.contains(&"，".to_string()));
+        assert!(out.contains(&",".to_string()));
+    }
+
+    #[test]
+    fn unknown_returns_empty() {
+        // Arbitrary words / empty input have neither variant chains nor
+        // reading entries in the symbol table.
+        let r = SymbolRewriter::new();
+        assert!(r.rewrite("競技").is_empty());
+        assert!(r.rewrite("").is_empty());
+        // (Single-kana readings like `あ` *do* hit reading entries from
+        // mozc's symbol.tsv — see kakko/kagikakko tests below — so they're
+        // intentionally not asserted to be empty here.)
+    }
+
+    #[test]
+    fn no_self_in_variants() {
+        let r = SymbolRewriter::new();
+        for key in SYMBOL_TABLE.variants.keys() {
+            let out = texts(&r.rewrite(key));
+            assert!(
+                !out.iter().any(|s| s == key),
+                "{} should not include self",
+                key
+            );
+        }
+    }
+
+    #[test]
+    fn single_digit_emits_width_pair() {
+        let r = SymbolRewriter::new();
+        assert!(texts(&r.rewrite("1")).contains(&"１".to_string()));
+        assert!(texts(&r.rewrite("１")).contains(&"1".to_string()));
+        assert!(texts(&r.rewrite("0")).contains(&"０".to_string()));
+        assert!(texts(&r.rewrite("9")).contains(&"９".to_string()));
+    }
+
+    #[test]
+    fn multi_digit_emits_width_pair() {
+        let r = SymbolRewriter::new();
+        assert!(texts(&r.rewrite("123")).contains(&"１２３".to_string()));
+        assert!(texts(&r.rewrite("１２３")).contains(&"123".to_string()));
+        assert!(texts(&r.rewrite("2026")).contains(&"２０２６".to_string()));
+    }
+
+    #[test]
+    fn mixed_or_non_digit_no_width_pair() {
+        let r = SymbolRewriter::new();
+        // Digits mixed with other chars are NOT expanded by digit_width_variants.
+        let out = texts(&r.rewrite("a1"));
+        assert!(!out.iter().any(|s| s == "ａ１"));
+        // Pure ASCII letters also not expanded (digit-only gate).
+        let out = texts(&r.rewrite("abc"));
+        assert!(!out.iter().any(|s| s == "ａｂｃ"));
+    }
+
+    #[test]
+    fn double_quote_returns_variants() {
+        let r = SymbolRewriter::new();
+        let out = texts(&r.rewrite("\""));
+        assert!(out.contains(&"”".to_string()));
+        assert!(out.contains(&"“".to_string()));
+        let out = texts(&r.rewrite("”"));
+        assert!(out.contains(&"\"".to_string()));
+        assert!(out.contains(&"“".to_string()));
+    }
+
+    #[test]
+    fn repeated_dots_emit_ellipsis() {
+        let r = SymbolRewriter::new();
+        assert!(texts(&r.rewrite("。。。")).contains(&"…".to_string()));
+        assert!(texts(&r.rewrite("...")).contains(&"…".to_string()));
+        assert!(texts(&r.rewrite("・・・")).contains(&"…".to_string()));
+        assert!(texts(&r.rewrite("。。")).contains(&"‥".to_string()));
+        assert!(texts(&r.rewrite("..")).contains(&"‥".to_string()));
+        let out = texts(&r.rewrite("…"));
+        assert!(out.contains(&"。。。".to_string()));
+        assert!(out.contains(&"...".to_string()));
+    }
+
+    #[test]
+    fn paired_brackets_emit_other_pairs() {
+        let r = SymbolRewriter::new();
+        let out = texts(&r.rewrite("「」"));
+        assert!(out.contains(&"『』".to_string()));
+        assert!(out.contains(&"【】".to_string()));
+        assert!(out.contains(&"（）".to_string()));
+        let out = texts(&r.rewrite("()"));
+        assert!(out.contains(&"「」".to_string()));
+    }
+
+    #[test]
+    fn ascii_symbol_pair_expands() {
+        let r = SymbolRewriter::new();
+        assert!(texts(&r.rewrite("@")).contains(&"＠".to_string()));
+        assert!(texts(&r.rewrite("＠")).contains(&"@".to_string()));
+    }
+
+    // ---------- description tests ----------
+
+    #[test]
+    fn description_returns_mozc_label() {
+        // These come from mozc's symbol.tsv via data/symbols.yml.
+        assert_eq!(description("。"), Some("句点"));
+        assert_eq!(description("、"), Some("読点"));
+        assert_eq!(description("…"), Some("三点リーダ"));
+        assert_eq!(description("‥"), Some("二点リーダ"));
+        assert_eq!(description("「"), Some("始めかぎ括弧"));
+        assert_eq!(description("『』"), Some("二重かぎ括弧"));
+    }
+
+    #[test]
+    fn description_returns_none_for_unknown() {
+        assert_eq!(description("あ"), None);
+        assert_eq!(description("競技"), None);
+        assert_eq!(description(""), None);
+    }
+
+    #[test]
+    fn rewriter_attaches_description_to_known_variants() {
+        let r = SymbolRewriter::new();
+        let out = r.rewrite("。。。");
+        // `…` should come back with its description.
+        assert_eq!(desc(&out, "…"), Some("三点リーダ".to_string()));
+    }
+
+    #[test]
+    fn rewriter_returns_none_for_undescribed_variants() {
+        let r = SymbolRewriter::new();
+        let out = r.rewrite("。");
+        // `.` (ASCII period) has no mozc description in our YAML — must be None,
+        // not a stale label from a different symbol.
+        assert!(desc(&out, ".").is_none());
+    }
+
+    // ---------- reading → symbol lookup (from mozc's symbol.tsv) ----------
+
+    #[test]
+    fn kagikakko_reading_emits_paired_brackets() {
+        // Typing the reading `かぎかっこ` should surface `「」` and `『』`
+        // as candidates (mozc symbol.tsv parity).
+        let r = SymbolRewriter::new();
+        let out = r.rewrite("かぎかっこ");
+        let texts: Vec<String> = out.iter().map(|(t, _)| t.clone()).collect();
+        assert!(
+            texts.contains(&"「」".to_string()),
+            "「」 should appear for reading かぎかっこ, got: {:?}",
+            texts
+        );
+        assert!(
+            texts.contains(&"『』".to_string()),
+            "『』 should appear for reading かぎかっこ, got: {:?}",
+            texts
+        );
+        // The mozc-sourced description rides along on the candidate.
+        assert_eq!(desc(&out, "「」"), Some("かぎ括弧".to_string()));
+    }
+
+    #[test]
+    fn kakko_reading_emits_many_bracket_pairs() {
+        // The broader `かっこ` reading covers many bracket variants in
+        // mozc's symbol.tsv.
+        let r = SymbolRewriter::new();
+        let out = r.rewrite("かっこ");
+        let texts: Vec<String> = out.iter().map(|(t, _)| t.clone()).collect();
+        for expected in ["「」", "『』", "（）", "【】"] {
+            assert!(
+                texts.iter().any(|t| t == expected),
+                "{} should appear for reading かっこ, got: {:?}",
+                expected,
+                texts
+            );
+        }
+    }
+
+    #[test]
+    fn ascii_reading_lookup_matches_mozc() {
+        // Mozc parity: typing the literal ASCII reading `<` should surface
+        // every symbol that lists `<` as a reading in symbol.tsv — the
+        // angle bracket, less-than-or-equal, triangles, etc. This was the
+        // case the earlier porter intentionally filtered out; regenerating
+        // entries: from symbol.tsv brings it back.
+        let r = SymbolRewriter::new();
+        let out = r.rewrite("<");
+        let texts: Vec<String> = out.iter().map(|(t, _)| t.clone()).collect();
+        for expected in ["〈", "‹", "＜", "≦", "◁", "◀"] {
+            assert!(
+                texts.iter().any(|t| t == expected),
+                "{} should appear for ASCII reading <, got: {:?}",
+                expected,
+                texts
+            );
+        }
+    }
+
+    #[test]
+    fn multichar_ascii_reading_lookup_matches_mozc() {
+        // `<<` (paired less-than) is a multi-char ASCII reading in mozc's
+        // symbol.tsv mapping to `《`, `«`, `≪`. Typing `<<` should surface
+        // these without going through the hiragana lookup.
+        let r = SymbolRewriter::new();
+        let out = r.rewrite("<<");
+        let texts: Vec<String> = out.iter().map(|(t, _)| t.clone()).collect();
+        for expected in ["《", "«", "≪"] {
+            assert!(
+                texts.iter().any(|t| t == expected),
+                "{} should appear for ASCII reading <<, got: {:?}",
+                expected,
+                texts
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_reading_yields_no_symbol_lookup() {
+        // A plain Japanese word with no symbol-table reading should not
+        // produce symbol candidates from this path.
+        let r = SymbolRewriter::new();
+        let out = r.rewrite("きょう");
+        let texts: Vec<String> = out.iter().map(|(t, _)| t.clone()).collect();
+        // None of these should appear from a plain word reading.
+        for unexpected in ["「」", "『』", "（）"] {
+            assert!(
+                !texts.iter().any(|t| t == unexpected),
+                "{} should not appear for reading きょう, got: {:?}",
+                unexpected,
+                texts
+            );
+        }
+    }
+}

--- a/karukan-im/README.md
+++ b/karukan-im/README.md
@@ -239,6 +239,7 @@ cp dict.bin ~/.local/share/karukan-im/
 3. 🤖 モデル推論
 4. 📚 システム辞書（スコア順）
 5. ひらがな / カタカナ
+6. 🔄 Rewriter（半角カタカナ・英字全角半角・記号バリアント）
 
 ### Learning Cache
 

--- a/karukan-im/fcitx5-addon/CMakeLists.txt
+++ b/karukan-im/fcitx5-addon/CMakeLists.txt
@@ -47,6 +47,11 @@ target_include_directories(karukan PRIVATE
     ${XKBCommon_INCLUDE_DIRS}
 )
 
+# Expose fcitx5 version to C++ so we can guard newer API usage
+if(Fcitx5Core_VERSION VERSION_GREATER_EQUAL "5.1.9")
+    target_compile_definitions(karukan PRIVATE FCITX5_HAS_CANDIDATE_SET_COMMENT)
+endif()
+
 target_link_libraries(karukan
     Fcitx5::Core
     Fcitx5::Config

--- a/karukan-im/fcitx5-addon/src/karukan.cpp
+++ b/karukan-im/fcitx5-addon/src/karukan.cpp
@@ -21,9 +21,26 @@ constexpr uint32_t kSuperMask = 64;   // Mod4Mask
 // --- KarukanCandidateWord ---
 
 KarukanCandidateWord::KarukanCandidateWord(KarukanEngine* engine, Text text, int index,
-                                           const std::string& annotation)
-    : CandidateWord(std::move(text)), engine_(engine), index_(index) {
-    (void)annotation;  // Annotation is shown in aux text, not inline
+                                           const std::string& description)
+    :
+#ifndef FCITX5_HAS_CANDIDATE_SET_COMMENT
+      // fcitx5 < 5.1.9: append description to candidate text
+      CandidateWord([&]() {
+          if (!description.empty()) {
+              text.append(" " + description);
+          }
+          return std::move(text);
+      }()),
+#else
+      CandidateWord(std::move(text)),
+#endif
+      engine_(engine), index_(index) {
+#ifdef FCITX5_HAS_CANDIDATE_SET_COMMENT
+    // fcitx5 >= 5.1.9: show description as a right-side comment
+    if (!description.empty()) {
+        setComment(Text(description));
+    }
+#endif
 }
 
 void KarukanCandidateWord::select(InputContext* inputContext) const {
@@ -54,9 +71,9 @@ void KarukanCandidateList::updateCandidates(::KarukanEngine* rustEngine) {
         if (text) {
             Text candidateText;
             candidateText.append(std::string(text));
-            const char* ann = karukan_engine_get_candidate_annotation(rustEngine, i);
-            std::string comment = (ann && ann[0] != '\0') ? std::string(ann) : "";
-            append<KarukanCandidateWord>(engine_, std::move(candidateText), i, comment);
+            const char* desc = karukan_engine_get_candidate_description(rustEngine, i);
+            std::string description = (desc && desc[0] != '\0') ? std::string(desc) : "";
+            append<KarukanCandidateWord>(engine_, std::move(candidateText), i, description);
         }
     }
 

--- a/karukan-im/fcitx5-addon/src/karukan.h
+++ b/karukan-im/fcitx5-addon/src/karukan.h
@@ -24,7 +24,7 @@ class KarukanEngine;
 class KarukanCandidateWord : public CandidateWord {
 public:
     KarukanCandidateWord(KarukanEngine* engine, Text text, int index,
-                         const std::string& annotation = "");
+                         const std::string& description = "");
     void select(InputContext* inputContext) const override;
 
 private:

--- a/karukan-im/include/karukan.h
+++ b/karukan-im/include/karukan.h
@@ -148,12 +148,15 @@ uint32_t karukan_engine_get_candidate_count(const KarukanEngine* engine);
 const char* karukan_engine_get_candidate(const KarukanEngine* engine, uint32_t index);
 
 /*
- * Get a candidate annotation (comment) by index.
- * Returns a pointer to a null-terminated UTF-8 string (e.g. "🤖", "📚"),
- * or NULL if index is out of range. Empty string means no annotation.
+ * Get the per-candidate description (mozc-style right-side comment) by index.
+ * Returns a "[…]"-wrapped UTF-8 string ready for fcitx5 setComment
+ * (e.g. "[三点リーダ]", "[全]英大文字"), or an empty string when the
+ * candidate has no description. Source labels ("🤖 AI", "📚 辞書", ...)
+ * are surfaced via the aux text instead.
+ * Returns NULL if index is out of range.
  * The pointer is valid until the next process_key call.
  */
-const char* karukan_engine_get_candidate_annotation(const KarukanEngine* engine, uint32_t index);
+const char* karukan_engine_get_candidate_description(const KarukanEngine* engine, uint32_t index);
 
 /*
  * Get the current candidate cursor position (selected index).

--- a/karukan-im/src/core/candidate.rs
+++ b/karukan-im/src/core/candidate.rs
@@ -2,17 +2,35 @@
 //!
 //! Handles the list of conversion candidates with pagination support.
 
-/// A single conversion candidate
+/// A single conversion candidate.
+///
+/// Two distinct annotation slots are kept separate so the same description
+/// never appears in two places at once:
+///
+/// - `source_label` — shown in the aux text (after the model name) to tell
+///   the user which subsystem produced the candidate (`🤖 AI`, `📚 辞書`,
+///   `📝 学習`, `🔄 変換`, ...).
+/// - `description` — shown as the mozc-style right-side comment on the
+///   candidate itself, describing what the candidate *is* (symbol names like
+///   `三点リーダ`, rewriter variants like `[全]英大文字`).
+///
+/// Position within a `CandidateList` is tracked by the list itself; the
+/// candidate doesn't carry its own index.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Candidate {
     /// The converted text
     pub text: String,
     /// The original reading (hiragana)
     pub reading: Option<String>,
-    /// Optional annotation (e.g., word type, dictionary info)
-    pub annotation: Option<String>,
-    /// Unique index from the conversion engine
-    pub index: usize,
+    /// Source label for the aux text slot (e.g. `🤖 AI`, `📚 辞書`).
+    /// `None` when the source has no label (Fallback).
+    pub source_label: Option<String>,
+    /// Per-candidate description shown as the right-side comment on the
+    /// candidate (mozc-style). Only set when the candidate itself has a
+    /// meaningful description — symbol descriptions like `三点リーダ`,
+    /// rewriter descriptions like `[全]英大文字`. Source labels are
+    /// intentionally excluded so they don't duplicate the aux text.
+    pub description: Option<String>,
 }
 
 impl Candidate {
@@ -20,8 +38,8 @@ impl Candidate {
         Self {
             text: text.into(),
             reading: None,
-            annotation: None,
-            index: 0,
+            source_label: None,
+            description: None,
         }
     }
 
@@ -29,14 +47,9 @@ impl Candidate {
         Self {
             text: text.into(),
             reading: Some(reading.into()),
-            annotation: None,
-            index: 0,
+            source_label: None,
+            description: None,
         }
-    }
-
-    pub fn with_index(mut self, index: usize) -> Self {
-        self.index = index;
-        self
     }
 }
 
@@ -78,26 +91,22 @@ impl CandidateList {
 
     /// Create a candidate list from strings
     pub fn from_strings(strings: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        let candidates = strings
-            .into_iter()
-            .enumerate()
-            .map(|(i, s)| Candidate::new(s).with_index(i))
-            .collect();
-        Self::new(candidates)
+        Self::new(strings.into_iter().map(Candidate::new).collect())
     }
 
-    /// Create a candidate list from strings with reading annotation
+    /// Create a candidate list from strings, attaching the same reading to
+    /// every candidate.
     pub fn from_strings_with_reading(
         strings: impl IntoIterator<Item = impl Into<String>>,
         reading: impl Into<String>,
     ) -> Self {
         let reading = reading.into();
-        let candidates = strings
-            .into_iter()
-            .enumerate()
-            .map(|(i, s)| Candidate::with_reading(s, &reading).with_index(i))
-            .collect();
-        Self::new(candidates)
+        Self::new(
+            strings
+                .into_iter()
+                .map(|s| Candidate::with_reading(s, &reading))
+                .collect(),
+        )
     }
 
     /// Get all candidates

--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -10,7 +10,24 @@ use super::*;
 /// Maximum number of learning candidates to show
 const MAX_LEARNING_CANDIDATES: usize = 3;
 
+/// Mozc-style width/script annotation for a pure-kana candidate, or `None`
+/// if the text mixes scripts or contains kanji/punctuation. Used to label
+/// `あ` / `ア` / `ｱ` candidates in the conversion list.
+fn width_annotation(text: &str) -> Option<&'static str> {
+    if karukan_engine::is_pure_hiragana(text) {
+        Some("[全]ひらがな")
+    } else if karukan_engine::is_pure_full_katakana(text) {
+        Some("[全]カタカナ")
+    } else {
+        None
+    }
+}
+
 /// Helper for building a deduplicated list of conversion candidates.
+///
+/// Two push paths exist: [`push`] dedups by text (skips duplicates), and
+/// [`push_force`] always inserts (used for learning candidates that should
+/// appear at the top even if a later source re-emits the same text).
 struct CandidateBuilder {
     candidates: Vec<AnnotatedCandidate>,
     seen: HashSet<String>,
@@ -25,21 +42,18 @@ impl CandidateBuilder {
     }
 
     /// Push a candidate if its text hasn't been seen yet.
-    fn push_if_new(&mut self, text: String, source: CandidateSource, reading: Option<String>) {
-        if self.seen.insert(text.clone()) {
-            self.candidates.push(AnnotatedCandidate {
-                text,
-                source,
-                reading,
-            });
-        }
-    }
-
-    /// Push a pre-built `AnnotatedCandidate` if its text hasn't been seen yet.
-    fn push_annotated_if_new(&mut self, ac: AnnotatedCandidate) {
+    fn push(&mut self, ac: AnnotatedCandidate) {
         if self.seen.insert(ac.text.clone()) {
             self.candidates.push(ac);
         }
+    }
+
+    /// Push a candidate unconditionally, marking its text as seen so later
+    /// dedup'd inserts skip it. Use only for sources that should win over
+    /// duplicates from later steps (e.g. learning cache).
+    fn push_force(&mut self, ac: AnnotatedCandidate) {
+        self.seen.insert(ac.text.clone());
+        self.candidates.push(ac);
     }
 
     fn is_empty(&self) -> bool {
@@ -56,11 +70,19 @@ impl InputMethodEngine {
     ///
     /// Determines the conversion strategy (main model, light model, or parallel beam),
     /// dispatches to the appropriate model(s), measures latency, and records which model was used.
+    ///
+    /// Skips the model entirely when the reading has no hiragana/katakana — the
+    /// model is trained on kana → kanji and hallucinates garbage (e.g. `「` → `w`)
+    /// for symbol- or alphabet-only inputs. Rule-based variants from
+    /// `SymbolRewriter` cover those cases instead.
     fn run_kana_kanji_conversion(&mut self, reading: &str, num_candidates: usize) -> Vec<String> {
+        if !karukan_engine::contains_kana(reading) {
+            return vec![];
+        }
         let Some(converter) = self.converters.kanji.as_ref() else {
             return vec![];
         };
-        let katakana = karukan_engine::kana::hiragana_to_katakana(reading);
+        let katakana = karukan_engine::hiragana_to_katakana(reading);
         let api_context = self.truncate_context_for_api();
         let main_model_name = converter.model_display_name().to_string();
 
@@ -160,10 +182,13 @@ impl InputMethodEngine {
         }
     }
 
-    /// Start conversion using the current live-conversion result + dictionary candidates.
+    /// Start kanji conversion for the current input buffer.
     ///
-    /// Called when DOWN/TAB is pressed during live conversion.  Instead of
-    /// Start kanji conversion
+    /// Called when DOWN/TAB/SPACE is pressed: flushes any pending romaji,
+    /// resolves the reading, runs `build_conversion_candidates`, and
+    /// transitions into the Conversion state. The previous live-conversion
+    /// result is preserved as the first model candidate so the user sees
+    /// the same text they had been looking at during input.
     pub(super) fn start_conversion(&mut self) -> EngineResult {
         // Flush any remaining romaji into composed_hiragana
         self.flush_romaji_to_composed();
@@ -194,11 +219,7 @@ impl InputMethodEngine {
         {
             candidates.insert(
                 0,
-                AnnotatedCandidate {
-                    text: prev_suggest_text,
-                    source: CandidateSource::Model,
-                    reading: None,
-                },
+                AnnotatedCandidate::new(prev_suggest_text, CandidateSource::Model),
             );
         }
 
@@ -212,26 +233,24 @@ impl InputMethodEngine {
             return EngineResult::consumed().with_action(EngineAction::UpdatePreedit(preedit));
         }
 
-        // Create candidate list with reading and source annotation
+        // Map AnnotatedCandidate → public Candidate. The two annotation
+        // slots are kept disjoint so descriptions never duplicate between the
+        // aux text and the candidate's right-side comment:
+        //   - `source_label` ← source.label() only (e.g. `🤖 AI`, `📚 辞書`)
+        //   - `description`  ← the per-candidate description only
+        //                      (e.g. `三点リーダ`, `[全]英大文字`)
         let candidate_list = CandidateList::new(
             candidates
                 .into_iter()
-                .enumerate()
-                .map(|(i, ac)| {
-                    let label = ac.source.label();
+                .map(|ac| {
                     let cand_reading = ac.reading.unwrap_or_else(|| reading.clone());
-                    let mut c = if label.is_empty() {
-                        Candidate::with_reading(&ac.text, &cand_reading)
-                    } else {
-                        Candidate {
-                            text: ac.text,
-                            reading: Some(cand_reading),
-                            annotation: Some(label.to_string()),
-                            index: 0,
-                        }
-                    };
-                    c.index = i;
-                    c
+                    let label = ac.source.label();
+                    Candidate {
+                        text: ac.text,
+                        reading: Some(cand_reading),
+                        source_label: (!label.is_empty()).then(|| label.to_string()),
+                        description: ac.description,
+                    }
                 })
                 .collect(),
         );
@@ -280,11 +299,10 @@ impl InputMethodEngine {
                     break;
                 }
                 if seen.insert(cand.surface.clone()) {
-                    candidates.push(AnnotatedCandidate {
-                        text: cand.surface.clone(),
-                        source: CandidateSource::UserDictionary,
-                        reading: None,
-                    });
+                    candidates.push(AnnotatedCandidate::new(
+                        cand.surface.clone(),
+                        CandidateSource::UserDictionary,
+                    ));
                 }
             }
         }
@@ -300,11 +318,10 @@ impl InputMethodEngine {
                     break;
                 }
                 if seen.insert(cand.surface.clone()) {
-                    candidates.push(AnnotatedCandidate {
-                        text: cand.surface,
-                        source: CandidateSource::Dictionary,
-                        reading: None,
-                    });
+                    candidates.push(AnnotatedCandidate::new(
+                        cand.surface,
+                        CandidateSource::Dictionary,
+                    ));
                 }
             }
         }
@@ -324,36 +341,33 @@ impl InputMethodEngine {
         reading: &str,
         num_candidates: usize,
     ) -> Vec<AnnotatedCandidate> {
-        // Ensure kanji converter is initialized
+        // Try to initialize the kanji converter, but don't bail out if it
+        // fails — symbol-only inputs (e.g. `。。。`) don't need the model and
+        // we still want to produce dictionary, rewriter, and fallback candidates.
+        // run_kana_kanji_conversion handles the converter-missing case.
         if self.converters.kanji.is_none()
             && let Err(e) = self.init_kanji_converter()
         {
             debug!("Failed to initialize kanji converter: {}", e);
-            return vec![AnnotatedCandidate {
-                text: reading.to_string(),
-                source: CandidateSource::Fallback,
-                reading: None,
-            }];
         }
 
         let candidates = self.run_kana_kanji_conversion(reading, num_candidates);
 
         let hiragana = reading.to_string();
-        let katakana = Self::hiragana_to_katakana(reading);
+        let katakana = karukan_engine::hiragana_to_katakana(reading);
 
         // Priority: Learning → User Dictionary → Model → System Dictionary → Fallback
         let mut builder = CandidateBuilder::new();
 
-        // 1. Learning cache candidates (highest priority)
+        // 1. Learning cache candidates (highest priority).
+        //    Force-inserted so they win against duplicate text from later sources.
         for c in self.lookup_learning_candidates(reading) {
-            // Force-insert learning candidates (always included even if duplicate text)
-            builder.seen.insert(c.text.clone());
-            builder.candidates.push(AnnotatedCandidate {
-                text: c.text,
-                source: CandidateSource::Learning,
-                // Exact matches have reading == input reading; use None to avoid redundancy
-                reading: c.reading.filter(|r| r != reading),
-            });
+            // Exact matches have reading == input reading; use None to avoid redundancy
+            let cand_reading = c.reading.filter(|r| r != reading);
+            builder.push_force(
+                AnnotatedCandidate::new(c.text, CandidateSource::Learning)
+                    .with_reading(cand_reading),
+            );
         }
 
         // 2. Dictionary candidates (user dict first, then system dict)
@@ -361,31 +375,82 @@ impl InputMethodEngine {
         // Insert user dictionary entries at the top (after learning)
         for ac in &dict_results {
             if ac.source == CandidateSource::UserDictionary {
-                builder.push_annotated_if_new(ac.clone());
+                builder.push(ac.clone());
             }
         }
 
         // 3. Model inference results
         if candidates.is_empty() {
             if builder.is_empty() {
-                builder.push_if_new(hiragana.clone(), CandidateSource::Fallback, None);
+                builder.push(AnnotatedCandidate::new(
+                    hiragana.clone(),
+                    CandidateSource::Fallback,
+                ));
             }
         } else {
             for text in candidates {
-                builder.push_if_new(text, CandidateSource::Model, None);
+                builder.push(AnnotatedCandidate::new(text, CandidateSource::Model));
             }
         }
 
         // 4. System dictionary candidates (from search_dictionaries result)
         for ac in dict_results {
             if ac.source == CandidateSource::Dictionary {
-                builder.push_annotated_if_new(ac);
+                builder.push(ac);
             }
         }
 
         // 5. Append hiragana/katakana fallback if not already present
-        builder.push_if_new(hiragana, CandidateSource::Fallback, None);
-        builder.push_if_new(katakana, CandidateSource::Fallback, None);
+        builder.push(AnnotatedCandidate::new(hiragana, CandidateSource::Fallback));
+        builder.push(AnnotatedCandidate::new(katakana, CandidateSource::Fallback));
+
+        // 6. Run rewriters only on the user's typed input (the reading itself).
+        //    Rewriters express width/punctuation variants of what the user
+        //    *typed* — not of conversion results. Running them on
+        //    dictionary/model/fallback candidates produces unrelated noise
+        //    (e.g. a dictionary entry of `,` for some reading would generate
+        //    `、`, `，` variants the user never asked for; a learning entry
+        //    `アト` pulled by prefix lookup on `あ` would emit `ｱﾄ`).
+        for (variant, description) in self
+            .converters
+            .rewriters
+            .rewrite_all(&[reading.to_string()])
+        {
+            builder.push(
+                AnnotatedCandidate::new(variant, CandidateSource::Rewriter)
+                    .with_description(description),
+            );
+        }
+
+        // 7. Enrich Fallback candidates whose text is a known symbol with
+        //    its description (mirrors the relevant slice of mozc's
+        //    `AddDescForCurrentCandidates`). Restricted to Fallback so the
+        //    AI/Dict/Learning paths don't pick up unwanted labels — e.g.
+        //    the model returning `金` for `きん` should NOT inherit mozc's
+        //    "部首" annotation. Typed-symbol input still gets annotated:
+        //    pressing `「` produces a Fallback candidate `「`, which here
+        //    picks up "始めかぎ括弧".
+        for c in &mut builder.candidates {
+            if c.source == CandidateSource::Fallback
+                && c.description.is_none()
+                && let Some(desc) = karukan_engine::symbol_description(&c.text)
+            {
+                c.description = Some(desc.to_string());
+            }
+        }
+
+        // 8. Attach mozc-style width annotations (`[全]ひらがな`,
+        //    `[全]カタカナ`, `[半]カタカナ`) to any pure-kana candidate that
+        //    still has no description. This catches `あ`/`ア` candidates that
+        //    arrived via the Model or Fallback paths and were deduped against
+        //    the rewriter's already-labelled variants.
+        for c in &mut builder.candidates {
+            if c.description.is_none()
+                && let Some(desc) = width_annotation(&c.text)
+            {
+                c.description = Some(desc.to_string());
+            }
+        }
 
         builder.into_candidates()
     }
@@ -410,8 +475,8 @@ impl InputMethodEngine {
                 candidates.push(Candidate {
                     text: surface,
                     reading: Some(reading.to_string()),
-                    annotation: Some(label.clone()),
-                    index: candidates.len(),
+                    source_label: Some(label.clone()),
+                    description: None,
                 });
             }
         }
@@ -428,8 +493,8 @@ impl InputMethodEngine {
                 candidates.push(Candidate {
                     text: surface,
                     reading: Some(full_reading),
-                    annotation: Some(label.clone()),
-                    index: candidates.len(),
+                    source_label: Some(label.clone()),
+                    description: None,
                 });
             }
         }
@@ -443,12 +508,29 @@ impl InputMethodEngine {
     pub(super) fn lookup_dict_candidates(&self, reading: &str) -> Vec<Candidate> {
         self.search_dictionaries(reading, CandidateList::DEFAULT_PAGE_SIZE)
             .into_iter()
-            .enumerate()
-            .map(|(i, ac)| Candidate {
+            .map(|ac| Candidate {
                 text: ac.text,
                 reading: Some(reading.to_string()),
-                annotation: Some(ac.source.label().to_string()),
-                index: i,
+                source_label: Some(ac.source.label().to_string()),
+                description: None,
+            })
+            .collect()
+    }
+
+    /// Build rule-based rewriter variants for the reading itself (e.g. for
+    /// symbol input `「` → `『`, `【`, `（`, ...). Used in the auto-suggest path
+    /// so users see mozc-style symbol variants without pressing Space first.
+    pub(super) fn lookup_rewriter_variants(&self, reading: &str) -> Vec<Candidate> {
+        let source_label = CandidateSource::Rewriter.label().to_string();
+        self.converters
+            .rewriters
+            .rewrite_all(&[reading.to_string()])
+            .into_iter()
+            .map(|(text, description)| Candidate {
+                text,
+                reading: Some(reading.to_string()),
+                source_label: Some(source_label.clone()),
+                description,
             })
             .collect()
     }

--- a/karukan-im/src/core/engine/display.rs
+++ b/karukan-im/src/core/engine/display.rs
@@ -23,12 +23,12 @@ impl InputMethodEngine {
 
         let katakana = self.input_mode == InputMode::Katakana;
         let display_before = if katakana {
-            Self::hiragana_to_katakana(&before)
+            karukan_engine::hiragana_to_katakana(&before)
         } else {
             before
         };
         let display_after = if katakana {
-            Self::hiragana_to_katakana(&after)
+            karukan_engine::hiragana_to_katakana(&after)
         } else {
             after
         };
@@ -169,7 +169,7 @@ impl InputMethodEngine {
             .unwrap_or_default();
         let source_label = candidates
             .and_then(|c| c.selected())
-            .and_then(|c| c.annotation.as_deref())
+            .and_then(|c| c.source_label.as_deref())
             .filter(|a| !a.is_empty())
             .map(|a| format!(" | {}", a))
             .unwrap_or_default();
@@ -212,11 +212,6 @@ impl InputMethodEngine {
                 indicator, display_reading, ctx, timing, model
             )
         }
-    }
-
-    /// Convert hiragana string to katakana
-    pub(super) fn hiragana_to_katakana(hiragana: &str) -> String {
-        karukan_engine::kana::hiragana_to_katakana(hiragana)
     }
 
     /// Truncate context to safe size for API calls

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -1,14 +1,11 @@
 //! Composing input handling (Empty and Composing states)
 
-use karukan_engine::ConversionEvent;
-
 use super::*;
 
-/// Append candidates to `target`, skipping duplicates and updating indices.
+/// Append candidates to `target`, skipping duplicates by text.
 fn append_candidates_dedup(target: &mut Vec<Candidate>, source: Vec<Candidate>) {
-    for mut c in source {
+    for c in source {
         if !target.iter().any(|existing| existing.text == c.text) {
-            c.index = target.len();
             target.push(c);
         }
     }
@@ -38,12 +35,15 @@ impl InputMethodEngine {
             };
 
         let Some((candidates, reading)) = candidates else {
-            // No useful AI suggestion — still show learning + dictionary candidates
+            // No useful AI suggestion — still show learning + dictionary + rule-based
+            // rewriter variants. The rewriter path produces mozc-style symbol variants
+            // (e.g. `「` → `『`, `【`, ...) for symbol-only inputs where the model is skipped.
             self.live.text.clear();
             let preedit = self.set_composing_state();
             let reading = self.input_buf.text.clone();
             let mut all_candidates = self.lookup_learning_candidates(&reading);
             append_candidates_dedup(&mut all_candidates, self.lookup_dict_candidates(&reading));
+            append_candidates_dedup(&mut all_candidates, self.lookup_rewriter_variants(&reading));
             if all_candidates.is_empty() {
                 return EngineResult::consumed()
                     .with_action(EngineAction::UpdatePreedit(preedit))
@@ -148,19 +148,13 @@ impl InputMethodEngine {
             self.input_buf.insert(&ch.to_string());
         } else {
             let prev_output_len = 0;
-            let event = self.converters.romaji.push(ch);
+            let _event = self.converters.romaji.push(ch);
             let romaji_buffer = self.converters.romaji.buffer().to_string();
 
-            // Check for PassThrough FIRST: the converter adds PassThrough chars
-            // to its output, so we must check the event before checking output emptiness.
-            // Exception: digits should enter Composing so users can type "20世紀" etc.
-            if let ConversionEvent::PassThrough(c) = event
-                && !c.is_ascii_digit()
-            {
-                self.converters.romaji.reset();
-                return EngineResult::consumed().with_action(EngineAction::Commit(c.to_string()));
-            }
-            // For digits, fall through to enter Composing normally
+            // PassThrough chars (no romaji rule, e.g. `'`, `;`, `<`, `(`) used to
+            // auto-commit immediately, but that prevented users from composing
+            // sequences like `「」` or getting symbol variants. Treat them like
+            // digits — let them enter Composing and accumulate in the preedit.
 
             if self.converters.romaji.output().is_empty() && romaji_buffer.is_empty() {
                 return EngineResult::not_consumed();
@@ -269,21 +263,13 @@ impl InputMethodEngine {
         }
 
         let prev_output_len = self.converters.romaji.output().chars().count();
-        let event = self.converters.romaji.push(ch);
+        let _event = self.converters.romaji.push(ch);
         let curr_output_len = self.converters.romaji.output().chars().count();
-        let romaji_buffer = self.converters.romaji.buffer().to_string();
-
-        // Track whether composed_hiragana was empty before processing.
-        // Used to decide if PassThrough chars should auto-commit (standalone punctuation)
-        // or stay in preedit (punctuation after hiragana).
-        let composed_was_empty = self.input_buf.text.is_empty();
 
         // Consume ALL new converter output into composed_hiragana at cursor position.
-        // This must happen BEFORE PassThrough handling because the converter may
-        // recursively pass through multiple chars (e.g., "thx" → output="th", buffer="x",
-        // event=PassThrough('h')), and we need to capture all of them via delta detection.
-        // PassThrough chars are already included in the converter output, so we must NOT
-        // also insert them separately.
+        // The converter may recursively pass through multiple chars (e.g., "thx" →
+        // output="th", buffer="x"), so capture all of them via delta detection.
+        // PassThrough chars are already included in the converter output.
         if curr_output_len > prev_output_len {
             let new_chars: String = self
                 .converters
@@ -295,23 +281,9 @@ impl InputMethodEngine {
             self.input_buf.insert(&new_chars);
         }
 
-        // Handle pass-through: only auto-commit when there was no previous hiragana
-        // (standalone punctuation). If hiragana was already in the preedit, keep the
-        // passthrough chars in composed_hiragana (already inserted by delta detection).
-        // Exception: digits always stay in preedit to allow "20世紀" style input.
-        if let ConversionEvent::PassThrough(c) = event
-            && !c.is_ascii_digit()
-            && composed_was_empty
-            && romaji_buffer.is_empty()
-        {
-            let text = self.input_buf.text.clone();
-            self.input_buf.clear();
-            self.state = InputState::Empty;
-            return EngineResult::consumed()
-                .with_action(EngineAction::UpdatePreedit(Preedit::new()))
-                .with_action(EngineAction::HideAuxText)
-                .with_action(EngineAction::Commit(text));
-        }
+        // PassThrough chars no longer auto-commit. They accumulate in the preedit
+        // alongside hiragana, allowing users to compose `「」`, type `'word'`,
+        // and access symbol variants from the candidate list.
 
         if let Some(result) = self.try_reset_if_empty() {
             return result;
@@ -329,7 +301,7 @@ impl InputMethodEngine {
         let reading = self.input_buf.text.clone();
         let text = if self.input_mode == InputMode::Katakana {
             // Katakana mode always commits katakana, ignoring live conversion
-            Self::hiragana_to_katakana(&reading)
+            karukan_engine::hiragana_to_katakana(&reading)
         } else if !self.live.text.is_empty() {
             // Live conversion active: commit converted text
             self.live.text.clone()

--- a/karukan-im/src/core/engine/mod.rs
+++ b/karukan-im/src/core/engine/mod.rs
@@ -20,7 +20,9 @@ use input_buffer::InputBuffer;
 #[cfg(test)]
 mod tests;
 
-use karukan_engine::{Dictionary, KanaKanjiConverter, LearningCache, RomajiConverter};
+use karukan_engine::{
+    Dictionary, KanaKanjiConverter, LearningCache, RewriterChain, RomajiConverter,
+};
 use tracing::{debug, trace};
 
 use super::candidate::{Candidate, CandidateList};
@@ -38,8 +40,11 @@ enum CandidateSource {
     Learning,
     /// Model inference result
     Model,
-    /// System dictionary lookup
+    /// System dictionary lookup (also covers reading→symbol lookups via
+    /// mozc's symbol.tsv — they're treated as just another dictionary).
     Dictionary,
+    /// Rewriter-generated variant (half-width katakana, symbol)
+    Rewriter,
     /// Hiragana/katakana fallback
     Fallback,
 }
@@ -51,18 +56,48 @@ impl CandidateSource {
             CandidateSource::Learning => "\u{1F4DD} \u{5B66}\u{7FD2}", // 📝 学習
             CandidateSource::Model => "\u{1F916} AI",                  // 🤖 AI
             CandidateSource::Dictionary => "\u{1F4DA} \u{8F9E}\u{66F8}", // 📚 辞書
+            CandidateSource::Rewriter => "\u{1F504} \u{5909}\u{63DB}", // 🔄 変換
             CandidateSource::Fallback => "",
         }
     }
 }
 
-/// A conversion candidate with source annotation
+/// A conversion candidate tagged with its source and an optional description.
+///
+/// Built up internally during candidate construction; later mapped onto the
+/// public `Candidate` (where `source.label()` becomes `source_label` and this
+/// `description` becomes `description`).
 #[derive(Debug, Clone)]
 struct AnnotatedCandidate {
     text: String,
     source: CandidateSource,
     /// Override reading (e.g. from prefix_lookup where the full reading differs from input)
     reading: Option<String>,
+    /// Per-candidate description (e.g. `三点リーダ` for `…`,
+    /// `[全]英大文字` for `ＡＢＣ`). Surfaced as the mozc-style right-side
+    /// comment on the candidate; never contains a source label.
+    description: Option<String>,
+}
+
+impl AnnotatedCandidate {
+    fn new(text: impl Into<String>, source: CandidateSource) -> Self {
+        Self {
+            text: text.into(),
+            source,
+            reading: None,
+            description: None,
+        }
+    }
+
+    fn with_reading(mut self, reading: Option<String>) -> Self {
+        self.reading = reading;
+        self
+    }
+
+    fn with_description(mut self, description: Option<String>) -> Self {
+        self.description = description;
+        self
+    }
 }
 
 /// Resolve a model variant id from settings.
@@ -117,6 +152,7 @@ impl InputMethodEngine {
                 romaji: RomajiConverter::new(),
                 kanji: None,
                 light_kanji: None,
+                rewriters: RewriterChain::default_chain(),
             },
             surrounding_context: None,
             config: EngineConfig::default(),
@@ -228,7 +264,7 @@ impl InputMethodEngine {
     /// Called when leaving Katakana mode so the preedit doesn't revert.
     fn bake_katakana(&mut self) {
         if !self.input_buf.text.is_empty() {
-            self.input_buf.text = karukan_engine::kana::hiragana_to_katakana(&self.input_buf.text);
+            self.input_buf.text = karukan_engine::hiragana_to_katakana(&self.input_buf.text);
         }
     }
 

--- a/karukan-im/src/core/engine/strategy.rs
+++ b/karukan-im/src/core/engine/strategy.rs
@@ -94,7 +94,7 @@ impl InputMethodEngine {
         num_candidates: usize,
     ) -> ConversionStrategy {
         let has_light_model = self.converters.light_kanji.is_some();
-        let katakana = karukan_engine::kana::hiragana_to_katakana(reading);
+        let katakana = karukan_engine::hiragana_to_katakana(reading);
 
         // Count tokens using main model's tokenizer
         let Some(converter) = &self.converters.kanji else {

--- a/karukan-im/src/core/engine/tests/katakana.rs
+++ b/karukan-im/src/core/engine/tests/katakana.rs
@@ -1,34 +1,10 @@
 use super::*;
 
 // --- Katakana Conversion Tests ---
-
-#[test]
-fn test_hiragana_to_katakana() {
-    assert_eq!(
-        InputMethodEngine::hiragana_to_katakana("あいうえお"),
-        "アイウエオ"
-    );
-    assert_eq!(
-        InputMethodEngine::hiragana_to_katakana("かきくけこ"),
-        "カキクケコ"
-    );
-    assert_eq!(
-        InputMethodEngine::hiragana_to_katakana("がぎぐげご"),
-        "ガギグゲゴ"
-    );
-    assert_eq!(
-        InputMethodEngine::hiragana_to_katakana("ぱぴぷぺぽ"),
-        "パピプペポ"
-    );
-    assert_eq!(InputMethodEngine::hiragana_to_katakana("っ"), "ッ");
-    assert_eq!(InputMethodEngine::hiragana_to_katakana("ゃゅょ"), "ャュョ");
-    // Mixed: non-hiragana characters should remain unchanged
-    assert_eq!(
-        InputMethodEngine::hiragana_to_katakana("あいabc"),
-        "アイabc"
-    );
-    assert_eq!(InputMethodEngine::hiragana_to_katakana("テスト"), "テスト"); // Already katakana
-}
+//
+// Pure hiragana→katakana mapping is covered by `karukan_engine::kana` tests;
+// the cases here exercise the IM-side state-machine integration (Ctrl+K
+// switches mode, baking, etc.).
 
 #[test]
 fn test_ctrl_k_converts_to_katakana() {

--- a/karukan-im/src/core/engine/tests/mod.rs
+++ b/karukan-im/src/core/engine/tests/mod.rs
@@ -12,6 +12,7 @@ mod katakana;
 mod live_conversion;
 mod mode_toggle;
 mod passthrough;
+mod rewriter;
 mod strategy;
 mod surrounding;
 

--- a/karukan-im/src/core/engine/tests/passthrough.rs
+++ b/karukan-im/src/core/engine/tests/passthrough.rs
@@ -2,26 +2,48 @@ use super::*;
 
 #[test]
 fn test_passthrough_no_double_counting() {
-    // Regression test: typing '<' twice should produce "<<", not "<<<".
-    // PassThrough chars are added to converter.output() AND returned as
-    // PassThrough events. Without proper handling, both paths insert the char.
+    // Regression test: typing '<' twice should produce "<<" in the preedit,
+    // not "<<<" or "<<<<". The converter adds PassThrough chars to output()
+    // AND returns them as PassThrough events; without proper handling, both
+    // paths would insert the char.
     let mut engine = InputMethodEngine::new();
 
-    // Type '<' (Shift+,) in empty state → should commit directly
-    let result = engine.process_key(&press('<'));
-    let has_commit = result
-        .actions
-        .iter()
-        .any(|a| matches!(a, EngineAction::Commit(text) if text == "<"));
-    assert!(has_commit, "First '<' should commit '<'");
+    // Type '<' from empty state → enters Composing with preedit "<"
+    engine.process_key(&press('<'));
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    assert_eq!(engine.preedit().unwrap().text(), "<");
 
-    // Type '<' again in empty state → should commit directly again
-    let result = engine.process_key(&press('<'));
-    let has_commit = result
-        .actions
-        .iter()
-        .any(|a| matches!(a, EngineAction::Commit(text) if text == "<"));
-    assert!(has_commit, "Second '<' should commit '<'");
+    // Type '<' again → preedit becomes "<<", not "<<<"
+    engine.process_key(&press('<'));
+    assert_eq!(
+        engine.preedit().unwrap().text(),
+        "<<",
+        "Second '<' should produce '<<', not over-count chars"
+    );
+}
+
+#[test]
+fn test_apostrophe_starts_input_mode() {
+    // Regression for: typing `'` in empty state should enter Composing,
+    // not auto-commit. This lets users type `'word'` or get symbol variants.
+    let mut engine = InputMethodEngine::new();
+
+    let result = engine.process_key(&press('\''));
+    assert!(result.consumed);
+    assert!(
+        matches!(engine.state(), InputState::Composing { .. }),
+        "Apostrophe should enter Composing, not auto-commit"
+    );
+    assert_eq!(engine.preedit().unwrap().text(), "'");
+
+    // No Commit action should have fired.
+    assert!(
+        !result
+            .actions
+            .iter()
+            .any(|a| matches!(a, EngineAction::Commit(_))),
+        "First apostrophe should not commit"
+    );
 }
 
 #[test]

--- a/karukan-im/src/core/engine/tests/rewriter.rs
+++ b/karukan-im/src/core/engine/tests/rewriter.rs
@@ -1,0 +1,312 @@
+//! Integration tests for the rewriter chain in conversion candidates.
+//!
+//! No kanji model is loaded — these tests exercise only the rewriter path,
+//! so they verify behaviour that holds independently of model output.
+
+use std::collections::HashSet;
+use std::io::Write;
+
+use karukan_engine::{Dictionary, RewriterChain};
+
+use super::*;
+
+// ---------- helpers ----------
+
+/// Engine in Composing state with the kanji model explicitly disabled.
+fn composing_engine(reading: &str) -> InputMethodEngine {
+    let mut engine = InputMethodEngine::new();
+    engine.input_buf.text = reading.to_string();
+    engine.input_buf.cursor_pos = reading.chars().count();
+    engine.state = InputState::Composing {
+        preedit: Preedit::new(),
+        romaji_buffer: String::new(),
+    };
+    engine.converters.kanji = None;
+    engine
+}
+
+/// Run `build_conversion_candidates` and return just the candidate texts.
+fn conversion_texts(reading: &str) -> Vec<String> {
+    let mut engine = composing_engine(reading);
+    engine
+        .build_conversion_candidates(reading, 9)
+        .into_iter()
+        .map(|c| c.text)
+        .collect()
+}
+
+/// Build a one-entry user dictionary as a temp JSON file and load it.
+fn user_dict_with(reading: &str, surface: &str) -> Dictionary {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    let json = format!(
+        r#"[{{"reading":"{reading}","candidates":[{{"surface":"{surface}","score":1.0}}]}}]"#
+    );
+    tmp.write_all(json.as_bytes()).unwrap();
+    tmp.flush().unwrap();
+    Dictionary::build_from_json(tmp.path()).unwrap()
+}
+
+/// Drive the engine by typing a string of characters.
+fn type_string(engine: &mut InputMethodEngine, s: &str) {
+    for ch in s.chars() {
+        engine.process_key(&press(ch));
+    }
+}
+
+/// Texts in the conversion-state candidate list.
+fn conversion_state_texts(engine: &InputMethodEngine) -> Vec<String> {
+    engine
+        .state()
+        .candidates()
+        .map(|cl| cl.candidates().iter().map(|c| c.text.clone()).collect())
+        .unwrap_or_default()
+}
+
+/// Texts from the most recent ShowCandidates action (auto-suggest path).
+fn auto_suggest_texts(result: &EngineResult) -> Vec<String> {
+    result
+        .actions
+        .iter()
+        .find_map(|a| match a {
+            EngineAction::ShowCandidates(list) => {
+                Some(list.candidates().iter().map(|c| c.text.clone()).collect())
+            }
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+#[track_caller]
+fn assert_contains(texts: &[String], expected: &str) {
+    assert!(
+        texts.iter().any(|t| t == expected),
+        "expected `{expected}` in candidates, got: {texts:?}"
+    );
+}
+
+#[track_caller]
+fn assert_not_contains(texts: &[String], forbidden: &str) {
+    assert!(
+        !texts.iter().any(|t| t == forbidden),
+        "`{forbidden}` should NOT be in candidates, got: {texts:?}"
+    );
+}
+
+// ---------- half-width katakana variants ----------
+
+#[test]
+fn single_hiragana_emits_half_width_katakana() {
+    assert_contains(&conversion_texts("あ"), "ｱ");
+}
+
+#[test]
+fn hiragana_word_emits_half_width_katakana() {
+    assert_contains(&conversion_texts("がっこう"), "ｶﾞｯｺｳ");
+}
+
+#[test]
+fn plain_hiragana_word_is_not_wrapped_in_brackets() {
+    let texts = conversion_texts("あいう");
+    assert_not_contains(&texts, "「あいう」");
+    assert_not_contains(&texts, "【あいう】");
+}
+
+// ---------- symbol variants ----------
+
+#[test]
+fn three_full_stops_emit_ellipsis_without_kanji_model() {
+    // Regression: previously `build_conversion_candidates` early-returned
+    // when init_kanji_converter failed, so symbol-only inputs lost rewriter
+    // variants and `。。。` produced no `…`.
+    assert_contains(&conversion_texts("。。。"), "…");
+}
+
+// ---------- rewriter scope (the headline regression) ----------
+
+#[test]
+fn rewriter_does_not_expand_dictionary_candidates() {
+    // The rewriter must operate ONLY on what the user typed, not on
+    // dictionary/model/fallback candidates derived from it.
+    //
+    // Setup: a user dict entry maps `てすと` → `,` (ASCII comma). The
+    // SymbolRewriter has `,` → [`、`, `，`, `､`]. If the rewriter were
+    // (wrongly) fed dictionary candidates, those three variants would
+    // appear even though the user typed only hiragana.
+    let mut engine = composing_engine("てすと");
+    engine.dicts.user = Some(user_dict_with("てすと", ","));
+
+    let texts: Vec<String> = engine
+        .build_conversion_candidates("てすと", 9)
+        .into_iter()
+        .map(|c| c.text)
+        .collect();
+
+    assert_contains(&texts, ","); // sanity: dict entry survives
+    for forbidden in ["、", "，", "､"] {
+        assert_not_contains(&texts, forbidden);
+    }
+}
+
+#[test]
+fn rewriter_candidates_only_derive_from_user_input() {
+    // Structural invariant: every Rewriter-source candidate must be a
+    // rewrite of the typed reading. Guards against future regressions where
+    // somebody re-introduces rewriting over dictionary/model/fallback entries.
+    let mut engine = composing_engine("あ");
+    let candidates = engine.build_conversion_candidates("あ", 9);
+
+    let allowed: HashSet<String> = RewriterChain::default_chain()
+        .rewrite_all(&["あ".to_string()])
+        .into_iter()
+        .map(|(text, _)| text)
+        .collect();
+
+    for c in &candidates {
+        if c.source == CandidateSource::Rewriter {
+            assert!(
+                allowed.contains(&c.text),
+                "Rewriter candidate `{}` is not a rewrite of input `あ` \
+                 (allowed: {:?})",
+                c.text,
+                allowed
+            );
+        }
+    }
+}
+
+// ---------- alphabet width / case variants ----------
+
+#[test]
+fn alphabet_input_emits_width_and_case_variants() {
+    // Typing `abc` (e.g. in a passthrough or alphabet path) should expand to
+    // the other three canonical forms.
+    let texts = conversion_texts("abc");
+    assert_contains(&texts, "ABC");
+    assert_contains(&texts, "ａｂｃ");
+    assert_contains(&texts, "ＡＢＣ");
+}
+
+#[test]
+fn alphabet_variants_carry_width_case_descriptions() {
+    let mut engine = composing_engine("abc");
+    let candidates = engine.build_conversion_candidates("abc", 9);
+    let upper = candidates.iter().find(|c| c.text == "ABC").unwrap();
+    let full_lower = candidates.iter().find(|c| c.text == "ａｂｃ").unwrap();
+    let full_upper = candidates.iter().find(|c| c.text == "ＡＢＣ").unwrap();
+    assert_eq!(upper.description.as_deref(), Some("[半]英大文字"));
+    assert_eq!(full_lower.description.as_deref(), Some("[全]英小文字"));
+    assert_eq!(full_upper.description.as_deref(), Some("[全]英大文字"));
+}
+
+// ---------- description (per-candidate right-side comment) ----------
+
+/// Find the candidate with text == `text` in the conversion-state list and
+/// return its per-candidate `description` (mozc-style right-side comment).
+fn description_for(engine: &InputMethodEngine, text: &str) -> Option<String> {
+    engine.state().candidates().and_then(|cl| {
+        cl.candidates()
+            .iter()
+            .find(|c| c.text == text)
+            .and_then(|c| c.description.clone())
+    })
+}
+
+#[test]
+fn ellipsis_candidate_carries_three_dot_leader_description() {
+    // When `。。。` expands via the rewriter, `…` should carry mozc's
+    // description "三点リーダ" as its per-candidate description (not
+    // duplicated into the aux text source-label slot).
+    let mut engine = InputMethodEngine::new();
+    type_string(&mut engine, "..");
+    engine.process_key(&press('.'));
+    engine.process_key(&press_key(Keysym::SPACE));
+
+    assert_eq!(
+        description_for(&engine, "…"),
+        Some("三点リーダ".to_string())
+    );
+}
+
+#[test]
+fn typed_symbol_itself_is_annotated_via_global_lookup() {
+    // The user typed `「` itself — it appears as a Fallback candidate
+    // (not from the rewriter). The post-pass enrichment should still attach
+    // mozc's description "始めかぎ括弧" because `「` is a known symbol.
+    let mut engine = composing_engine("「");
+    let candidates = engine.build_conversion_candidates("「", 9);
+
+    let kagi = candidates.iter().find(|c| c.text == "「").unwrap();
+    assert_eq!(
+        kagi.description.as_deref(),
+        Some("始めかぎ括弧"),
+        "Fallback `「` should pick up `始めかぎ括弧` via symbol_description"
+    );
+}
+
+#[test]
+fn kagikakko_reading_emits_paired_brackets_in_conversion() {
+    // End-to-end: typing the reading `かぎかっこ` and pressing Space should
+    // surface `「」` and `『』` in the conversion candidate list (mozc
+    // symbol.tsv via SymbolRewriter).
+    let texts = conversion_texts("かぎかっこ");
+    assert_contains(&texts, "「」");
+    assert_contains(&texts, "『』");
+}
+
+#[test]
+fn katakana_variants_carry_width_form_description() {
+    // mozc-style width annotation: full-width katakana → `[全]カタカナ`,
+    // half-width katakana → `[半]カタカナ`. The hiragana fallback also picks
+    // up `[全]ひらがな` since hiragana is intrinsically full-width.
+    let mut engine = composing_engine("あ");
+    let candidates = engine.build_conversion_candidates("あ", 9);
+
+    let hira = candidates.iter().find(|c| c.text == "あ").unwrap();
+    assert_eq!(
+        hira.description.as_deref(),
+        Some("[全]ひらがな"),
+        "hiragana fallback `あ` should be annotated as `[全]ひらがな`",
+    );
+
+    let full = candidates.iter().find(|c| c.text == "ア").unwrap();
+    assert_eq!(
+        full.description.as_deref(),
+        Some("[全]カタカナ"),
+        "full-width katakana variant `ア` should be annotated as `[全]カタカナ`",
+    );
+
+    let half = candidates.iter().find(|c| c.text == "ｱ").unwrap();
+    assert_eq!(
+        half.description.as_deref(),
+        Some("[半]カタカナ"),
+        "half-width katakana variant `ｱ` should be annotated as `[半]カタカナ`",
+    );
+}
+
+// ---------- end-to-end key flow ----------
+
+#[test]
+fn typing_three_dots_emits_ellipsis_in_auto_suggest_and_conversion() {
+    // Regression: typing `.` `.` `.` should populate `。。。` and surface `…`
+    // both in the auto-suggest list (before Space) and in the conversion
+    // candidate list (after Space).
+    let mut engine = InputMethodEngine::new();
+    type_string(&mut engine, "..");
+    let final_result = engine.process_key(&press('.'));
+    assert_eq!(engine.input_buf.text, "。。。");
+
+    assert_contains(&auto_suggest_texts(&final_result), "…");
+
+    engine.process_key(&press_key(Keysym::SPACE));
+    assert_contains(&conversion_state_texts(&engine), "…");
+}
+
+#[test]
+fn typing_a_then_space_emits_half_width_katakana() {
+    let mut engine = InputMethodEngine::new();
+    type_string(&mut engine, "a");
+
+    let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(result.consumed);
+    assert_contains(&conversion_state_texts(&engine), "ｱ");
+}

--- a/karukan-im/src/core/engine/types.rs
+++ b/karukan-im/src/core/engine/types.rs
@@ -1,6 +1,6 @@
 //! Type definitions for the IME engine
 
-use karukan_engine::{Dictionary, KanaKanjiConverter, RomajiConverter};
+use karukan_engine::{Dictionary, KanaKanjiConverter, RewriterChain, RomajiConverter};
 
 use crate::config::settings::StrategyMode;
 
@@ -105,6 +105,8 @@ pub(in crate::core) struct Converters {
     pub kanji: Option<KanaKanjiConverter>,
     /// Light model for beam search
     pub light_kanji: Option<KanaKanjiConverter>,
+    /// Candidate rewriters (half-width katakana, symbol variants)
+    pub rewriters: RewriterChain,
 }
 
 /// Input mode for the IME engine

--- a/karukan-im/src/ffi/mod.rs
+++ b/karukan-im/src/ffi/mod.rs
@@ -73,7 +73,10 @@ struct PreeditCache {
 #[derive(Default)]
 struct CandidateCache {
     texts: Vec<CString>,
-    annotations: Vec<CString>,
+    /// Per-candidate descriptions, already wrapped in `[...]` and ready
+    /// to be passed to fcitx5 `setComment`. Empty string when the candidate
+    /// has no description.
+    descriptions: Vec<CString>,
     count: usize,
     cursor: usize,
     dirty: bool,
@@ -175,11 +178,21 @@ impl KarukanEngine {
                         .iter()
                         .filter_map(|c| CString::new(c.text.as_str()).ok())
                         .collect();
-                    self.candidates.annotations = page
+                    // Per-candidate `description` powers the mozc-style
+                    // right-side comment. Source labels live in the aux
+                    // text (via `Candidate.source_label`), so here we only
+                    // surface the description and wrap it in `[…]` so it's
+                    // visually distinct from the candidate text itself.
+                    self.candidates.descriptions = page
                         .iter()
                         .map(|c| {
-                            let ann = c.annotation.as_deref().unwrap_or("");
-                            CString::new(ann).unwrap_or_default()
+                            let formatted = c
+                                .description
+                                .as_deref()
+                                .filter(|s| !s.is_empty())
+                                .map(|s| format!("[{}]", s))
+                                .unwrap_or_default();
+                            CString::new(formatted).unwrap_or_default()
                         })
                         .collect();
                     self.candidates.count = self.candidates.texts.len();

--- a/karukan-im/src/ffi/query.rs
+++ b/karukan-im/src/ffi/query.rs
@@ -92,17 +92,21 @@ pub extern "C" fn karukan_engine_get_candidate(
         .unwrap_or(ptr::null())
 }
 
-/// Get a candidate annotation (comment) by index
-/// Returns a pointer to a null-terminated UTF-8 string, or null if index is out of range
+/// Get the per-candidate description (mozc-style right-side comment) by index.
+///
+/// Returns a `[…]`-wrapped UTF-8 string suitable for fcitx5 `setComment`,
+/// or an empty string when the candidate has no description. Source labels
+/// (`🤖 AI`, `📚 辞書`, ...) are surfaced via the aux text instead, not here.
+/// Returns null if the index is out of range.
 #[unsafe(no_mangle)]
-pub extern "C" fn karukan_engine_get_candidate_annotation(
+pub extern "C" fn karukan_engine_get_candidate_description(
     engine: *const KarukanEngine,
     index: c_uint,
 ) -> *const c_char {
     let engine = ffi_ref!(engine, ptr::null());
     engine
         .candidates
-        .annotations
+        .descriptions
         .get(index as usize)
         .map(|c| c.as_ptr())
         .unwrap_or(ptr::null())


### PR DESCRIPTION
## Summary

候補リストに全角・半角・大文字小文字・記号バリアントを自動生成するRewriterシステムを追加。

### 主な変更

- **Rewriterモジュール** (`karukan-engine/src/rewriter/`)
  - `HalfWidthKatakanaRewriter`: ひらがな/カタカナ → 半角カタカナ変換（例: `がっこう` → `ｶﾞｯｺｳ`）
  - `AlphabetRewriter`: 英字の全角/半角・大文字/小文字バリアント生成（例: `abc` → `ABC`, `ａｂｃ`, `ＡＢＣ`）
  - `SymbolRewriter`: Mozc由来の記号変換チェーン（例: `「` → `『`, `【`, `（` など）と読み→記号候補の展開
- **全角/半角変換関数** (`karukan-engine/src/kana.rs`): `katakana_to_half_width`, `ascii_to_fullwidth_char` など8関数を追加
- **候補のdescriptionフィールド**: `Candidate` に `description` を追加し、Mozc風の注釈（`[半]英小文字`, `三点リーダ` など）をfcitx5の候補コメントとして表示
- **fcitx5互換性**: `CandidateWord::setComment` を `#ifdef` ガードし、fcitx5 < 5.1.9では候補テキストにdescriptionを付加するフォールバック実装
- **`[全]`/`[半]` 幅アノテーション**: ひらがな/カタカナ候補に `[全]ひらがな` `[全]カタカナ` `[半]カタカナ` のMozc風ラベルを付与

### Mozcデータの利用について

`karukan-engine/data/*` には [Mozc](https://github.com/google/mozc) から派生したデータを含みます（今後も拡充予定）。Mozcのライセンス（BSD 3-Clause）および著作権表記は [THIRD_PARTY_LICENSES](https://github.com/togatoga/karukan/blob/add-full-half-patterns/THIRD_PARTY_LICENSES) を参照してください。

### 設計方針

- Rewriterはユーザー入力（reading）にのみ適用し、辞書/モデル候補には適用しない（ノイズ防止）
- 候補の優先順位: 学習 → ユーザー辞書 → モデル → システム辞書 → フォールバック → Rewriter
- `source_label`（`🤖 AI` / `📚 辞書`）と `description`（`[全]英大文字`）を分離し、UI上で重複しない設計
