### PR TITLE
Drop redundant #[serde(default)] on strategy field

### DIFF
--- a/karukan-im/src/config/settings.rs
+++ b/karukan-im/src/config/settings.rs
@@ -40,7 +40,6 @@ pub enum StrategyMode {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversionSettings {
     /// Conversion strategy mode (adaptive, light, main)
-    #[serde(default)]
     pub strategy: StrategyMode,
     /// Number of candidates to show on Space conversion
     pub num_candidates: usize,


### PR DESCRIPTION
## Summary
- `ConversionSettings::strategy` に付いていた `#[serde(default)]` を削除しました。
- `parse_with_defaults` (`karukan-im/src/config/settings.rs:104-110`) が user TOML を埋め込み済みの `DEFAULT_CONFIG_TOML` にマージしてから deserialize するため、deserialize 時点では `strategy` フィールドが必ず埋まっており、フィールド単位の serde default は dead code でした。
- 同じ理由で他のフィールド（`use_context`, `max_context_length` など）にも serde default は付いていません。PR #25 で `live_conversion` を消したのと完全に同じ症状です。

## Test plan
- [x] `cargo test -p karukan-im --lib`（170 件 pass、`test_strategy_default_when_unspecified` がマージ経由で従来通り `Adaptive` を返すことを確認）
- [x] `cargo clippy -p karukan-im --lib` クリーン
- [x] `cargo fmt --all -- --check` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)