### PR TITLE
Commit full-width space on bare Space from Empty in Hiragana

### DIFF
--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -114,6 +114,18 @@ impl InputMethodEngine {
                 .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()));
         }
 
+        // Plain Space from Empty state: don't intercept. Without this
+        // guard the key falls into the printable-char path below, where
+        // the romaji converter has no rule for ' ' and pass-throughs it
+        // into a Composing session whose preedit is a single half-width
+        // space — a useless state the user then has to Escape/Enter out
+        // of. The full-width space gesture is `Ctrl+Space` (above); a
+        // plain space with no composition in progress should just reach
+        // the application as a normal ASCII space.
+        if key.keysym == Keysym::SPACE && !key.modifiers.control_key && !key.modifiers.alt_key {
+            return EngineResult::not_consumed();
+        }
+
         // `:` from Empty state enters emoji shortcode mode — `:pien` stays
         // as `:pien` literally (no romaji conversion) while emoji candidates
         // are surfaced via the rewriter. The mode auto-exits back to Hiragana

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -103,34 +103,27 @@ impl InputMethodEngine {
 
     /// Process key in empty state
     pub(super) fn process_key_empty(&mut self, key: &KeyEvent, shift_active: bool) -> EngineResult {
-        // Ctrl+Space: start input with full-width space, regardless of mode.
-        // Kept as an explicit "always full-width" shortcut even for users who
-        // are in Alphabet mode and want to insert a `　`.
+        // Ctrl+Space: start input with full-width space
         if key.modifiers.control_key && key.keysym == Keysym::SPACE {
-            return self.start_input_with_fullwidth_space();
+            self.converters.romaji.reset();
+            self.input_buf.clear();
+            self.input_buf.insert("\u{3000}");
+            let preedit = self.set_composing_state();
+            return EngineResult::consumed()
+                .with_action(EngineAction::UpdatePreedit(preedit))
+                .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()));
         }
 
-        // Bare Space from Empty state — mozc-compatible behavior:
-        //
-        // * Kana modes (Hiragana / Katakana) → insert a full-width space
-        //   `　` and enter Composing. Matches mozc's default
-        //   `space_character_form = FUNDAMENTAL_INPUT_MODE`, which the
-        //   typical Japanese IME user expects.
-        // * Alphabet mode → return `not_consumed` so the OS delivers a
-        //   normal half-width ASCII space to the application. The user is
-        //   typing ASCII; injecting `　` here would be wrong.
-        //
-        // Without this guard the key used to fall into the printable-char
-        // path below, where the romaji converter has no rule for ' ' and
-        // pass-throughs it into a Composing session whose preedit was a
-        // single half-width space — a useless state the user then had to
-        // Escape/Enter out of.
+        // Plain Space from Empty state: don't intercept. Without this
+        // guard the key falls into the printable-char path below, where
+        // the romaji converter has no rule for ' ' and pass-throughs it
+        // into a Composing session whose preedit is a single half-width
+        // space — a useless state the user then has to Escape/Enter out
+        // of. The full-width space gesture is `Ctrl+Space` (above); a
+        // plain space with no composition in progress should just reach
+        // the application as a normal ASCII space.
         if key.keysym == Keysym::SPACE && !key.modifiers.control_key && !key.modifiers.alt_key {
-            return if matches!(self.input_mode, InputMode::Hiragana | InputMode::Katakana) {
-                self.start_input_with_fullwidth_space()
-            } else {
-                EngineResult::not_consumed()
-            };
+            return EngineResult::not_consumed();
         }
 
         // `:` from Empty state enters emoji shortcode mode — `:pien` stays
