### PR TITLE
Restore pre-emoji mode on exit instead of forcing Hiragana

### DIFF
--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -662,9 +662,7 @@ impl InputMethodEngine {
 
         self.state = InputState::Empty;
         self.input_buf.text.clear();
-        if self.input_mode == InputMode::Emoji {
-            self.input_mode = InputMode::Hiragana;
-        }
+        self.exit_emoji_mode();
 
         EngineResult::consumed()
             .with_action(EngineAction::UpdatePreedit(Preedit::new()))
@@ -687,9 +685,7 @@ impl InputMethodEngine {
 
         self.state = InputState::Empty;
         self.input_buf.text.clear();
-        if self.input_mode == InputMode::Emoji {
-            self.input_mode = InputMode::Hiragana;
-        }
+        self.exit_emoji_mode();
 
         // Start new input with the character
         let new_input_result = self.start_input(ch);

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -289,6 +289,13 @@ impl InputMethodEngine {
         self.converters.romaji.reset();
         self.input_buf.clear();
         self.live.text.clear();
+        // Remember where the user was so commit/cancel/erase-to-empty
+        // can drop them back into the same mode (e.g. Katakana stays
+        // Katakana). Guard against clobbering on re-entry just in case
+        // start_emoji_mode is ever called while already in Emoji mode.
+        if self.input_mode != InputMode::Emoji {
+            self.pre_emoji_mode = Some(self.input_mode);
+        }
         self.input_mode = InputMode::Emoji;
         self.input_buf.insert(":");
         self.refresh_input_state()
@@ -387,9 +394,7 @@ impl InputMethodEngine {
         self.input_buf.clear();
         self.live.text.clear();
         self.state = InputState::Empty;
-        if self.input_mode == InputMode::Emoji {
-            self.input_mode = InputMode::Hiragana;
-        }
+        self.exit_emoji_mode();
 
         EngineResult::consumed()
             .with_action(EngineAction::UpdatePreedit(Preedit::new()))
@@ -428,12 +433,10 @@ impl InputMethodEngine {
         self.input_buf.clear();
         self.live.text.clear();
         self.state = InputState::Empty;
-        // Emoji mode is per-session: leaving it returns the user to the
-        // default Hiragana behavior so their next word doesn't unexpectedly
-        // stay in ASCII-passthrough mode.
-        if self.input_mode == InputMode::Emoji {
-            self.input_mode = InputMode::Hiragana;
-        }
+        // Emoji mode is per-session: leaving it returns the user to
+        // whatever mode they were in before typing `:` so their next
+        // word doesn't unexpectedly stay in ASCII-passthrough mode.
+        self.exit_emoji_mode();
 
         let mut result = EngineResult::consumed()
             .with_action(EngineAction::UpdatePreedit(Preedit::new()))

--- a/karukan-im/src/core/engine/mod.rs
+++ b/karukan-im/src/core/engine/mod.rs
@@ -133,6 +133,11 @@ pub struct InputMethodEngine {
     metrics: ConversionMetrics,
     /// Current input mode (Hiragana, Katakana, or Alphabet)
     input_mode: InputMode,
+    /// Mode active immediately before entering [`InputMode::Emoji`],
+    /// so commit/cancel/backspace-to-empty can put the user back where
+    /// they were instead of dropping them in Hiragana every time. `None`
+    /// whenever the current mode is not Emoji.
+    pre_emoji_mode: Option<InputMode>,
     /// Composed input buffer (hiragana text, cursor position)
     input_buf: InputBuffer,
     /// Live conversion state
@@ -158,6 +163,7 @@ impl InputMethodEngine {
             config: EngineConfig::default(),
             metrics: ConversionMetrics::default(),
             input_mode: InputMode::Hiragana,
+            pre_emoji_mode: None,
             input_buf: InputBuffer::new(),
             live: LiveConversion::default(),
             dicts: Dictionaries::default(),
@@ -227,9 +233,21 @@ impl InputMethodEngine {
         self.state = InputState::Empty;
         self.converters.romaji.reset();
         self.input_mode = InputMode::Hiragana;
+        self.pre_emoji_mode = None;
         self.input_buf.clear();
         self.live.text.clear();
         self.metrics = ConversionMetrics::default();
+    }
+
+    /// If currently in Emoji mode, restore the mode the user was in
+    /// before they typed `:`. Falls back to Hiragana if nothing was
+    /// saved (defensive — `start_emoji_mode` always sets it). No-op
+    /// when not in Emoji mode, so it's safe to call unconditionally
+    /// from the various exit sites.
+    pub(super) fn exit_emoji_mode(&mut self) {
+        if self.input_mode == InputMode::Emoji {
+            self.input_mode = self.pre_emoji_mode.take().unwrap_or(InputMode::Hiragana);
+        }
     }
 
     /// If the display is empty, reset to Empty state and return the result.
@@ -238,6 +256,13 @@ impl InputMethodEngine {
         if self.build_input_display().is_empty() {
             self.state = InputState::Empty;
             self.input_buf.clear();
+            // Emoji mode is per-session and bound to the typed `:` —
+            // if the user erased back to an empty buffer, the session
+            // is over. Restore whatever mode the user was in before
+            // entering Emoji so the next keypress doesn't get treated
+            // as a literal emoji-query char (and so a Katakana-mode user
+            // lands back in Katakana, not Hiragana).
+            self.exit_emoji_mode();
             Some(
                 EngineResult::consumed()
                     .with_action(EngineAction::UpdatePreedit(Preedit::new()))

--- a/karukan-im/src/core/engine/tests/emoji.rs
+++ b/karukan-im/src/core/engine/tests/emoji.rs
@@ -261,6 +261,82 @@ fn typing_kiniku_surfaces_muscle_via_silent_n() {
 }
 
 #[test]
+fn backspacing_to_empty_exits_emoji_mode() {
+    // Regression: deleting back through the leading `:` left the
+    // engine in Emoji mode even though the buffer was empty. The
+    // next typed char would then be inserted literally (e.g. `a`
+    // staying as `a` instead of romaji-converting to `あ`) and the
+    // aux text would keep showing `[☺]`. After erasing back to
+    // empty, the session is over and the mode should drop back to
+    // Hiragana.
+    let mut engine = InputMethodEngine::new();
+    engine.process_key(&press_colon());
+    for ch in ['s', 'm', 'i', 'l', 'e'] {
+        engine.process_key(&press(ch));
+    }
+    assert_eq!(engine.input_mode, InputMode::Emoji);
+
+    for _ in 0..6 {
+        engine.process_key(&press_key(Keysym::BACKSPACE));
+    }
+    assert!(matches!(engine.state(), InputState::Empty));
+    assert_eq!(engine.input_mode, InputMode::Hiragana);
+
+    // And the very next keypress should behave like normal kana
+    // input — `a` becomes `あ`, not literal `a`.
+    engine.process_key(&press('a'));
+    assert_eq!(engine.preedit().unwrap().text(), "あ");
+}
+
+#[test]
+fn backspacing_to_empty_restores_pre_emoji_katakana_mode() {
+    // Same exit path as the empty-backspace case, but verifies the
+    // pre-emoji mode is *restored* rather than forced back to Hiragana.
+    // A user typing in Katakana who pops into emoji and bails out
+    // should land back in Katakana.
+    let mut engine = InputMethodEngine::new();
+    engine.input_mode = InputMode::Katakana;
+
+    engine.process_key(&press_colon());
+    assert_eq!(engine.input_mode, InputMode::Emoji);
+    for ch in ['s', 'm', 'i', 'l', 'e'] {
+        engine.process_key(&press(ch));
+    }
+
+    for _ in 0..6 {
+        engine.process_key(&press_key(Keysym::BACKSPACE));
+    }
+    assert!(matches!(engine.state(), InputState::Empty));
+    assert_eq!(engine.input_mode, InputMode::Katakana);
+}
+
+#[test]
+fn commit_emoji_restores_pre_emoji_katakana_mode() {
+    let mut engine = InputMethodEngine::new();
+    engine.input_mode = InputMode::Katakana;
+
+    engine.process_key(&press_colon());
+    for ch in ['s', 'm', 'i', 'l', 'e'] {
+        engine.process_key(&press(ch));
+    }
+    engine.process_key(&press_key(Keysym::RETURN));
+    assert_eq!(engine.input_mode, InputMode::Katakana);
+}
+
+#[test]
+fn escape_emoji_restores_pre_emoji_katakana_mode() {
+    let mut engine = InputMethodEngine::new();
+    engine.input_mode = InputMode::Katakana;
+
+    engine.process_key(&press_colon());
+    for ch in ['s', 'm', 'i', 'l', 'e'] {
+        engine.process_key(&press(ch));
+    }
+    engine.process_key(&press_key(Keysym::ESCAPE));
+    assert_eq!(engine.input_mode, InputMode::Katakana);
+}
+
+#[test]
 fn colon_in_hiragana_does_not_enter_emoji_when_already_composing() {
     // A `:` typed in the middle of an existing hiragana composition is
     // just punctuation, not an emoji trigger — emoji mode only starts


### PR DESCRIPTION
## Summary

絵文字モードの実装で2つの問題があったので修正しました:

1. **空文字に戻しても Emoji モードが解除されない** — `:smile` を全部 backspace で消すと `state` は Empty に戻る一方 `input_mode` は `Emoji` のまま残り、次に打った `a` がローマ字変換されずリテラルで挿入されたり、aux text に `[☺]` が表示され続けたりしていました。
2. **退出時は常に Hiragana に戻されていた** — カタカナモードで `:` を打って絵文字モードに入った場合でも、コミット/Esc/空文字バックスペースのいずれの経路でも強制的に Hiragana に戻されていました。

修正方針として、`:` を打って絵文字モードへ入る瞬間の `input_mode` を新フィールド `pre_emoji_mode: Option<InputMode>` に保存し、退出時はそれを復元するようにしました。退出処理は新ヘルパー `exit_emoji_mode()` に集約して、`commit_composing` / `cancel_composing` / `try_reset_if_empty` / `commit_conversion` / `commit_conversion_and_continue` の5箇所から呼ぶよう統一しています。

## Test plan

- [x] `cargo test --workspace` — 全 185 件パス
- [x] `cargo clippy --workspace` — 警告なし
- [x] 既存の絵文字テスト 12 件パス（既存の「常に Hiragana に戻す」アサーションは「絵文字モード前は Hiragana だった」ケースなのでそのまま通る）
- [x] 新規回帰テスト 3 件:
  - `backspacing_to_empty_restores_pre_emoji_katakana_mode` — Katakana から `:smile` → 全 backspace で Katakana へ復帰
  - `commit_emoji_restores_pre_emoji_katakana_mode` — Katakana から `:smile` → Enter で Katakana へ復帰
  - `escape_emoji_restores_pre_emoji_katakana_mode` — Katakana から `:smile` → Esc で Katakana へ復帰
- [x] 直前コミットで追加した `backspacing_to_empty_exits_emoji_mode`（空文字に戻しても次の `a` が `あ` になることを確認）も継続してパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)