### PR TITLE
Add F6–F10 and Muhenkan key support for kana commit shortcuts

### DIFF
--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -583,6 +583,33 @@ impl InputMethodEngine {
             Keysym::PAGE_DOWN => self.next_candidate_page(),
             Keysym::PAGE_UP => self.prev_candidate_page(),
             Keysym::BACKSPACE => self.backspace_conversion(),
+            Keysym::F6 => {
+                let text = self.input_buf.text.clone();
+                self.commit_text(text)
+            }
+            Keysym::F7 => {
+                let text = karukan_engine::hiragana_to_katakana(&self.input_buf.text);
+                self.commit_text(text)
+            }
+            Keysym::F8 => {
+                let text = karukan_engine::kana::hiragana_to_half_katakana(&self.input_buf.text);
+                self.commit_text(text)
+            }
+            Keysym::F9 => {
+                // start_conversion calls flush_romaji_to_composed, so raw_inputs has all romaji
+                let text: String = self.raw_inputs.join("").chars()
+                    .map(karukan_engine::kana::ascii_to_fullwidth_char)
+                    .collect();
+                self.commit_text(text)
+            }
+            Keysym::F10 => {
+                let text = self.raw_inputs.join("");
+                self.commit_text(text)
+            }
+            Keysym::MUHENKAN => {
+                let text = karukan_engine::hiragana_to_katakana(&self.input_buf.text);
+                self.commit_text(text)
+            }
             _ => {
                 // Ctrl+N / Ctrl+P: emacs-style candidate navigation
                 if key.modifiers.control_key && !key.modifiers.alt_key {
@@ -651,6 +678,7 @@ impl InputMethodEngine {
 
         self.state = InputState::Empty;
         self.input_buf.text.clear();
+        self.raw_inputs.clear();
         self.exit_emoji_mode();
 
         EngineResult::consumed()
@@ -674,6 +702,7 @@ impl InputMethodEngine {
 
         self.state = InputState::Empty;
         self.input_buf.text.clear();
+        self.raw_inputs.clear();
         self.exit_emoji_mode();
 
         // Start new input with the character

--- a/karukan-im/src/core/engine/cursor.rs
+++ b/karukan-im/src/core/engine/cursor.rs
@@ -37,6 +37,29 @@ impl InputMethodEngine {
         // Remove character before cursor from composed_hiragana
         if self.input_buf.cursor_pos > 0 {
             self.input_buf.remove_char_before_cursor();
+            let new_pos = self.input_buf.cursor_pos;
+            let removed_raw = if new_pos < self.raw_inputs.len() {
+                self.raw_inputs.remove(new_pos)
+            } else {
+                String::new()
+            };
+            // A secondary char of a multi-kana group (e.g. "ゃ" from "kya") has an
+            // empty raw entry. Delete back through the group to its root so that
+            // F9/F10 never emit romaji for chars that no longer exist.
+            if removed_raw.is_empty() {
+                while self.input_buf.cursor_pos > 0 {
+                    let prev = self.input_buf.cursor_pos - 1;
+                    let is_secondary = self.raw_inputs.get(prev).map_or(false, |s| s.is_empty());
+                    self.input_buf.remove_char_before_cursor();
+                    let p = self.input_buf.cursor_pos;
+                    if p < self.raw_inputs.len() {
+                        self.raw_inputs.remove(p);
+                    }
+                    if !is_secondary {
+                        break;
+                    }
+                }
+            }
         } else {
             // Nothing to delete
             return EngineResult::consumed();
@@ -70,8 +93,12 @@ impl InputMethodEngine {
         }
 
         // Delete character at cursor position
+        let cursor_pos = self.input_buf.cursor_pos;
         if self.input_buf.remove_char_at_cursor().is_none() {
             return EngineResult::consumed();
+        }
+        if cursor_pos < self.raw_inputs.len() {
+            self.raw_inputs.remove(cursor_pos);
         }
 
         if let Some(result) = self.try_reset_if_empty() {

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -123,7 +123,9 @@ impl InputMethodEngine {
         if key.modifiers.control_key && key.keysym == Keysym::SPACE {
             self.converters.romaji.reset();
             self.input_buf.clear();
+            self.raw_inputs.clear();
             self.input_buf.insert("\u{3000}");
+            self.raw_inputs.push(" ".to_string());
             let preedit = self.set_composing_state();
             return EngineResult::consumed()
                 .with_action(EngineAction::UpdatePreedit(preedit))
@@ -203,11 +205,14 @@ impl InputMethodEngine {
     pub(super) fn start_input(&mut self, ch: char) -> EngineResult {
         self.converters.romaji.reset();
         self.input_buf.clear();
+        self.raw_inputs.clear();
 
         if self.input_mode == InputMode::Alphabet {
+            self.raw_inputs.push(ch.to_string());
             self.input_buf.insert(&ch.to_string());
         } else {
             let prev_output_len = 0;
+            let ch_lower = ch.to_ascii_lowercase();
             let _event = self.converters.romaji.push(ch);
             let romaji_buffer = self.converters.romaji.buffer().to_string();
 
@@ -223,6 +228,9 @@ impl InputMethodEngine {
             // Consume new converter output into composed_hiragana
             let new_output_len = self.converters.romaji.output().chars().count();
             if new_output_len > prev_output_len {
+                // prev_buffer was "" (just reset), so consumed = ch_lower minus new_buffer
+                let new_buf = self.converters.romaji.buffer();
+                let consumed_len = 1_usize.saturating_sub(new_buf.len());
                 let new_chars: String = self
                     .converters
                     .romaji
@@ -230,6 +238,10 @@ impl InputMethodEngine {
                     .chars()
                     .skip(prev_output_len)
                     .collect();
+                for (i, _) in new_chars.chars().enumerate() {
+                    let s = if i == 0 && consumed_len > 0 { ch_lower.to_string() } else { String::new() };
+                    self.raw_inputs.push(s);
+                }
                 self.input_buf.insert(&new_chars);
             }
         }
@@ -243,7 +255,9 @@ impl InputMethodEngine {
 
     /// Insert a full-width space (U+3000) at cursor position
     pub(super) fn input_fullwidth_space(&mut self) -> EngineResult {
+        let insert_pos = self.input_buf.cursor_pos;
         self.input_buf.insert("\u{3000}");
+        self.raw_inputs.insert(insert_pos, " ".to_string());
         self.refresh_input_state()
     }
 
@@ -287,6 +301,35 @@ impl InputMethodEngine {
             Keysym::RIGHT => self.move_caret_right(),
             Keysym::HOME => self.move_caret_home(),
             Keysym::END => self.move_caret_end(),
+            Keysym::F6 => {
+                self.flush_romaji_to_composed();
+                let text = self.input_buf.text.clone();
+                self.commit_text(text)
+            }
+            Keysym::F7 => {
+                self.flush_romaji_to_composed();
+                let text = karukan_engine::hiragana_to_katakana(&self.input_buf.text);
+                self.commit_text(text)
+            }
+            Keysym::F8 => {
+                self.flush_romaji_to_composed();
+                let text = karukan_engine::kana::hiragana_to_half_katakana(&self.input_buf.text);
+                self.commit_text(text)
+            }
+            Keysym::F9 => {
+                // raw_inputs holds committed romaji; romaji buffer holds any pending suffix
+                let raw = format!("{}{}", self.raw_inputs.join(""), self.converters.romaji.buffer());
+                let text: String = raw
+                    .chars()
+                    .map(karukan_engine::kana::ascii_to_fullwidth_char)
+                    .collect();
+                self.commit_text(text)
+            }
+            Keysym::F10 => {
+                let text = format!("{}{}", self.raw_inputs.join(""), self.converters.romaji.buffer());
+                self.commit_text(text)
+            }
+            Keysym::MUHENKAN => self.toggle_katakana_composing(),
             _ => {
                 if let Some(ch) = key.to_char()
                     && !key.modifiers.control_key
@@ -327,6 +370,7 @@ impl InputMethodEngine {
     pub(super) fn start_emoji_mode(&mut self) -> EngineResult {
         self.converters.romaji.reset();
         self.input_buf.clear();
+        self.raw_inputs.clear();
         self.live.text.clear();
         // Remember where the user was so commit/cancel/erase-to-empty
         // can drop them back into the same mode (e.g. Katakana stays
@@ -337,6 +381,7 @@ impl InputMethodEngine {
         }
         self.input_mode = InputMode::Emoji;
         self.input_buf.insert(":");
+        self.raw_inputs.push(":".to_string());
         self.refresh_input_state()
     }
 
@@ -356,11 +401,15 @@ impl InputMethodEngine {
     /// In alphabet mode, inserts directly; otherwise goes through romaji conversion.
     pub(super) fn input_char(&mut self, ch: char) -> EngineResult {
         if matches!(self.input_mode, InputMode::Alphabet | InputMode::Emoji) {
+            let insert_pos = self.input_buf.cursor_pos;
             self.input_buf.insert(&ch.to_string());
+            self.raw_inputs.insert(insert_pos, ch.to_string());
             return self.refresh_input_state();
         }
 
+        let prev_buffer = self.converters.romaji.buffer().to_string();
         let prev_output_len = self.converters.romaji.output().chars().count();
+        let ch_lower = ch.to_ascii_lowercase();
         let _event = self.converters.romaji.push(ch);
         let curr_output_len = self.converters.romaji.output().chars().count();
 
@@ -369,6 +418,9 @@ impl InputMethodEngine {
         // output="th", buffer="x"), so capture all of them via delta detection.
         // PassThrough chars are already included in the converter output.
         if curr_output_len > prev_output_len {
+            let new_buffer = self.converters.romaji.buffer();
+            let combined = format!("{}{}", prev_buffer, ch_lower);
+            let consumed_len = combined.len().saturating_sub(new_buffer.len());
             let new_chars: String = self
                 .converters
                 .romaji
@@ -376,7 +428,16 @@ impl InputMethodEngine {
                 .chars()
                 .skip(prev_output_len)
                 .collect();
+            let insert_pos = self.input_buf.cursor_pos;
             self.input_buf.insert(&new_chars);
+            for (i, _) in new_chars.chars().enumerate() {
+                let s = if i == 0 && consumed_len > 0 {
+                    combined[..consumed_len].to_string()
+                } else {
+                    String::new()
+                };
+                self.raw_inputs.insert(insert_pos + i, s);
+            }
         }
 
         // PassThrough chars no longer auto-commit. They accumulate in the preedit
@@ -436,6 +497,7 @@ impl InputMethodEngine {
         self.input_buf.clear();
         self.live.text.clear();
         self.chunks.clear();
+        self.raw_inputs.clear();
         self.state = InputState::Empty;
         self.exit_emoji_mode();
 
@@ -481,6 +543,7 @@ impl InputMethodEngine {
         self.input_buf.clear();
         self.live.text.clear();
         self.chunks.clear();
+        self.raw_inputs.clear();
         self.state = InputState::Empty;
         // Emoji mode is per-session: leaving it returns the user to
         // whatever mode they were in before typing `:` so their next

--- a/karukan-im/src/core/engine/mod.rs
+++ b/karukan-im/src/core/engine/mod.rs
@@ -153,6 +153,10 @@ pub struct InputMethodEngine {
     dicts: Dictionaries,
     /// Learning cache (user conversion history)
     learning: Option<LearningCache>,
+    /// Parallel to input_buf.text chars: raw_inputs[i] is the romaji that produced char i.
+    /// Enables F9/F10 to reconstruct typed romaji without lossy reverse conversion, even after
+    /// cursor movement or mid-buffer edits.
+    raw_inputs: Vec<String>,
 }
 
 impl InputMethodEngine {
@@ -176,6 +180,7 @@ impl InputMethodEngine {
             chunks: Vec::new(),
             dicts: Dictionaries::default(),
             learning: None,
+            raw_inputs: Vec::new(),
         }
     }
 
@@ -247,6 +252,7 @@ impl InputMethodEngine {
         self.input_buf.clear();
         self.live.text.clear();
         self.chunks.clear();
+        self.raw_inputs.clear();
         self.metrics = ConversionMetrics::default();
     }
 
@@ -274,6 +280,7 @@ impl InputMethodEngine {
             // against a buffer it no longer matches).
             self.live.text.clear();
             self.chunks.clear();
+            self.raw_inputs.clear();
             // Emoji mode is per-session and bound to the typed `:` —
             // if the user erased back to an empty buffer, the session
             // is over. Restore whatever mode the user was in before
@@ -312,14 +319,33 @@ impl InputMethodEngine {
         }
     }
 
+    /// Commit `text` immediately, resetting all input state. Skips learning — the user dictated the form.
+    pub(super) fn commit_text(&mut self, text: String) -> EngineResult {
+        self.converters.romaji.reset();
+        self.input_buf.clear();
+        self.live.text.clear();
+        self.chunks.clear();
+        self.raw_inputs.clear();
+        self.state = InputState::Empty;
+        self.exit_emoji_mode();
+        let mut result = EngineResult::consumed()
+            .with_action(EngineAction::UpdatePreedit(Preedit::new()))
+            .with_action(EngineAction::HideCandidates)
+            .with_action(EngineAction::HideAuxText);
+        if !text.is_empty() {
+            result = result.with_action(EngineAction::Commit(text));
+        }
+        result
+    }
+
     /// Flush the romaji buffer and insert result at cursor position
     fn flush_romaji_to_composed(&mut self) {
         if self.converters.romaji.buffer().is_empty() {
             return;
         }
+        let pre_flush_buffer = self.converters.romaji.buffer().to_string();
         let prev_output_len = self.converters.romaji.output().chars().count();
         let _flushed = self.converters.romaji.flush();
-        // flush() appends converted buffer to output internally
         let new_from_flush: String = self
             .converters
             .romaji
@@ -328,7 +354,12 @@ impl InputMethodEngine {
             .skip(prev_output_len)
             .collect();
         if !new_from_flush.is_empty() {
+            let insert_pos = self.input_buf.cursor_pos;
             self.input_buf.insert(&new_from_flush);
+            for (i, _) in new_from_flush.chars().enumerate() {
+                let s = if i == 0 { pre_flush_buffer.clone() } else { String::new() };
+                self.raw_inputs.insert(insert_pos + i, s);
+            }
         }
     }
 

--- a/karukan-im/src/core/engine/mode.rs
+++ b/karukan-im/src/core/engine/mode.rs
@@ -33,6 +33,23 @@ impl InputMethodEngine {
             .with_action(EngineAction::UpdateAuxText(aux))
     }
 
+    /// Toggle hiragana/katakana display in Composing state without committing (Muhenkan key).
+    pub(super) fn toggle_katakana_composing(&mut self) -> EngineResult {
+        self.flush_romaji_to_composed();
+        self.converters.romaji.reset();
+        self.input_mode = match self.input_mode {
+            InputMode::Katakana => InputMode::Hiragana,
+            _ => InputMode::Katakana,
+        };
+        self.live.text.clear();
+        let preedit = self.set_composing_state();
+        let aux = self.format_aux_composing();
+        EngineResult::consumed()
+            .with_action(EngineAction::UpdatePreedit(preedit))
+            .with_action(EngineAction::UpdateAuxText(aux))
+            .with_action(EngineAction::HideCandidates)
+    }
+
     /// Toggle live conversion mode via Ctrl+Shift+L.
     ///
     /// When toggled ON during Composing, immediately convert the current

--- a/karukan-im/src/core/engine/tests/fkey.rs
+++ b/karukan-im/src/core/engine/tests/fkey.rs
@@ -1,0 +1,368 @@
+use super::*;
+
+// "n" alone does not produce "ん" — "nn" or "n'" is required by the romaji converter.
+
+#[test]
+fn test_f6_commits_hiragana_in_composing() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo");
+    assert_eq!(engine.preedit().unwrap().text(), "あいうえお");
+
+    let result = engine.process_key(&press_key(Keysym::F6));
+    assert!(result.consumed);
+    assert_eq!(commit_text(&result), Some("あいうえお".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_f7_commits_full_katakana_in_composing() {
+    let mut engine = InputMethodEngine::new();
+    // "nihonn" → "にほん" ("nn" で "ん" を確定)
+    type_str(&mut engine, "nihonn");
+    assert_eq!(engine.preedit().unwrap().text(), "にほん");
+
+    let result = engine.process_key(&press_key(Keysym::F7));
+    assert!(result.consumed);
+    assert_eq!(commit_text(&result), Some("ニホン".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_f8_commits_half_katakana_in_composing() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo");
+
+    let result = engine.process_key(&press_key(Keysym::F8));
+    assert!(result.consumed);
+    assert_eq!(commit_text(&result), Some("ｱｲｳｴｵ".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_f9_commits_fullwidth_romaji_in_hiragana_mode() {
+    let mut engine = InputMethodEngine::new();
+    // "aiueo" は各1文字ずつ確定するため raw_input = "aiueo"
+    type_str(&mut engine, "aiueo");
+
+    let result = engine.process_key(&press_key(Keysym::F9));
+    assert!(result.consumed);
+    // 打ったローマ字をそのまま全角化: aiueo → ａｉｕｅｏ
+    assert_eq!(commit_text(&result), Some("ａｉｕｅｏ".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_f10_commits_halfwidth_romaji_in_hiragana_mode() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo");
+
+    let result = engine.process_key(&press_key(Keysym::F10));
+    assert!(result.consumed);
+    // 打ったローマ字をそのまま: aiueo
+    assert_eq!(commit_text(&result), Some("aiueo".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_f10_windows_stays_windows() {
+    // ユーザーが "windows" と打った場合、かな変換されても F10 で "windows" に戻れること
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "windows");
+
+    let result = engine.process_key(&press_key(Keysym::F10));
+    assert!(result.consumed);
+    // 逆変換せず打ったローマ字をそのまま返す
+    let text = commit_text(&result).unwrap_or_default();
+    assert_eq!(text, "windows");
+}
+
+#[test]
+fn test_f9_windows_fullwidth() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "windows");
+
+    let result = engine.process_key(&press_key(Keysym::F9));
+    assert!(result.consumed);
+    let text = commit_text(&result).unwrap_or_default();
+    assert_eq!(text, "ｗｉｎｄｏｗｓ");
+}
+
+#[test]
+fn test_f10_includes_pending_romaji_buffer() {
+    let mut engine = InputMethodEngine::new();
+    // "nihon" → raw_input="niho", romaji_buffer="n"
+    type_str(&mut engine, "nihon");
+
+    let result = engine.process_key(&press_key(Keysym::F10));
+    assert!(result.consumed);
+    // raw_input "niho" + pending "n" = "nihon"
+    assert_eq!(commit_text(&result), Some("nihon".to_string()));
+}
+
+#[test]
+fn test_f9_includes_pending_romaji_buffer() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "nihon");
+
+    let result = engine.process_key(&press_key(Keysym::F9));
+    assert!(result.consumed);
+    // raw_input "niho" + pending "n" = "nihon" → 全角: "ｎｉｈｏｎ"
+    assert_eq!(commit_text(&result), Some("ｎｉｈｏｎ".to_string()));
+}
+
+#[test]
+fn test_f9_commits_fullwidth_alpha_in_alphabet_mode() {
+    let mut engine = InputMethodEngine::new();
+    // Shift+A でアルファベットモードに入り、そのまま b, c と入力
+    engine.process_key(&press_shift('A'));
+    engine.process_key(&press('b'));
+    engine.process_key(&press('c'));
+    assert_eq!(engine.input_mode, InputMode::Alphabet);
+    // input_buf = "Abc"
+
+    let result = engine.process_key(&press_key(Keysym::F9));
+    assert!(result.consumed);
+    // 全角変換: 大小を保ったまま全角に
+    assert_eq!(commit_text(&result), Some("Ａｂｃ".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_f10_commits_halfwidth_alpha_in_alphabet_mode() {
+    let mut engine = InputMethodEngine::new();
+    engine.process_key(&press_shift('A'));
+    engine.process_key(&press('b'));
+    engine.process_key(&press('c'));
+    assert_eq!(engine.input_mode, InputMode::Alphabet);
+    // input_buf = "Abc" (半角ASCII なので変化なし)
+
+    let result = engine.process_key(&press_key(Keysym::F10));
+    assert!(result.consumed);
+    assert_eq!(commit_text(&result), Some("Abc".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+// 無変換: Composing ステートでひらがな↔カタカナをトグル（コミットしない）
+
+#[test]
+fn test_muhenkan_toggles_to_katakana_in_composing() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo");
+    assert_eq!(engine.preedit().unwrap().text(), "あいうえお");
+
+    let result = engine.process_key(&press_key(Keysym::MUHENKAN));
+    assert!(result.consumed);
+    // コミットは発生しない
+    assert!(commit_text(&result).is_none());
+    // preedit がカタカナに変わる
+    assert_eq!(engine.preedit().unwrap().text(), "アイウエオ");
+    assert_eq!(engine.input_mode, InputMode::Katakana);
+    // Composing のまま
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+}
+
+#[test]
+fn test_muhenkan_toggles_back_to_hiragana_in_composing() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo");
+
+    engine.process_key(&press_key(Keysym::MUHENKAN)); // → カタカナ
+    engine.process_key(&press_key(Keysym::MUHENKAN)); // → ひらがなに戻る
+
+    assert_eq!(engine.input_mode, InputMode::Hiragana);
+    assert_eq!(engine.preedit().unwrap().text(), "あいうえお");
+}
+
+#[test]
+fn test_muhenkan_then_enter_commits_katakana() {
+    let mut engine = InputMethodEngine::new();
+    // "nihonn" で "にほん" を確定
+    type_str(&mut engine, "nihonn");
+    assert_eq!(engine.preedit().unwrap().text(), "にほん");
+
+    engine.process_key(&press_key(Keysym::MUHENKAN)); // カタカナモードに
+    assert_eq!(engine.preedit().unwrap().text(), "ニホン");
+
+    let result = engine.process_key(&press_key(Keysym::RETURN));
+    assert_eq!(commit_text(&result), Some("ニホン".to_string()));
+}
+
+// Conversion ステート（Space 後）の F キー
+
+#[test]
+fn test_f9_commits_fullwidth_romaji_after_space() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo");
+    engine.process_key(&press_key(Keysym::SPACE));
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+
+    let result = engine.process_key(&press_key(Keysym::F9));
+    assert!(result.consumed);
+    // raw_input "aiueo" → 全角
+    assert_eq!(commit_text(&result), Some("ａｉｕｅｏ".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_f10_commits_halfwidth_romaji_after_space() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo");
+    engine.process_key(&press_key(Keysym::SPACE));
+
+    let result = engine.process_key(&press_key(Keysym::F10));
+    assert!(result.consumed);
+    // raw_input "aiueo" → 半角そのまま
+    assert_eq!(commit_text(&result), Some("aiueo".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_f7_commits_katakana_after_space() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "nihonn");
+    engine.process_key(&press_key(Keysym::SPACE)); // 変換モードへ
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+
+    let result = engine.process_key(&press_key(Keysym::F7));
+    assert!(result.consumed);
+    assert_eq!(commit_text(&result), Some("ニホン".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_f6_commits_hiragana_after_space() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo");
+    engine.process_key(&press_key(Keysym::SPACE));
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+
+    let result = engine.process_key(&press_key(Keysym::F6));
+    assert!(result.consumed);
+    assert_eq!(commit_text(&result), Some("あいうえお".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_muhenkan_commits_katakana_after_space() {
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo");
+    engine.process_key(&press_key(Keysym::SPACE));
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+
+    let result = engine.process_key(&press_key(Keysym::MUHENKAN));
+    assert!(result.consumed);
+    assert_eq!(commit_text(&result), Some("アイウエオ".to_string()));
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+// --- Regression tests (bugs found in code review) ---
+
+#[test]
+fn test_f10_after_cursor_move_with_pending_romaji() {
+    // Bug 1: flush_romaji_to_composed via cursor movement didn't push a raw entry,
+    // so F10 after LEFT dropped the flushed char from the output.
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "nihon"); // input_buf="にほ", romaji_buf="n"
+
+    engine.process_key(&press_key(Keysym::LEFT)); // flushes "n"→"ん", cursor moves left
+    // Now input_buf="にほん", raw_inputs=["ni","ho","n"]
+
+    let result = engine.process_key(&press_key(Keysym::F10));
+    assert_eq!(commit_text(&result), Some("nihon".to_string()));
+}
+
+#[test]
+fn test_backspace_after_ctrl_space_does_not_corrupt_raw_inputs() {
+    // Bug 2: Ctrl+Space (full-width space) wasn't tracked in raw_inputs, so
+    // backspacing it would pop the preceding kana's entry and corrupt raw_inputs.
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "ai"); // raw_inputs=["a","i"]
+    engine.process_key(&press_ctrl(Keysym::SPACE)); // inserts "　", raw_inputs=["a","i"," "]
+    engine.process_key(&press_key(Keysym::BACKSPACE)); // removes space, raw_inputs=["a","i"]
+
+    let result = engine.process_key(&press_key(Keysym::F10));
+    assert_eq!(commit_text(&result), Some("ai".to_string()));
+}
+
+#[test]
+fn test_f10_mid_buffer_insert_preserves_order() {
+    // Bug 3: raw_inputs was an end-stack; inserting mid-buffer after cursor movement
+    // appended the new entry at the wrong position, so F10 emitted romaji out of order.
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "aiueo"); // raw_inputs=["a","i","u","e","o"], cursor=5
+
+    engine.process_key(&press_key(Keysym::LEFT));
+    engine.process_key(&press_key(Keysym::LEFT)); // cursor=3
+
+    engine.process_key(&press('k'));
+    engine.process_key(&press('a')); // inserts "か" at pos 3 → raw_inputs=["a","i","u","ka","e","o"]
+
+    let result = engine.process_key(&press_key(Keysym::F10));
+    assert_eq!(commit_text(&result), Some("aiukaeo".to_string()));
+}
+
+#[test]
+fn test_muhenkan_flushes_pending_romaji_before_toggle() {
+    // Bug 4: toggle_katakana_composing didn't flush the romaji buffer first.
+    // "as" leaves "s" pending; without the flush, typing "a" after MUHENKAN
+    // continues the old sequence "sa"→"さ"→"サ". With the flush "s" is frozen
+    // as a literal and the subsequent "a" starts a fresh sequence → "ア".
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "as"); // input_buf="あ", romaji_buf="s"
+
+    engine.process_key(&press_key(Keysym::MUHENKAN)); // flush "s" as literal, toggle
+    engine.process_key(&press('a')); // fresh "a"→"あ"→katakana"ア"
+
+    assert_eq!(engine.preedit().unwrap().text(), "アsア");
+}
+
+#[test]
+fn test_ctrl_space_from_empty_then_type_does_not_panic() {
+    // Bug (review finding 1): Ctrl+Space from Empty state inserted U+3000 into
+    // input_buf without pushing to raw_inputs, so the next keystroke panicked
+    // with "insertion index out of bounds".
+    let mut engine = InputMethodEngine::new();
+    assert!(matches!(engine.state(), InputState::Empty));
+    engine.process_key(&press_ctrl(Keysym::SPACE));
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+    // Must not panic; just verify it proceeds normally
+    engine.process_key(&press('a'));
+    assert!(matches!(engine.state(), InputState::Composing { .. }));
+}
+
+#[test]
+fn test_f10_after_digraph_partial_backspace() {
+    // Bug (review finding 2): backspacing the secondary char of a multi-kana
+    // group (e.g. "ゃ" from "kya"→"きゃ") left the root "き" with raw="kya",
+    // so F10 would emit "kya" even though only "き" was still in the buffer.
+    // Fix: backspace on a secondary char now deletes the whole group atomically.
+    let mut engine = InputMethodEngine::new();
+    type_str(&mut engine, "kya"); // "きゃ" (two chars from one sequence)
+    assert_eq!(engine.preedit().unwrap().text(), "きゃ");
+
+    engine.process_key(&press_key(Keysym::BACKSPACE)); // removes whole "きゃ" group
+    assert!(matches!(engine.state(), InputState::Empty));
+
+    // Confirm raw_inputs is clean: start fresh and F10 gives only the new input
+    type_str(&mut engine, "a");
+    let result = engine.process_key(&press_key(Keysym::F10));
+    assert_eq!(commit_text(&result), Some("a".to_string()));
+}
+
+// --- ヘルパー ---
+
+fn type_str(engine: &mut InputMethodEngine, s: &str) {
+    for ch in s.chars() {
+        engine.process_key(&press(ch));
+    }
+}
+
+fn commit_text(result: &EngineResult) -> Option<String> {
+    result.actions.iter().find_map(|a| {
+        if let EngineAction::Commit(text) = a {
+            Some(text.clone())
+        } else {
+            None
+        }
+    })
+}

--- a/karukan-im/src/core/engine/tests/mod.rs
+++ b/karukan-im/src/core/engine/tests/mod.rs
@@ -5,6 +5,7 @@ use crate::core::keycode::KeyModifiers;
 
 mod alphabet;
 mod basic;
+mod fkey;
 mod candidates;
 mod chunks;
 mod conversion;

--- a/karukan-im/src/core/keycode.rs
+++ b/karukan-im/src/core/keycode.rs
@@ -85,6 +85,9 @@ impl Keysym {
     pub const F11: Keysym = Keysym(0xffc8);
     pub const F12: Keysym = Keysym(0xffc9);
 
+    // Japanese keyboard keys
+    pub const MUHENKAN: Keysym = Keysym(0xff22); // 無変換
+
     /// Check if this keysym represents a printable character
     pub fn is_printable(&self) -> bool {
         // ASCII printable range (0x20-0x7e)


### PR DESCRIPTION
## 概要
ATOK・Mozc・MS-IME など主要な日本語 IME が対応しているファンクションキーショートカットと無変換キーを実装しました。

## 追加したキーバインド：
| Key | Output |
| --- | --- |
| F6 | ひらがなで確定 |
| F7 | 全角カタカナで確定 |
| F8 | 半角カタカナで確定 |
| F9 | 打ったローマ字を全角英数で確定（例: aiueo → ａｉｕｅｏ） |
| F10 | 打ったローマ字を半角英数で確定（例: aiueo → aiueo） |
| 無変換 | 変換中: ひらがな↔カタカナをトグル（確定しない）／候補選択中: 全角カタカナで確定 |

## 設計: raw_inputs によるロスレスなローマ字再構築
F9/F10 では「ユーザーが実際に打ったローマ字」を復元する必要があります（例: うぃんどうｓ から windowsを返す）。ひらがな→ローマ字の逆変換は情報損失が避けられないため、raw_inputs: Vec<String> という並列 Vecを導入しました。raw_inputs[i] は input_buf.text の i 番目の文字を生成したローマ字を保持します。

**これにより以下のケースを正確に処理できます：**
 - カーソル移動後の中間挿入
- Ctrl+Space（全角スペース）
- 拗音グループ（例: kya→きゃ）：バックスペースでグループ全体をアトミックに削除
- 未確定ローマ字バッファ（F10 は romaji.buffer() の内容も末尾に付加）

## テスト
- cargo test -p karukan-im — 244 テストすべて通過
- fcitx5 での動作確認: windows と入力して F10 → windows、F9 → ｗｉｎｄｏｗｓ
- カーソル移動後の確認: aiueo と入力しカーソルを 2 つ左に移動、ka を入力して F10 → aiukaeo
- 無変換トグルの確認: aiueo 入力後に無変換 → プリエディットが アイウエオ に変わり、Enter でカタカナ確定