@@ -216,19 +209,6 @@ impl InputMethodEngine {
 
         let preedit = self.set_composing_state();
 
-        EngineResult::consumed()
-            .with_action(EngineAction::UpdatePreedit(preedit))
-            .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()))
-    }
-
-    /// Start a fresh Composing session seeded with a single full-width
-    /// space (U+3000). Used both by `Ctrl+Space` from Empty (any mode)
-    /// and by a bare Space from Empty in kana modes.
-    fn start_input_with_fullwidth_space(&mut self) -> EngineResult {
-        self.converters.romaji.reset();
-        self.input_buf.clear();
-        self.input_buf.insert("\u{3000}");
-        let preedit = self.set_composing_state();
         EngineResult::consumed()
             .with_action(EngineAction::UpdatePreedit(preedit))
             .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()))

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -103,27 +103,34 @@ impl InputMethodEngine {
 
     /// Process key in empty state
     pub(super) fn process_key_empty(&mut self, key: &KeyEvent, shift_active: bool) -> EngineResult {
-        // Ctrl+Space: start input with full-width space
+        // Ctrl+Space: start input with full-width space, regardless of mode.
+        // Kept as an explicit "always full-width" shortcut even for users who
+        // are in Alphabet mode and want to insert a `　`.
         if key.modifiers.control_key && key.keysym == Keysym::SPACE {
-            self.converters.romaji.reset();
-            self.input_buf.clear();
-            self.input_buf.insert("\u{3000}");
-            let preedit = self.set_composing_state();
-            return EngineResult::consumed()
-                .with_action(EngineAction::UpdatePreedit(preedit))
-                .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()));
+            return self.start_input_with_fullwidth_space();
         }
 
-        // Plain Space from Empty state: don't intercept. Without this
-        // guard the key falls into the printable-char path below, where
-        // the romaji converter has no rule for ' ' and pass-throughs it
-        // into a Composing session whose preedit is a single half-width
-        // space — a useless state the user then has to Escape/Enter out
-        // of. The full-width space gesture is `Ctrl+Space` (above); a
-        // plain space with no composition in progress should just reach
-        // the application as a normal ASCII space.
+        // Bare Space from Empty state — mozc-compatible behavior:
+        //
+        // * Kana modes (Hiragana / Katakana) → insert a full-width space
+        //   `　` and enter Composing. Matches mozc's default
+        //   `space_character_form = FUNDAMENTAL_INPUT_MODE`, which the
+        //   typical Japanese IME user expects.
+        // * Alphabet mode → return `not_consumed` so the OS delivers a
+        //   normal half-width ASCII space to the application. The user is
+        //   typing ASCII; injecting `　` here would be wrong.
+        //
+        // Without this guard the key used to fall into the printable-char
+        // path below, where the romaji converter has no rule for ' ' and
+        // pass-throughs it into a Composing session whose preedit was a
+        // single half-width space — a useless state the user then had to
+        // Escape/Enter out of.
         if key.keysym == Keysym::SPACE && !key.modifiers.control_key && !key.modifiers.alt_key {
-            return EngineResult::not_consumed();
+            return if matches!(self.input_mode, InputMode::Hiragana | InputMode::Katakana) {
+                self.start_input_with_fullwidth_space()
+            } else {
+                EngineResult::not_consumed()
+            };
         }
 
         // `:` from Empty state enters emoji shortcode mode — `:pien` stays
@@ -209,6 +216,19 @@ impl InputMethodEngine {
 
         let preedit = self.set_composing_state();
 
+        EngineResult::consumed()
+            .with_action(EngineAction::UpdatePreedit(preedit))
+            .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()))
+    }
+
+    /// Start a fresh Composing session seeded with a single full-width
+    /// space (U+3000). Used both by `Ctrl+Space` from Empty (any mode)
+    /// and by a bare Space from Empty in kana modes.
+    fn start_input_with_fullwidth_space(&mut self) -> EngineResult {
+        self.converters.romaji.reset();
+        self.input_buf.clear();
+        self.input_buf.insert("\u{3000}");
+        let preedit = self.set_composing_state();
         EngineResult::consumed()
             .with_action(EngineAction::UpdatePreedit(preedit))
             .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()))

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -114,16 +114,27 @@ impl InputMethodEngine {
                 .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()));
         }
 
