### PR TITLE
fix(engine): Shift英字入力を一時モード化して確定後に自動でかなへ復帰 (#37)

### DIFF
--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -652,6 +652,7 @@ impl InputMethodEngine {
         self.state = InputState::Empty;
         self.input_buf.text.clear();
         self.exit_emoji_mode();
+        self.exit_alphabet_mode();
 
         EngineResult::consumed()
             .with_action(EngineAction::UpdatePreedit(Preedit::new()))
@@ -675,6 +676,7 @@ impl InputMethodEngine {
         self.state = InputState::Empty;
         self.input_buf.text.clear();
         self.exit_emoji_mode();
+        self.exit_alphabet_mode();
 
         // Start new input with the character
         let new_input_result = self.start_input(ch);

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -186,6 +186,10 @@ impl InputMethodEngine {
                 ch.is_ascii_uppercase() || (shift_active && ch.is_ascii_alphabetic());
 
             if is_shift_alpha && self.input_mode != InputMode::Alphabet {
+                // Remember the mode to restore when this word is committed:
+                // Shift-alphabet is a temporary per-word mode, not a sticky
+                // toggle, so the next word returns to kana (issue #37).
+                self.pre_alphabet_mode = Some(self.input_mode);
                 self.input_mode = InputMode::Alphabet;
             }
             let ch = if self.input_mode == InputMode::Alphabet && is_shift_alpha {
@@ -298,6 +302,10 @@ impl InputMethodEngine {
                         ch.is_ascii_uppercase() || (shift_active && ch.is_ascii_alphabetic());
 
                     if is_shift_alpha && self.input_mode != InputMode::Alphabet {
+                        // Remember the mode to restore on commit/cancel:
+                        // Shift-alphabet is a temporary per-word mode, so the
+                        // next word returns to the prior mode (issue #37).
+                        self.pre_alphabet_mode = Some(self.input_mode);
                         // Bake katakana before switching so preedit doesn't revert
                         if self.input_mode == InputMode::Katakana {
                             self.bake_katakana();
@@ -438,6 +446,9 @@ impl InputMethodEngine {
         self.chunks.clear();
         self.state = InputState::Empty;
         self.exit_emoji_mode();
+        // Shift-alphabet is temporary: committing the word returns to the
+        // prior mode (Hiragana), so the next word is converted again (#37).
+        self.exit_alphabet_mode();
 
         // HideCandidates is required here: the auto-suggest/live-conversion
         // window may be open while Composing, and the macOS frontend's
@@ -486,6 +497,9 @@ impl InputMethodEngine {
         // whatever mode they were in before typing `:` so their next
         // word doesn't unexpectedly stay in ASCII-passthrough mode.
         self.exit_emoji_mode();
+        // Same for Shift-triggered Alphabet mode: cancelling restores the
+        // prior mode so the next word is back in kana (#37).
+        self.exit_alphabet_mode();
 
         let mut result = EngineResult::consumed()
             .with_action(EngineAction::UpdatePreedit(Preedit::new()))

--- a/karukan-im/src/core/engine/mod.rs
+++ b/karukan-im/src/core/engine/mod.rs
@@ -139,6 +139,13 @@ pub struct InputMethodEngine {
     /// they were instead of dropping them in Hiragana every time. `None`
     /// whenever the current mode is not Emoji.
     pre_emoji_mode: Option<InputMode>,
+    /// Mode active immediately before Shift+letter switched to
+    /// [`InputMode::Alphabet`]. Alphabet is a *temporary* per-composition
+    /// mode: commit/cancel/backspace-to-empty restores this mode so the next
+    /// word goes back to kana automatically, matching the macOS/Google IME
+    /// convention (the Shift gesture is per-word, not a sticky toggle). `None`
+    /// whenever the current mode is not Alphabet.
+    pre_alphabet_mode: Option<InputMode>,
     /// Composed input buffer (hiragana text, cursor position)
     input_buf: InputBuffer,
     /// Live conversion state
@@ -171,6 +178,7 @@ impl InputMethodEngine {
             metrics: ConversionMetrics::default(),
             input_mode: InputMode::Hiragana,
             pre_emoji_mode: None,
+            pre_alphabet_mode: None,
             input_buf: InputBuffer::new(),
             live: LiveConversion::default(),
             chunks: Vec::new(),
@@ -244,6 +252,7 @@ impl InputMethodEngine {
         self.converters.romaji.reset();
         self.input_mode = InputMode::Hiragana;
         self.pre_emoji_mode = None;
+        self.pre_alphabet_mode = None;
         self.input_buf.clear();
         self.live.text.clear();
         self.chunks.clear();
@@ -258,6 +267,21 @@ impl InputMethodEngine {
     pub(super) fn exit_emoji_mode(&mut self) {
         if self.input_mode == InputMode::Emoji {
             self.input_mode = self.pre_emoji_mode.take().unwrap_or(InputMode::Hiragana);
+        }
+    }
+
+    /// If currently in Alphabet mode, restore the mode the user was in before
+    /// Shift+letter switched to it. Falls back to Hiragana if nothing was
+    /// saved. No-op when not in Alphabet mode, so it's safe to call
+    /// unconditionally from the commit/cancel/erase-to-empty exit sites.
+    ///
+    /// This is what makes Shift-triggered alphabet input *temporary*: once the
+    /// word is committed (or abandoned), the next word returns to kana without
+    /// an explicit toggle key — the behavior US-layout users expect, since
+    /// they have no JIS かな key to switch back with (issue #37).
+    pub(super) fn exit_alphabet_mode(&mut self) {
+        if self.input_mode == InputMode::Alphabet {
+            self.input_mode = self.pre_alphabet_mode.take().unwrap_or(InputMode::Hiragana);
         }
     }
 
@@ -281,6 +305,9 @@ impl InputMethodEngine {
             // as a literal emoji-query char (and so a Katakana-mode user
             // lands back in Katakana, not Hiragana).
             self.exit_emoji_mode();
+            // Likewise, Shift-triggered Alphabet mode is per-composition:
+            // erasing back to empty ends it, so restore the prior mode.
+            self.exit_alphabet_mode();
             Some(
                 EngineResult::consumed()
                     .with_action(EngineAction::UpdatePreedit(Preedit::new()))

--- a/karukan-im/src/core/engine/tests/alphabet.rs
+++ b/karukan-im/src/core/engine/tests/alphabet.rs
@@ -228,38 +228,72 @@ fn test_mixed_hiragana_alphabet_input() {
 }
 
 #[test]
-fn test_alphabet_mode_persists_across_commit() {
+fn test_shift_alphabet_reverts_to_hiragana_after_commit() {
     let mut engine = InputMethodEngine::new();
 
-    // Enter alphabet mode via Shift+H
+    // Enter alphabet mode via Shift+H from the default Hiragana mode
     engine.process_key(&press_shift('H'));
     assert!(engine.input_mode == InputMode::Alphabet);
 
-    // Type and commit
+    // Type and commit the alphabet word
     engine.process_key(&press('i'));
     engine.process_key(&press_key(Keysym::RETURN));
     assert!(matches!(engine.state(), InputState::Empty));
 
-    // alphabet_mode should persist
-    assert!(engine.input_mode == InputMode::Alphabet);
-
-    // New input should still be in alphabet mode
-    engine.process_key(&press('y'));
-    assert_eq!(engine.preedit().unwrap().text(), "y");
+    // Shift-alphabet is a temporary per-word mode: after commit we are back
+    // in Hiragana, so the next word is converted to kana again (issue #37).
+    assert!(engine.input_mode == InputMode::Hiragana);
+    engine.process_key(&press('a'));
+    assert_eq!(engine.preedit().unwrap().text(), "あ");
 }
 
 #[test]
-fn test_alphabet_mode_cancel_clears_flags() {
+fn test_shift_alphabet_reverts_to_hiragana_after_cancel() {
     let mut engine = InputMethodEngine::new();
 
-    // Enter alphabet mode via Shift+A, type, cancel
+    // Enter alphabet mode via Shift+A, type, then cancel
     engine.process_key(&press_shift('A'));
     engine.process_key(&press('b'));
 
     engine.process_key(&press_key(Keysym::ESCAPE));
     assert!(matches!(engine.state(), InputState::Empty));
-    // Mode persists even after cancel
+    // Cancelling the temporary alphabet word restores Hiragana
+    assert!(engine.input_mode == InputMode::Hiragana);
+    engine.process_key(&press('a'));
+    assert_eq!(engine.preedit().unwrap().text(), "あ");
+}
+
+#[test]
+fn test_shift_alphabet_reverts_to_hiragana_after_erase_to_empty() {
+    let mut engine = InputMethodEngine::new();
+
+    // Enter alphabet mode via Shift+A
+    engine.process_key(&press_shift('A'));
     assert!(engine.input_mode == InputMode::Alphabet);
+
+    // Erasing back to an empty buffer ends the temporary alphabet word
+    engine.process_key(&press_key(Keysym::BACKSPACE));
+    assert!(matches!(engine.state(), InputState::Empty));
+    assert!(engine.input_mode == InputMode::Hiragana);
+}
+
+#[test]
+fn test_shift_alphabet_from_katakana_reverts_to_katakana() {
+    let mut engine = InputMethodEngine::new();
+
+    // Type a char, then switch to katakana mode (Ctrl+K)
+    engine.process_key(&press('a'));
+    engine.process_key(&press_ctrl(Keysym::KEY_K));
+    assert!(engine.input_mode == InputMode::Katakana);
+
+    // Shift+A enters alphabet, remembering Katakana as the prior mode
+    engine.process_key(&press_shift('A'));
+    assert!(engine.input_mode == InputMode::Alphabet);
+
+    // Commit → reverts to Katakana (the mode before the Shift gesture),
+    // not all the way to Hiragana
+    engine.process_key(&press_key(Keysym::RETURN));
+    assert!(engine.input_mode == InputMode::Katakana);
 }
 
 #[test]

--- a/karukan-im/src/core/engine/tests/mode_toggle.rs
+++ b/karukan-im/src/core/engine/tests/mode_toggle.rs
@@ -9,14 +9,15 @@ fn test_mode_toggle_key_switches_alphabet_to_hiragana() {
     // Enter alphabet mode via Shift+A
     engine.process_key(&press_shift('A'));
     assert!(engine.input_mode == InputMode::Alphabet);
-    engine.process_key(&press_key(Keysym::RETURN)); // commit to clear state
 
-    // Alt_R press → switch to hiragana mode
+    // Alt_R press → switch to hiragana mode (mid-composition; the toggle key
+    // is the explicit way out, independent of the per-word auto-revert)
     let result = engine.process_key(&press_key(Keysym::ALT_R));
     assert!(result.consumed);
     assert!(engine.input_mode != InputMode::Alphabet);
 
-    // Type 'a' → should be 'あ' (hiragana mode)
+    // Clear the composed "A", then type 'a' → should be 'あ' (hiragana mode)
+    engine.process_key(&press_key(Keysym::RETURN));
     engine.process_key(&press('a'));
     assert_eq!(engine.preedit().unwrap().text(), "あ");
 }


### PR DESCRIPTION
## 概要 / Summary

US配列のmacOSで `Shift+英字` の後にひらがなへ戻れない問題 (#37) を修正します。

`Shift+英字` で入る `InputMode::Alphabet` は **sticky な片道モード**で、確定/キャンセルしても維持され、ひらがなへ戻すにはモードトグルキー（JIS かな / 右Super）が必要でした。US配列キーボードには かなキーが無いため、英字を打つと一方通行で詰まり、Enterで確定して入力を再開してもローマ字が変換されずそのまま挿入されていました。

本修正では、emoji モードと同じ仕組みで **Shift英字を「一時モード」化**します。`Shift+英字` で Alphabet に入るときに直前のモードを `pre_alphabet_mode` に保存し、確定 / キャンセル / 全消去のタイミングで `exit_alphabet_mode()` により元のモードへ復帰します。これにより Shift ジェスチャは**1語単位**になり（macOS標準IMEやGoogle日本語入力と同じ挙動）、次の語は自動的にかな入力へ戻ります。Katakana モードから入った場合は Katakana に戻ります。

明示的なモードトグルキーは従来どおり composing 中に機能します（例: Katakana から抜ける用途）。共有エンジンの変更なので Linux/fcitx5 にも同じ改善が入ります。

## 変更点 / Changes
- `mod.rs`: `pre_alphabet_mode` フィールド追加、`exit_alphabet_mode()` 追加、`reset()` と erase-to-empty 経路で復帰。
- `input.rs`: `Shift+英字` の2つの入口で直前モードを保存、commit/cancel で `exit_alphabet_mode()` を呼び出し。
- `conversion.rs`: 変換確定の経路でも復帰。
- tests: 旧「確定後もAlphabet維持」を前提とした2テストを新挙動（自動復帰）に書き換え、確定/キャンセル/全消去/Katakana復帰の4ケースを追加。`mode_toggle.rs` のトグルキーのテストは composing 中に切り替えるよう調整。

## テスト / Test plan
- `cargo test -p karukan-im` — 221 件すべてパス
- `cargo clippy -p karukan-im` — クリーン
- 手動: ひらがなモードで `Shift+A` → 英字 → Enter で確定 → そのままローマ字を打つと、かなへ自動変換される。

Closes #37