### PR TITLE
macOSの候補ウィンドウの番号・候補・説明を列で揃える

### DIFF
--- a/karukan-im/macos/Sources/KarukanIME/CandidateWindowController.swift
+++ b/karukan-im/macos/Sources/KarukanIME/CandidateWindowController.swift
@@ -1,10 +1,33 @@
 import Cocoa
 
+/// A candidate row that paints its own selection background across its full
+/// bounds. Rows are given a uniform width (the widest row on the page), so a
+/// selected row's highlight is a clean bar rather than one that hugs the text.
+private final class RowView: NSView {
+    var fillColor: NSColor? {
+        didSet { needsDisplay = true }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard let fillColor else { return }
+        fillColor.setFill()
+        bounds.fill()
+    }
+}
+
 /// Custom candidate window (borderless non-activating NSPanel).
 ///
 /// The engine pre-paginates: `show` receives only the visible page plus
 /// page metadata, so this controller just renders rows. An optional aux
 /// line (reading hint / model info from the engine) is shown as a footer.
+///
+/// Each row places the number, candidate text, and (optional) description at
+/// fixed x offsets computed from the widest number and widest candidate on the
+/// page. Because the offsets are the same on every row, the candidate and
+/// description columns line up regardless of number width — `1.` and `2.`
+/// render at different widths in the proportional system font, which would
+/// otherwise make the candidate text start at a different x per row.
 class CandidateWindowController {
     // Visual scale of the panel. Candidate rows use a larger type size
     // than the footers (page indicator / aux line), matching the system
@@ -12,6 +35,11 @@ class CandidateWindowController {
     private static let candidateFontSize: CGFloat = 18
     private static let footerFontSize: CGFloat = 13
     private static let minPanelWidth: CGFloat = 160
+    // Horizontal gaps between the aligned columns (points).
+    private static let numberGap: CGFloat = 6
+    private static let descriptionGap: CGFloat = 16
+    // Uniform height for every candidate row.
+    private static let rowHeight: CGFloat = 25
 
     private let panel: NSPanel
     private let stackView: NSStackView
@@ -25,6 +53,14 @@ class CandidateWindowController {
         let totalPages: Int
     }
     private var pageState: PageState?
+
+    /// Precomputed column geometry shared by every row on a page. All values
+    /// are x offsets (points) from the row's leading edge.
+    private struct ColumnLayout {
+        let candidateX: CGFloat
+        let descriptionX: CGFloat?
+        let rowWidth: CGFloat
+    }
 
     init() {
         panel = NSPanel(
@@ -94,8 +130,10 @@ class CandidateWindowController {
             return
         }
 
+        let layout = columnLayout(for: state.candidates)
         for (index, candidate) in state.candidates.enumerated() {
-            addCandidateRow(candidate, number: index + 1, selected: index == state.cursor)
+            addCandidateRow(
+                candidate, number: index + 1, selected: index == state.cursor, layout: layout)
         }
         if state.totalPages > 1 {
             addFooterLabel("[\(state.page + 1)/\(state.totalPages)]")
@@ -115,38 +153,88 @@ class CandidateWindowController {
         rowViews.removeAll()
     }
 
-    private func addCandidateRow(_ candidate: CandidateItem, number: Int, selected: Bool) {
-        let text = NSMutableAttributedString(
-            string: "\(number). \(candidate.text)",
-            attributes: [
-                .font: NSFont.systemFont(ofSize: Self.candidateFontSize),
-                .foregroundColor: selected ? NSColor.white : NSColor.labelColor,
-            ]
-        )
-        if let description = candidate.description {
-            text.append(
-                NSAttributedString(
-                    string: "  \(description)",
-                    attributes: [
-                        .font: NSFont.systemFont(ofSize: Self.footerFontSize),
-                        .foregroundColor: selected
-                            ? NSColor.white.withAlphaComponent(0.8)
-                            : NSColor.secondaryLabelColor,
-                    ]
-                ))
+    /// Measure the page's columns. The candidate column starts past the widest
+    /// `N.`, and the description column (when any candidate has one) starts past
+    /// the widest candidate text. These offsets are shared by every row, which
+    /// is what keeps the columns aligned.
+    private func columnLayout(for candidates: [CandidateItem]) -> ColumnLayout {
+        let candidateFont = NSFont.systemFont(ofSize: Self.candidateFontSize)
+        let descriptionFont = NSFont.systemFont(ofSize: Self.footerFontSize)
+
+        func width(_ string: String, _ font: NSFont) -> CGFloat {
+            ceil((string as NSString).size(withAttributes: [.font: font]).width)
         }
 
-        let label = NSTextField(labelWithAttributedString: text)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        if selected {
-            label.backgroundColor = NSColor.selectedContentBackgroundColor
-            label.drawsBackground = true
-        } else {
-            label.backgroundColor = .clear
-            label.drawsBackground = false
+        let numberWidth = (1...candidates.count).map { width("\($0).", candidateFont) }.max() ?? 0
+        let candidateWidth = candidates.map { width($0.text, candidateFont) }.max() ?? 0
+        let descriptions = candidates.compactMap { $0.description }
+        let descriptionWidth = descriptions.map { width($0, descriptionFont) }.max() ?? 0
+
+        let candidateX = numberWidth + Self.numberGap
+        if descriptions.isEmpty {
+            return ColumnLayout(
+                candidateX: candidateX, descriptionX: nil,
+                rowWidth: candidateX + candidateWidth)
         }
-        stackView.addArrangedSubview(label)
-        rowViews.append(label)
+        let descriptionX = candidateX + candidateWidth + Self.descriptionGap
+        return ColumnLayout(
+            candidateX: candidateX, descriptionX: descriptionX,
+            rowWidth: descriptionX + descriptionWidth)
+    }
+
+    private func addCandidateRow(
+        _ candidate: CandidateItem, number: Int, selected: Bool, layout: ColumnLayout
+    ) {
+        let row = RowView()
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.fillColor = selected ? NSColor.selectedContentBackgroundColor : nil
+
+        let textColor: NSColor = selected ? .white : .labelColor
+        let numberLabel = makeLabel(
+            "\(number).", size: Self.candidateFontSize, color: textColor)
+        let candidateLabel = makeLabel(
+            candidate.text, size: Self.candidateFontSize, color: textColor)
+        row.addSubview(numberLabel)
+        row.addSubview(candidateLabel)
+
+        var constraints: [NSLayoutConstraint] = [
+            row.heightAnchor.constraint(equalToConstant: Self.rowHeight),
+            row.widthAnchor.constraint(equalToConstant: layout.rowWidth),
+            numberLabel.leadingAnchor.constraint(equalTo: row.leadingAnchor),
+            numberLabel.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            candidateLabel.leadingAnchor.constraint(
+                equalTo: row.leadingAnchor, constant: layout.candidateX),
+            candidateLabel.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+        ]
+
+        if let descriptionX = layout.descriptionX, let description = candidate.description {
+            let descColor: NSColor =
+                selected ? NSColor.white.withAlphaComponent(0.8) : .secondaryLabelColor
+            let descriptionLabel = makeLabel(
+                description, size: Self.footerFontSize, color: descColor)
+            row.addSubview(descriptionLabel)
+            constraints.append(
+                descriptionLabel.leadingAnchor.constraint(
+                    equalTo: row.leadingAnchor, constant: descriptionX))
+            constraints.append(
+                descriptionLabel.centerYAnchor.constraint(equalTo: row.centerYAnchor))
+        }
+
+        NSLayoutConstraint.activate(constraints)
+        stackView.addArrangedSubview(row)
+        rowViews.append(row)
+    }
+
+    /// A single-line, non-wrapping label pinned to its intrinsic width.
+    private func makeLabel(_ string: String, size: CGFloat, color: NSColor) -> NSTextField {
+        let label = NSTextField(labelWithString: string)
+        label.font = NSFont.systemFont(ofSize: size)
+        label.textColor = color
+        label.maximumNumberOfLines = 1
+        label.lineBreakMode = .byClipping
+        label.drawsBackground = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }
 
     private func addFooterLabel(_ text: String) {


### PR DESCRIPTION
## 概要

macOS の候補ウィンドウは各候補を「1. 変換」「2. 候補」…のように表示します。パネルはプロポーショナルなシステムフォントを使うため、番号の字幅が数字ごとに異なり（「1.」は「2.」より狭い）、候補テキストの開始位置が行ごとにわずかにずれて左端がガタガタに見えていました。

この変更で、番号・候補テキスト・説明を固定の列に揃え、全行が桁揃えされるようにします。

## 課題

- `NSFont.systemFont` では「1.」と「2.」の描画幅が異なる。
- 番号と候補テキストが1つの attributed run に同居していたため、候補テキストがその幅の差をそのまま受け、行ごとに左右へずれていた。
- 説明（ある場合）は可変幅の候補テキストの後ろに続くため、これも列として揃わなかった。

## アプローチ

各列の最大幅を実測し、番号・候補・説明を絶対 x 位置に固定配置して揃えます。

- `columnLayout(for:)` を新設。ページ内で最も広い「N.」と最も広い候補テキストを実測し、候補列 x（= 最大番号幅 + gap）と説明列 x（= 候補列 x + 最大候補幅 + gap）、および全行共通の `rowWidth` を算出する。
- 各行は `RowView`（選択背景を自前描画する `NSView`）の中に、番号・候補・（あれば）説明の3つの `NSTextField` を Auto Layout で同じ絶対 x に固定配置する。オフセットが全行で同じなので候補・説明の左端が必ず揃う。
- 各ラベルは単一行（`maximumNumberOfLines = 1` / `.byClipping`）で折り返さない。列 x は各列の最大幅から取るため、実際にはクリップされない。
- 各行 `RowView` を全行共通の `rowWidth`・固定高さ（`rowHeight`）にし、選択ハイライトがテキスト長に張り付かず均一なバーになるようにする。
- 説明列は、少なくとも1件の候補に説明があるときだけ追加する。

変更は `karukan-macos` フロントエンドの描画のみで、ワイヤープロトコルやエンジンには手を入れていません。

## Before / After

比較しやすいようにひらがなの「こ」の左に赤線を引いています。

| Before | After |
| --- | --- |
| 候補テキストの左端が「1.」と「3.」でずれる | 番号 / 候補 / 説明が列で揃う |
| <img width="308" height="410" alt="CleanShot 2026-07-05 at 15 44 45@2x" src="https://github.com/user-attachments/assets/4687d102-1d3f-4a5a-a505-1fe7512951d9" /> | <img width="320" height="450" alt="CleanShot 2026-07-05 at 15 39 08@2x" src="https://github.com/user-attachments/assets/e9f32ea5-f981-491c-8e54-773c777362de" /> |


<!-- スクリーンショットを添付 -->

## 動作確認

- `swift build` … 通過
- `xcrun swift-format lint` … 指摘なし
- `make install` でインストールし、実機で目視確認：短い候補・長い候補、「1.」〜「9.」の番号、aux/説明フッター、選択ハイライトのいずれも折り返しなく、番号に対して候補の左端が揃って表示されることを確認。
- `CandidateWindowController` はレイアウトが AppKit に委譲され、抽出可能な純粋ロジックがないため、ユニットテストは追加していません。
