### PR TITLE
英数モードでもバッファにかなが残っていればライブ変換を継続する

### DIFF
--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -14,25 +14,36 @@ fn append_candidates_dedup(target: &mut Vec<Candidate>, source: Vec<Candidate>) 
 impl InputMethodEngine {
     /// Refresh the input state: rebuild preedit and run auto-suggest for candidates.
     pub(super) fn refresh_input_state(&mut self) -> EngineResult {
-        // Alphabet mode with active live conversion: preserve the conversion display
-        if self.input_mode == InputMode::Alphabet && !self.live.text.is_empty() {
+        // Alphabet mode with active live conversion but no kana left to convert:
+        // preserve the existing conversion display without re-running the model.
+        // (When the buffer still contains kana we fall through and reconvert below,
+        // so a mixed reading like `きょうはABC` keeps live-converting.)
+        if self.input_mode == InputMode::Alphabet
+            && !self.live.text.is_empty()
+            && !karukan_engine::contains_kana(&self.input_buf.text)
+        {
             let preedit = self.set_composing_state();
             return EngineResult::consumed().with_action(EngineAction::UpdatePreedit(preedit));
         }
 
-        // Run auto-suggest (skip in alphabet mode — no hiragana to convert)
-        let candidates =
-            if self.input_mode != InputMode::Alphabet && !self.input_buf.text.is_empty() {
-                let reading = self.input_buf.text.clone();
-                let result = self.run_auto_suggest(&reading, 1);
-                if !result.is_empty() && result[0] != self.input_buf.text {
-                    Some((result, reading))
-                } else {
-                    None
-                }
+        // Run auto-suggest. Normally skipped in alphabet mode (raw latin has no
+        // hiragana to convert), but if the buffer still contains kana — e.g. the
+        // user typed hiragana, switched to alphabet mode, and kept typing — keep
+        // converting the mixed reading so live conversion stays alive.
+        let convert = !self.input_buf.text.is_empty()
+            && (self.input_mode != InputMode::Alphabet
+                || karukan_engine::contains_kana(&self.input_buf.text));
+        let candidates = if convert {
+            let reading = self.input_buf.text.clone();
+            let result = self.run_auto_suggest(&reading, 1);
+            if !result.is_empty() && result[0] != self.input_buf.text {
+                Some((result, reading))
             } else {
                 None
-            };
+            }
+        } else {
+            None
+        };
 
         let Some((candidates, reading)) = candidates else {
             // No useful AI suggestion — still show learning + dictionary + rule-based

--- a/karukan-im/src/core/engine/tests/live_conversion.rs
+++ b/karukan-im/src/core/engine/tests/live_conversion.rs
@@ -172,6 +172,54 @@ fn test_live_conversion_build_preedit() {
     assert_eq!(preedit.caret(), 2); // 漢字 = 2 chars
 }
 
+#[test]
+fn test_alphabet_mode_with_kana_keeps_converting() {
+    // Live conversion must stay alive in alphabet mode as long as the buffer
+    // still contains kana. Type hiragana, switch to alphabet mode, keep typing:
+    // the mixed reading (e.g. `あAb`) must keep being reconverted instead of
+    // freezing at a stale live.text.
+    let mut engine = make_live_conversion_engine();
+
+    // "あ" then Shift+letter switches into alphabet mode -> buffer "あA"
+    engine.process_key(&press('a'));
+    engine.process_key(&press_shift('A'));
+    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(karukan_engine::contains_kana(&engine.input_buf.text));
+
+    // Simulate a previous live conversion result lingering on screen.
+    engine.live.text = "亜A".to_string();
+
+    // Typing another latin char re-runs refresh_input_state. Because the buffer
+    // still has kana, the "preserve display" early-return is bypassed and
+    // conversion runs again; with no model loaded run_auto_suggest returns the
+    // reading itself, so live.text is cleared rather than frozen.
+    engine.process_key(&press('b'));
+    assert!(
+        engine.live.text.is_empty(),
+        "mixed kana buffer must reconvert in alphabet mode, not preserve stale live.text"
+    );
+}
+
+#[test]
+fn test_alphabet_mode_pure_latin_preserves_live_text() {
+    // Regression guard for the original behavior: with no kana in the buffer,
+    // alphabet mode preserves an existing live.text display without re-running
+    // conversion (raw latin has nothing for the model to convert).
+    let mut engine = make_live_conversion_engine();
+
+    // Enter alphabet mode with pure latin "Ab".
+    engine.process_key(&press_shift('A'));
+    engine.process_key(&press('b'));
+    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(!karukan_engine::contains_kana(&engine.input_buf.text));
+
+    engine.live.text = "AB".to_string();
+
+    // Another latin char keeps the preserved live.text (no reconversion).
+    engine.process_key(&press('c'));
+    assert_eq!(engine.live.text, "AB");
+}
+
 // --- Ctrl+Space full-width space tests ---
 
 #[test]


### PR DESCRIPTION
## 概要

英数モード（`InputMode::Alphabet`）に入るとライブ変換が一律で解除される問題を修正します。バッファにまだかな（ひらがな/カタカナ）が残っている場合は、英数モードでもライブ変換を継続するようにしました。

例:「きょうは」をライブ変換中に Shift+英字 で英数モードへ入り「ABC」を打つと、バッファは `きょうはABC`。これまではこの時点でライブ変換が解除されていましたが、本変更で `今日はABC` のように変換し続けます。

## 変更内容

`karukan-im/src/core/engine/input.rs` の `refresh_input_state` にある、英数モードでライブ変換／auto-suggest を止めていた2つのゲートを、既存の `karukan_engine::contains_kana` を使って緩和しました。

- **auto-suggest スキップ条件**: 英数モードでもバッファにかなを含む場合は混在 reading を変換する。純 latin（`ABC` など）は従来どおりスキップ。
- **「表示だけ保持」early-return**: かなが残っている間は早期 return せず再変換に流す。純 latin で `live.text` が残る既存ケースは従来どおり保持。

コミット時に `live.text`（変換後テキスト）を確定する既存ロジックはそのまま機能します。

## テスト

`tests/live_conversion.rs` に2件追加:

- `test_alphabet_mode_with_kana_keeps_converting` — 混在バッファで再変換が走ること
- `test_alphabet_mode_pure_latin_preserves_live_text` — 純 latin では従来の保持挙動が維持されること（リグレッションガード）

`cargo test -p karukan-im` 全184件パス、`cargo fmt` / `cargo clippy` クリーン。

## 補足

ゲート変更は live・非live 両方の auto-suggest に効くため、ライブ変換 OFF でも英数モードでバッファにかなを含むと候補ウィンドウが出ます。かなを含む場合のみ発火するため純 latin 入力には影響しません。「ライブ変換 ON のときだけ」に限定したい場合は `live.enabled` でさらに絞れます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)