### PR TITLE
JetBrains IDEなど一部のソフトウェアで入力できないバグを修正 (#46 + fmt)

### DIFF
--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -654,7 +654,6 @@ impl InputMethodEngine {
         self.exit_emoji_mode();
 
         EngineResult::consumed()
-            .with_action(EngineAction::UpdatePreedit(Preedit::new()))
             .with_action(EngineAction::HideCandidates)
             .with_action(EngineAction::HideAuxText)
             .with_action(EngineAction::Commit(text))
@@ -793,7 +792,6 @@ impl InputMethodEngine {
         self.state = InputState::Empty;
 
         EngineResult::consumed()
-            .with_action(EngineAction::UpdatePreedit(Preedit::new()))
             .with_action(EngineAction::HideCandidates)
             .with_action(EngineAction::HideAuxText)
             .with_action(EngineAction::Commit(selected_text))

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -444,7 +444,6 @@ impl InputMethodEngine {
         // NSPanel only closes on an explicit hide (fcitx5 resets its panel
         // on commit implicitly, which masked this on Linux).
         EngineResult::consumed()
-            .with_action(EngineAction::UpdatePreedit(Preedit::new()))
             .with_action(EngineAction::Commit(text))
             .with_action(EngineAction::HideCandidates)
             .with_action(EngineAction::HideAuxText)
@@ -487,13 +486,16 @@ impl InputMethodEngine {
         // word doesn't unexpectedly stay in ASCII-passthrough mode.
         self.exit_emoji_mode();
 
-        let mut result = EngineResult::consumed()
-            .with_action(EngineAction::UpdatePreedit(Preedit::new()))
-            .with_action(EngineAction::HideCandidates)
-            .with_action(EngineAction::HideAuxText);
         if let Some(literal) = emoji_literal {
-            result = result.with_action(EngineAction::Commit(literal));
+            EngineResult::consumed()
+                .with_action(EngineAction::Commit(literal))
+                .with_action(EngineAction::HideCandidates)
+                .with_action(EngineAction::HideAuxText)
+        } else {
+            EngineResult::consumed()
+                .with_action(EngineAction::UpdatePreedit(Preedit::new()))
+                .with_action(EngineAction::HideCandidates)
+                .with_action(EngineAction::HideAuxText)
         }
-        result
     }
 }

--- a/karukan-im/src/core/engine/mod.rs
+++ b/karukan-im/src/core/engine/mod.rs
@@ -533,10 +533,11 @@ impl InputMethodEngine {
     /// preedit/candidate-window teardown.
     pub fn commit_result(&mut self) -> EngineResult {
         let text = self.commit();
-        let mut result =
-            EngineResult::consumed().with_action(EngineAction::UpdatePreedit(Preedit::new()));
+        let mut result = EngineResult::consumed();
         if !text.is_empty() {
             result = result.with_action(EngineAction::Commit(text));
+        } else {
+            result = result.with_action(EngineAction::UpdatePreedit(Preedit::new()));
         }
         result
             .with_action(EngineAction::HideCandidates)

--- a/karukan-im/src/server/tests.rs
+++ b/karukan-im/src/server/tests.rs
@@ -111,6 +111,7 @@ fn test_typing_and_commit() {
     let resp = press(&mut server, XKB_KEY_RETURN);
     let commits = actions_of(&resp, "commit");
     assert_eq!(commits.last().unwrap()["text"], "か");
+    assert!(actions_of(&resp, "update_preedit").is_empty());
 }
 
 #[test]
@@ -140,6 +141,7 @@ fn test_explicit_commit_method() {
     );
     let commits = actions_of(&resp, "commit");
     assert_eq!(commits.last().unwrap()["text"], "か");
+    assert!(actions_of(&resp, "update_preedit").is_empty());
 
     // Nothing left to commit afterwards
     let resp = request(
@@ -147,6 +149,7 @@ fn test_explicit_commit_method() {
         json!({"jsonrpc":"2.0","id":8,"method":"commit"}),
     );
     assert!(actions_of(&resp, "commit").is_empty());
+    assert_eq!(actions_of(&resp, "update_preedit").last().unwrap()["text"], "");
 }
 
 #[test]
@@ -168,6 +171,7 @@ fn test_select_candidate_commits_page_candidate() {
     assert_eq!(resp["result"]["consumed"], true);
     let commits = actions_of(&resp, "commit");
     assert_eq!(commits.last().unwrap()["text"], first_text);
+    assert!(actions_of(&resp, "update_preedit").is_empty());
     assert!(!actions_of(&resp, "hide_candidates").is_empty());
 
     let resp = request(

--- a/karukan-im/src/server/tests.rs
+++ b/karukan-im/src/server/tests.rs
@@ -149,7 +149,10 @@ fn test_explicit_commit_method() {
         json!({"jsonrpc":"2.0","id":8,"method":"commit"}),
     );
     assert!(actions_of(&resp, "commit").is_empty());
-    assert_eq!(actions_of(&resp, "update_preedit").last().unwrap()["text"], "");
+    assert_eq!(
+        actions_of(&resp, "update_preedit").last().unwrap()["text"],
+        ""
+    );
 }
 
 #[test]


### PR DESCRIPTION
#46 の取り込みPRです。作者は @kota113 さん（コミットの author はそのまま保持しています）。

#46 は CI の Format チェックが fail していましたが、フォークブランチへの maintainer push が権限エラーで通らなかったため、こちらで `cargo fmt` の修正コミット（\`Run fmt\`）を乗せた別PRとして作成しました。

## 元PRの概要（#46 より）

macOS では \`Commit(text)\` が \`insertText(text, replacementRange:)\` に対応し、現在の marked text を確定文字列で置き換えます。これまで確定時に \`UpdatePreedit("")\` と \`Commit(text)\` を同じ action バッチで返していたため、\`setMarkedText("")\` の直後に \`insertText(...)\` を呼ぶ順序になっており、JetBrains の IDE など一部のソフトウェアでは確定文字列が入力欄へ反映されず、Enter キーが素通りしていました。

commit する文字列がある場合は同じバッチ内で空の \`UpdatePreedit("")\` を送らないようにします。キャンセルや reset など commit を伴わない cleanup では従来どおり空 preedit を送ります。

## このPRでの追加分

- \`Run fmt\`: \`karukan-im/src/server/tests.rs\` の rustfmt 修正（CI Format fail の解消）

## テスト

- \`cargo test -p karukan-im -p karukan-fcitx5\`
- \`cargo fmt --all --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)