### PR TITLE
#46のフォローアップ: rustfmt修正とmacOSのsurrounding text再取得の回帰修正

### DIFF
--- a/karukan-im/src/server/tests.rs
+++ b/karukan-im/src/server/tests.rs
@@ -149,7 +149,10 @@ fn test_explicit_commit_method() {
         json!({"jsonrpc":"2.0","id":8,"method":"commit"}),
     );
     assert!(actions_of(&resp, "commit").is_empty());
-    assert_eq!(actions_of(&resp, "update_preedit").last().unwrap()["text"], "");
+    assert_eq!(
+        actions_of(&resp, "update_preedit").last().unwrap()["text"],
+        ""
+    );
 }
 
 #[test]

--- a/karukan-macos/Sources/KarukanIME/KarukanInputController.swift
+++ b/karukan-macos/Sources/KarukanIME/KarukanInputController.swift
@@ -130,6 +130,11 @@ class KarukanInputController: IMKInputController {
         for action in actions {
             switch action {
             case .commit(let text):
+                // insertText replaces the marked text and ends the
+                // composition; since #46 the engine no longer pairs Commit
+                // with an empty UpdatePreedit, so clear the flag here or the
+                // next keystroke would skip the surrounding-text refresh.
+                hasPreedit = false
                 client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
 
             case .updatePreedit(let text, let caret, let attributes):


### PR DESCRIPTION
## 背景

#46（commit 時に空の `UpdatePreedit` を送らない変更）のフォローアップ2件です。

## 変更点

### 1. `cargo fmt` の修正（`karukan-im/src/server/tests.rs`）

#46 で追加されたテストに rustfmt 未適用の箇所があり、CI の Format チェックが fail していたため修正しました。

### 2. macOS: 確定後に surrounding text が再取得されなくなる回帰の修正

macOS フロントエンドの `hasPreedit` フラグは `update_preedit` action からのみ更新され、`!hasPreedit` のときだけ次のキー入力前に surrounding text（変換文脈 lctx 用）をエンジンへ送る設計になっています。

#46 で commit バッチに空の `UpdatePreedit("")` が含まれなくなった結果、確定後も `hasPreedit` が `true` のまま残り、surrounding text の再取得が確定以降スキップされ続けていました。エンジン側は `commit()` で `surrounding_context` をクリアするため、確定後の変換が常に文脈なしで走る（変換精度が静かに劣化する）状態でした。

`Commit` action の適用時に `hasPreedit = false` を立てて修正します。`insertText` 自体が marked text を置換して composition を終了させるため、これはエンジンが空 preedit を送らなくなった挙動とも整合します。

## テスト

- `cargo fmt --all --check`
- `cargo test -p karukan-im`（219件パス）
- `swift build` / `swift test`（27件パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)