-        // Plain Space from Empty state: don't intercept. Without this
-        // guard the key falls into the printable-char path below, where
-        // the romaji converter has no rule for ' ' and pass-throughs it
-        // into a Composing session whose preedit is a single half-width
-        // space — a useless state the user then has to Escape/Enter out
-        // of. The full-width space gesture is `Ctrl+Space` (above); a
-        // plain space with no composition in progress should just reach
-        // the application as a normal ASCII space.
+        // Bare Space from Empty state:
+        //
+        // * Hiragana mode → commit a full-width `　` directly, matching
+        //   the Japanese-IME convention. We deliberately do NOT enter
+        //   Composing here: if we did, the next Space the user typed
+        //   would be interpreted by `process_key_composing` as the
+        //   conversion trigger and an unwanted candidate window would
+        //   appear after two spaces in a row.
+        // * Any other mode → return `not_consumed` so the OS delivers
+        //   a normal half-width ASCII space to the application. The
+        //   user is either typing ASCII (Alphabet) or in an edge mode
+        //   (Katakana / Emoji) where injecting `　` would be wrong.
+        //
+        // The full-width space gesture from Empty in any mode is
+        // `Ctrl+Space` (above), which seeds a Composing session.
         if key.keysym == Keysym::SPACE && !key.modifiers.control_key && !key.modifiers.alt_key {
-            return EngineResult::not_consumed();
+            return if self.input_mode == InputMode::Hiragana {
+                EngineResult::consumed().with_action(EngineAction::Commit("\u{3000}".to_string()))
+            } else {
+                EngineResult::not_consumed()
+            };
         }
 
         // `:` from Empty state enters emoji shortcode mode — `:pien` stays

--- a/karukan-im/src/core/engine/tests/basic.rs
+++ b/karukan-im/src/core/engine/tests/basic.rs
@@ -59,46 +59,19 @@ fn test_engine_backspace() {
 }
 
 #[test]
