### PR TITLE
Skip learning cache on Tab conversion

### DIFF
--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -189,7 +189,10 @@ impl InputMethodEngine {
     /// transitions into the Conversion state. The previous live-conversion
     /// result is preserved as the first model candidate so the user sees
     /// the same text they had been looking at during input.
-    pub(super) fn start_conversion(&mut self) -> EngineResult {
+    ///
+    /// `skip_learning` is set by the Tab path to omit learning-cache
+    /// candidates (Space/Down keep the default learning-included behavior).
+    pub(super) fn start_conversion(&mut self, skip_learning: bool) -> EngineResult {
         // Flush any remaining romaji into composed_hiragana
         self.flush_romaji_to_composed();
 
@@ -208,7 +211,8 @@ impl InputMethodEngine {
         }
 
         // Get candidates from kanji converter (use full num_candidates for explicit conversion)
-        let mut candidates = self.build_conversion_candidates(&reading, self.config.num_candidates);
+        let mut candidates =
+            self.build_conversion_candidates(&reading, self.config.num_candidates, skip_learning);
 
         // If the previous auto-suggest result is not in the new candidates, insert it at the top
         // so it doesn't disappear when the conversion strategy changes.
@@ -336,10 +340,15 @@ impl InputMethodEngine {
     /// count for performance.
     ///
     /// Priority: Learning → User Dictionary → Model → System Dictionary → Fallback
+    ///
+    /// `skip_learning` suppresses the learning-cache step (1). Used by the Tab
+    /// key path so users can escape a noisy learning history without losing
+    /// access to dictionary/model candidates.
     pub(super) fn build_conversion_candidates(
         &mut self,
         reading: &str,
         num_candidates: usize,
+        skip_learning: bool,
     ) -> Vec<AnnotatedCandidate> {
         // Try to initialize the kanji converter, but don't bail out if it
         // fails — symbol-only inputs (e.g. `。。。`) don't need the model and
@@ -361,13 +370,16 @@ impl InputMethodEngine {
 
         // 1. Learning cache candidates (highest priority).
         //    Force-inserted so they win against duplicate text from later sources.
-        for c in self.lookup_learning_candidates(reading) {
-            // Exact matches have reading == input reading; use None to avoid redundancy
-            let cand_reading = c.reading.filter(|r| r != reading);
-            builder.push_force(
-                AnnotatedCandidate::new(c.text, CandidateSource::Learning)
-                    .with_reading(cand_reading),
-            );
+        //    Skipped when the caller asks for a learning-free conversion (Tab key).
+        if !skip_learning {
+            for c in self.lookup_learning_candidates(reading) {
+                // Exact matches have reading == input reading; use None to avoid redundancy
+                let cand_reading = c.reading.filter(|r| r != reading);
+                builder.push_force(
+                    AnnotatedCandidate::new(c.text, CandidateSource::Learning)
+                        .with_reading(cand_reading),
+                );
+            }
         }
 
         // 2. Dictionary candidates (user dict first, then system dict)

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -218,7 +218,11 @@ impl InputMethodEngine {
             Keysym::BACKSPACE => self.backspace_composing(),
             Keysym::DELETE => self.delete_composing(),
             Keysym::SPACE if self.input_mode == InputMode::Alphabet => self.input_char(' '),
-            Keysym::SPACE | Keysym::DOWN | Keysym::TAB => self.start_conversion(),
+            // Tab triggers conversion that bypasses the learning cache, so users
+            // can escape stale or unwanted learned entries (mozc binds Tab to a
+            // different conversion path — PredictAndConvert — in the same spirit).
+            Keysym::TAB => self.start_conversion(true),
+            Keysym::SPACE | Keysym::DOWN => self.start_conversion(false),
             Keysym::LEFT => self.move_caret_left(),
             Keysym::RIGHT => self.move_caret_right(),
             Keysym::HOME => self.move_caret_home(),

--- a/karukan-im/src/core/engine/tests/learning.rs
+++ b/karukan-im/src/core/engine/tests/learning.rs
@@ -1,0 +1,111 @@
+//! Tests for the learning cache and the Tab-skips-learning behavior.
+//!
+//! Space/Down: include learning candidates (default conversion).
+//! Tab: skip learning candidates (lets users escape stale learned entries).
+
+use karukan_engine::LearningCache;
+
+use super::*;
+
+/// Engine seeded with a learning entry `reading → surface`, no kanji model.
+/// We bypass `init.rs` (which gates learning on settings + file I/O) and just
+/// inject a populated `LearningCache` directly — these tests assert the
+/// build_conversion_candidates branching, not the load path.
+fn engine_with_learned(reading: &str, surface: &str) -> InputMethodEngine {
+    let mut engine = InputMethodEngine::new();
+    engine.converters.kanji = None;
+    let mut cache = LearningCache::new(100);
+    cache.record(reading, surface);
+    engine.learning = Some(cache);
+    engine
+}
+
+#[test]
+fn build_candidates_includes_learning_when_not_skipped() {
+    let mut engine = engine_with_learned("あい", "藍");
+
+    let texts: Vec<String> = engine
+        .build_conversion_candidates("あい", 9, false)
+        .into_iter()
+        .map(|c| c.text)
+        .collect();
+
+    assert!(
+        texts.contains(&"藍".to_string()),
+        "Space path (skip_learning=false) should surface learned `藍`, got {:?}",
+        texts,
+    );
+}
+
+#[test]
+fn build_candidates_omits_learning_when_skipped() {
+    let mut engine = engine_with_learned("あい", "藍");
+
+    let texts: Vec<String> = engine
+        .build_conversion_candidates("あい", 9, true)
+        .into_iter()
+        .map(|c| c.text)
+        .collect();
+
+    assert!(
+        !texts.contains(&"藍".to_string()),
+        "Tab path (skip_learning=true) must drop learned `藍`, got {:?}",
+        texts,
+    );
+}
+
+#[test]
+fn tab_key_skips_learning_in_composing() {
+    // End-to-end: type the reading, press Tab → learned candidate is gone.
+    let mut engine = engine_with_learned("あい", "藍");
+
+    engine.process_key(&press('a'));
+    engine.process_key(&press('i'));
+    assert_eq!(engine.input_buf.text, "あい");
+
+    let result = engine.process_key(&press_key(Keysym::TAB));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+
+    let texts: Vec<String> = engine
+        .state()
+        .candidates()
+        .unwrap()
+        .candidates()
+        .iter()
+        .map(|c| c.text.clone())
+        .collect();
+    assert!(
+        !texts.contains(&"藍".to_string()),
+        "Tab must skip the learned `藍` candidate, got {:?}",
+        texts,
+    );
+}
+
+#[test]
+fn space_key_keeps_learning_in_composing() {
+    // Counterpart to tab_key_skips_learning_in_composing: Space stays on the
+    // learning-included path so the default UX is unchanged.
+    let mut engine = engine_with_learned("あい", "藍");
+
+    engine.process_key(&press('a'));
+    engine.process_key(&press('i'));
+
+    let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+
+    let texts: Vec<String> = engine
+        .state()
+        .candidates()
+        .unwrap()
+        .candidates()
+        .iter()
+        .map(|c| c.text.clone())
+        .collect();
+    assert!(
+        texts.contains(&"藍".to_string()),
+        "Space must surface learned `藍`, got {:?}",
+        texts,
+    );
+}

--- a/karukan-im/src/core/engine/tests/mod.rs
+++ b/karukan-im/src/core/engine/tests/mod.rs
@@ -9,6 +9,7 @@ mod candidates;
 mod conversion;
 mod cursor;
 mod katakana;
+mod learning;
 mod live_conversion;
 mod mode_toggle;
 mod passthrough;

--- a/karukan-im/src/core/engine/tests/rewriter.rs
+++ b/karukan-im/src/core/engine/tests/rewriter.rs
@@ -29,7 +29,7 @@ fn composing_engine(reading: &str) -> InputMethodEngine {
 fn conversion_texts(reading: &str) -> Vec<String> {
     let mut engine = composing_engine(reading);
     engine
-        .build_conversion_candidates(reading, 9)
+        .build_conversion_candidates(reading, 9, false)
         .into_iter()
         .map(|c| c.text)
         .collect()
@@ -136,7 +136,7 @@ fn rewriter_does_not_expand_dictionary_candidates() {
     engine.dicts.user = Some(user_dict_with("てすと", ","));
 
     let texts: Vec<String> = engine
-        .build_conversion_candidates("てすと", 9)
+        .build_conversion_candidates("てすと", 9, false)
         .into_iter()
         .map(|c| c.text)
         .collect();
@@ -153,7 +153,7 @@ fn rewriter_candidates_only_derive_from_user_input() {
     // rewrite of the typed reading. Guards against future regressions where
     // somebody re-introduces rewriting over dictionary/model/fallback entries.
     let mut engine = composing_engine("あ");
-    let candidates = engine.build_conversion_candidates("あ", 9);
+    let candidates = engine.build_conversion_candidates("あ", 9, false);
 
     let allowed: HashSet<String> = RewriterChain::default_chain()
         .rewrite_all(&["あ".to_string()])
@@ -189,7 +189,7 @@ fn alphabet_input_emits_width_and_case_variants() {
 #[test]
 fn alphabet_variants_carry_width_case_descriptions() {
     let mut engine = composing_engine("abc");
-    let candidates = engine.build_conversion_candidates("abc", 9);
+    let candidates = engine.build_conversion_candidates("abc", 9, false);
     let upper = candidates.iter().find(|c| c.text == "ABC").unwrap();
     let full_lower = candidates.iter().find(|c| c.text == "ａｂｃ").unwrap();
     let full_upper = candidates.iter().find(|c| c.text == "ＡＢＣ").unwrap();
@@ -233,7 +233,7 @@ fn typed_symbol_itself_is_annotated_via_global_lookup() {
     // (not from the rewriter). The post-pass enrichment should still attach
     // mozc's description "始めかぎ括弧" because `「` is a known symbol.
     let mut engine = composing_engine("「");
-    let candidates = engine.build_conversion_candidates("「", 9);
+    let candidates = engine.build_conversion_candidates("「", 9, false);
 
     let kagi = candidates.iter().find(|c| c.text == "「").unwrap();
     assert_eq!(
@@ -259,7 +259,7 @@ fn katakana_variants_carry_width_form_description() {
     // half-width katakana → `[半]カタカナ`. The hiragana fallback also picks
     // up `[全]ひらがな` since hiragana is intrinsically full-width.
     let mut engine = composing_engine("あ");
-    let candidates = engine.build_conversion_candidates("あ", 9);
+    let candidates = engine.build_conversion_candidates("あ", 9, false);
 
     let hira = candidates.iter().find(|c| c.text == "あ").unwrap();
     assert_eq!(


### PR DESCRIPTION
## Summary

Composing 状態で **Space と Tab を別々の変換経路** にしました。Mozc が `Space=Convert` / `Tab=PredictAndConvert` と分けているのに倣い、karukan-im では:

- **Space / Down**: 従来どおり学習キャッシュを含めた変換（デフォルト挙動を維持）
- **Tab**: 学習キャッシュを **スキップ** する変換 — 学習履歴が荒れた／不要な候補を出してくる時に逃げ道になる

Conversion 状態（候補表示中）の Tab は引き続き `next_candidate()` のままです。Mozc 同様、一度始まった変換セッションの途中で学習方針を切り替えないのが整合的なため。

## 設計判断

- 学習エントリ自体は編集しないので、Tab で変換 → Return 確定すると通常どおり `record_learning()` で学習に記録されます。「**一時的に**学習を回避したい」というユースケースを想定。
- 候補生成の優先順位 Learning → User Dict → Model → System Dict → Fallback → Rewriter は維持。`build_conversion_candidates` の step 1 だけを `skip_learning` フラグでガードする最小変更。

## 変更点

| File | What |
|---|---|
| `karukan-im/src/core/engine/conversion.rs` | `build_conversion_candidates` / `start_conversion` に `skip_learning: bool` を追加 |
| `karukan-im/src/core/engine/input.rs` | `process_key_composing` で Tab と Space/Down を別分岐に |
| `karukan-im/src/core/engine/tests/learning.rs`（新規） | Tab/Space の挙動分岐のユニットテスト 4 件 |
| `tests/{mod.rs, rewriter.rs}` | 新シグネチャに追従 |

## Test plan

- [x] `cargo test -p karukan-im` — 167 tests pass（新規 4 件含む）
- [x] `cargo clippy -p karukan-im --tests` — クリーン
- [x] `cargo fmt -p karukan-im --check` — クリーン
- [ ] fcitx5 上で実機確認: 学習済みの読み（例 `あい→藍` を記録後）で
  - Space を押すと `藍` が候補に出ること
  - Tab を押すと `藍` が候補から消えること
  - Tab で別候補を確定した後、その確定が学習に記録されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)