-fn space_in_empty_hiragana_inserts_fullwidth_space() {
+fn space_in_empty_state_passes_through() {
     // Regression: pressing Space with no composition in progress used
-    // to enter Composing with a literal *half-width* space as the
-    // preedit (the romaji converter PassThrough'd ' ' into input_buf).
-    // mozc-compat behavior is to insert a *full-width* `　` and enter
-    // Composing in kana modes — the typical Japanese-IME expectation.
+    // to enter Composing with a single half-width space as the preedit
+    // (the romaji converter PassThrough'd ' ' into input_buf). The
+    // user then had to Escape or Enter to recover. The IME should not
+    // intercept a bare Space when there's nothing being composed —
+    // let it reach the application as a normal ASCII space. The
+    // full-width space gesture remains Ctrl+Space.
     let mut engine = InputMethodEngine::new();
-    assert_eq!(engine.input_mode, InputMode::Hiragana);
-
-    let result = engine.process_key(&press_key(Keysym::SPACE));
-    assert!(result.consumed);
-    assert!(matches!(engine.state(), InputState::Composing { .. }));
-    assert_eq!(engine.preedit().unwrap().text(), "\u{3000}");
-}
-
-#[test]
-fn space_in_empty_katakana_inserts_fullwidth_space() {
-    // Katakana is a kana mode too — same full-width behavior as
-    // Hiragana when Space is pressed from Empty.
-    let mut engine = InputMethodEngine::new();
-    engine.input_mode = InputMode::Katakana;
-
-    let result = engine.process_key(&press_key(Keysym::SPACE));
-    assert!(result.consumed);
-    assert!(matches!(engine.state(), InputState::Composing { .. }));
-    assert_eq!(engine.preedit().unwrap().text(), "\u{3000}");
-}
-
-#[test]
-fn space_in_empty_alphabet_passes_through() {
-    // In Alphabet mode the user is typing ASCII — injecting `　` would
-    // be wrong. Return not_consumed so the OS delivers a normal
-    // half-width space to the application.
-    let mut engine = InputMethodEngine::new();
-    engine.input_mode = InputMode::Alphabet;
-
     let result = engine.process_key(&press_key(Keysym::SPACE));
     assert!(
         !result.consumed,
-        "Space in Empty+Alphabet should not be consumed"
+        "Space in Empty state should not be consumed"
     );
     assert!(matches!(engine.state(), InputState::Empty));
     assert!(
@@ -110,9 +83,9 @@ fn space_in_empty_alphabet_passes_through() {
 
 #[test]
 fn space_after_composing_starts_still_triggers_conversion() {
-    // Sanity check that the Empty-state change doesn't affect
-    // Composing-state behavior: Space inside an existing composition
-    // still acts as the conversion trigger.
+    // Sanity check that the Empty-state pass-through doesn't change
+    // the Composing-state behavior: Space inside an existing
+    // composition still acts as the conversion trigger.
     let mut engine = InputMethodEngine::new();
     engine.process_key(&press('a'));
     assert_eq!(engine.preedit().unwrap().text(), "あ");

--- a/karukan-im/src/core/engine/tests/basic.rs
+++ b/karukan-im/src/core/engine/tests/basic.rs
@@ -59,19 +59,46 @@ fn test_engine_backspace() {
 }
 
 #[test]
-fn space_in_empty_state_passes_through() {
+fn space_in_empty_hiragana_inserts_fullwidth_space() {
     // Regression: pressing Space with no composition in progress used
-    // to enter Composing with a single half-width space as the preedit
-    // (the romaji converter PassThrough'd ' ' into input_buf). The
-    // user then had to Escape or Enter to recover. The IME should not
-    // intercept a bare Space when there's nothing being composed —
-    // let it reach the application as a normal ASCII space. The
-    // full-width space gesture remains Ctrl+Space.
+    // to enter Composing with a literal *half-width* space as the
+    // preedit (the romaji converter PassThrough'd ' ' into input_buf).
+    // mozc-compat behavior is to insert a *full-width* `　` and enter
+    // Composing in kana modes — the typical Japanese-IME expectation.
     let mut engine = InputMethodEngine::new();
+    assert_eq!(engine.input_mode, InputMode::Hiragana);
+
+    let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    assert_eq!(engine.preedit().unwrap().text(), "\u{3000}");
+}
+
+#[test]
+fn space_in_empty_katakana_inserts_fullwidth_space() {
+    // Katakana is a kana mode too — same full-width behavior as
+    // Hiragana when Space is pressed from Empty.
+    let mut engine = InputMethodEngine::new();
+    engine.input_mode = InputMode::Katakana;
+
+    let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    assert_eq!(engine.preedit().unwrap().text(), "\u{3000}");
+}
+
+#[test]
+fn space_in_empty_alphabet_passes_through() {
+    // In Alphabet mode the user is typing ASCII — injecting `　` would
+    // be wrong. Return not_consumed so the OS delivers a normal
+    // half-width space to the application.
+    let mut engine = InputMethodEngine::new();
+    engine.input_mode = InputMode::Alphabet;
+
     let result = engine.process_key(&press_key(Keysym::SPACE));
     assert!(
         !result.consumed,
-        "Space in Empty state should not be consumed"
+        "Space in Empty+Alphabet should not be consumed"
     );
     assert!(matches!(engine.state(), InputState::Empty));
     assert!(
@@ -83,9 +110,9 @@ fn space_in_empty_state_passes_through() {
 
 #[test]
 fn space_after_composing_starts_still_triggers_conversion() {
-    // Sanity check that the Empty-state pass-through doesn't change
-    // the Composing-state behavior: Space inside an existing
-    // composition still acts as the conversion trigger.
+    // Sanity check that the Empty-state change doesn't affect
+    // Composing-state behavior: Space inside an existing composition
+    // still acts as the conversion trigger.
     let mut engine = InputMethodEngine::new();
     engine.process_key(&press('a'));
     assert_eq!(engine.preedit().unwrap().text(), "あ");

--- a/karukan-im/src/core/engine/tests/basic.rs
+++ b/karukan-im/src/core/engine/tests/basic.rs
@@ -59,6 +59,43 @@ fn test_engine_backspace() {
 }
 
 #[test]
+fn space_in_empty_state_passes_through() {
+    // Regression: pressing Space with no composition in progress used
+    // to enter Composing with a single half-width space as the preedit
+    // (the romaji converter PassThrough'd ' ' into input_buf). The
+    // user then had to Escape or Enter to recover. The IME should not
+    // intercept a bare Space when there's nothing being composed —
+    // let it reach the application as a normal ASCII space. The
+    // full-width space gesture remains Ctrl+Space.
+    let mut engine = InputMethodEngine::new();
+    let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(
+        !result.consumed,
+        "Space in Empty state should not be consumed"
+    );
+    assert!(matches!(engine.state(), InputState::Empty));
+    assert!(
+        result.actions.is_empty(),
+        "expected no actions, got {:?}",
+        result.actions
+    );
+}
+
+#[test]
+fn space_after_composing_starts_still_triggers_conversion() {
+    // Sanity check that the Empty-state pass-through doesn't change
+    // the Composing-state behavior: Space inside an existing
+    // composition still acts as the conversion trigger.
+    let mut engine = InputMethodEngine::new();
+    engine.process_key(&press('a'));
+    assert_eq!(engine.preedit().unwrap().text(), "あ");
+
+    let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+}
+
+#[test]
 fn test_engine_cancel() {
     let mut engine = InputMethodEngine::new();
 

--- a/karukan-im/src/core/engine/tests/basic.rs
+++ b/karukan-im/src/core/engine/tests/basic.rs
@@ -59,20 +59,65 @@ fn test_engine_backspace() {
 }
 
 #[test]
-fn space_in_empty_state_passes_through() {
-    // Regression: pressing Space with no composition in progress used
-    // to enter Composing with a single half-width space as the preedit
-    // (the romaji converter PassThrough'd ' ' into input_buf). The
-    // user then had to Escape or Enter to recover. The IME should not
-    // intercept a bare Space when there's nothing being composed —
-    // let it reach the application as a normal ASCII space. The
-    // full-width space gesture remains Ctrl+Space.
+fn space_in_empty_hiragana_commits_fullwidth_space() {
+    // Bare Space from Empty in Hiragana mode commits a full-width `　`
+    // directly without entering Composing — the Japanese-IME
+    // convention, but without the side effect of "second Space starts
+    // Conversion mode" that a Composing-state insertion would cause.
     let mut engine = InputMethodEngine::new();
+    assert_eq!(engine.input_mode, InputMode::Hiragana);
+
     let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(result.consumed);
+    assert!(matches!(engine.state(), InputState::Empty));
+    let committed = result.actions.iter().find_map(|a| match a {
+        EngineAction::Commit(t) => Some(t.clone()),
+        _ => None,
+    });
+    assert_eq!(committed.as_deref(), Some("\u{3000}"));
+}
+
+#[test]
+fn double_space_in_empty_hiragana_commits_two_fullwidth_spaces() {
+    // Regression for the conversion-mode-on-second-Space issue: two
+    // consecutive Spaces from Empty must produce two committed `　`s,
+    // never enter Composing, and never trigger Conversion.
+    let mut engine = InputMethodEngine::new();
+    for _ in 0..2 {
+        let result = engine.process_key(&press_key(Keysym::SPACE));
+        assert!(matches!(engine.state(), InputState::Empty));
+        let committed = result.actions.iter().find_map(|a| match a {
+            EngineAction::Commit(t) => Some(t.clone()),
+            _ => None,
+        });
+        assert_eq!(committed.as_deref(), Some("\u{3000}"));
+    }
+}
+
+#[test]
+fn space_in_empty_katakana_passes_through() {
+    // Non-Hiragana modes pass the bare Space through to the OS so the
+    // application gets a normal half-width ASCII space.
+    let mut engine = InputMethodEngine::new();
+    engine.input_mode = InputMode::Katakana;
+
+    let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(!result.consumed);
+    assert!(matches!(engine.state(), InputState::Empty));
     assert!(
-        !result.consumed,
-        "Space in Empty state should not be consumed"
+        result.actions.is_empty(),
+        "expected no actions, got {:?}",
+        result.actions
     );
+}
+
+#[test]
+fn space_in_empty_alphabet_passes_through() {
+    let mut engine = InputMethodEngine::new();
+    engine.input_mode = InputMode::Alphabet;
+
+    let result = engine.process_key(&press_key(Keysym::SPACE));
+    assert!(!result.consumed);
     assert!(matches!(engine.state(), InputState::Empty));
     assert!(
         result.actions.is_empty(),
@@ -83,9 +128,9 @@ fn space_in_empty_state_passes_through() {
 
 #[test]
 fn space_after_composing_starts_still_triggers_conversion() {
-    // Sanity check that the Empty-state pass-through doesn't change
-    // the Composing-state behavior: Space inside an existing
-    // composition still acts as the conversion trigger.
+    // Sanity check that the Empty-state change doesn't affect
+    // Composing-state behavior: Space inside an existing composition
+    // still acts as the conversion trigger.
     let mut engine = InputMethodEngine::new();
     engine.process_key(&press('a'));
     assert_eq!(engine.preedit().unwrap().text(), "あ");


### PR DESCRIPTION
## Summary

無入力 (Empty) 状態で素のスペースを押すと、IME がキーを消費して半角スペース1個だけが preedit に入った無意味な `Composing` 状態に遷移していました。`process_key_empty` が Ctrl+Space と `:` 以外を全部汎用の printable-char パスに流していたため、ローマ字コンバータがスペースのルールを持たず `PassThrough(' ')` で `input_buf` に挿入していたのが原因です。ユーザは Escape か Enter でその状態から抜ける必要がありました。

修正後の挙動:

| 状態 / 修飾キー | キー | 修正前 | 修正後 |
|---|---|---|---|
| Empty + Hiragana | Space | 半角スペース1個で Composing 入り (バグ) | **全角スペース `　` を直接 commit（Empty 維持）** |
| Empty + Katakana / Alphabet / Emoji | Space | 半角スペース1個で Composing 入り (バグ) | `not_consumed` で OS にパススルー → アプリに通常の半角スペース |
| Empty | Ctrl+Space | 全角スペース `　` を挿入して Composing 入り | 変更なし（明示的な Composing 入りショートカット） |
| Composing 中 | Space | 変換トリガー | 変更なし |
| Composing 中 (Alphabet) | Space | 半角スペースを literal 挿入 | 変更なし |
| Composing 中 | Ctrl+Space | カーソル位置に全角スペース挿入 | 変更なし |
| Conversion 中 | Space | 次候補 | 変更なし |

### なぜ commit して Composing に入らないか

Hiragana モードで `　` を「Composing 入り」させると、続けて Space を押したときに `process_key_composing` が変換トリガーとして解釈してしまい、ユーザが意図せず変換候補ウィンドウを開くことになります。Composing を経由せず直接 commit することで:

- 「Space 2連打 → 変換モード起動」のリグレッションを防ぐ
- 1文字目スペースで Empty → Composing → Conversion と段階を踏まない素直な挙動

mozc も `PRECOMPOSITION` (= Empty) で `InsertSpaceHalfWidth` が `EchoBack`（`consumed = false`）を返してパススルーする実装 (`session.cc:1646-1672`) になっており、無入力時は composition を作らない方針です。karukan はそれを Hiragana モードでは全角コミット、それ以外ではパススルーに割って実装しています。

## Test plan

- [x] `cargo test --workspace` — 全 186 件パス（新規4件含む）
- [x] `cargo clippy --workspace` — 警告なし
- [x] `cargo fmt --all --check` — 整形済み
- [x] 新規回帰テスト:
  - `space_in_empty_hiragana_commits_fullwidth_space` — Hiragana + Empty + Space → `Commit("　")`、状態は Empty 維持
  - `double_space_in_empty_hiragana_commits_two_fullwidth_spaces` — Space 2連打でも一切 Composing/Conversion に入らず `　` 2回 commit
  - `space_in_empty_katakana_passes_through` — Katakana + Empty + Space → `not_consumed`
  - `space_in_empty_alphabet_passes_through` — Alphabet + Empty + Space → `not_consumed`
  - `space_after_composing_starts_still_triggers_conversion` — Composing 中の Space は引き続き変換トリガー
- [x] 既存の `test_ctrl_space_inserts_fullwidth_space_in_empty` 等の Ctrl+Space テストもパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
