### PR TITLE
refactor(im): consolidate input-mode state into ModeState

### DIFF
--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -386,7 +386,7 @@ impl InputMethodEngine {
             // after rewriters have run — otherwise `:smile` would be
             // pinned to the top of the candidate list as a Fallback
             // and outrank the 😄 we surface in step 5/6.
-            if builder.is_empty() && self.input_mode != InputMode::Emoji {
+            if builder.is_empty() && self.mode.current() != InputMode::Emoji {
                 builder.push(AnnotatedCandidate::new(
                     hiragana.clone(),
                     CandidateSource::Fallback,
@@ -420,7 +420,7 @@ impl InputMethodEngine {
             .converters
             .rewriters
             .rewrite_all(&[reading.to_string()]);
-        if self.input_mode == InputMode::Emoji {
+        if self.mode.current() == InputMode::Emoji {
             for (variant, description) in rewriter_variants {
                 builder.push(
                     AnnotatedCandidate::new(variant, CandidateSource::Rewriter)
@@ -643,7 +643,7 @@ impl InputMethodEngine {
         // Skip learning when the buffer is a `:shortcode` query — the
         // reading would be e.g. `:smile`, which isn't a hiragana key
         // and would corrupt the kana-keyed learning cache.
-        if self.input_mode != InputMode::Emoji
+        if self.mode.current() != InputMode::Emoji
             && let Some(reading) = &reading
         {
             self.record_learning(reading, &text);
@@ -651,8 +651,7 @@ impl InputMethodEngine {
 
         self.state = InputState::Empty;
         self.input_buf.text.clear();
-        self.exit_emoji_mode();
-        self.exit_alphabet_mode();
+        self.mode.exit_temporary();
 
         EngineResult::consumed()
             .with_action(EngineAction::HideCandidates)
@@ -666,7 +665,7 @@ impl InputMethodEngine {
             return EngineResult::not_consumed();
         };
 
-        if self.input_mode != InputMode::Emoji
+        if self.mode.current() != InputMode::Emoji
             && let Some(reading) = &reading
         {
             self.record_learning(reading, &text);
@@ -674,8 +673,7 @@ impl InputMethodEngine {
 
         self.state = InputState::Empty;
         self.input_buf.text.clear();
-        self.exit_emoji_mode();
-        self.exit_alphabet_mode();
+        self.mode.exit_temporary();
 
         // Start new input with the character
         let new_input_result = self.start_input(ch);

--- a/karukan-im/src/core/engine/display.rs
+++ b/karukan-im/src/core/engine/display.rs
@@ -21,7 +21,7 @@ impl InputMethodEngine {
             .collect();
         let buffer = self.converters.romaji.buffer();
 
-        let katakana = self.input_mode == InputMode::Katakana;
+        let katakana = self.mode.current() == InputMode::Katakana;
         let display_before = if katakana {
             karukan_engine::hiragana_to_katakana(&before)
         } else {
@@ -124,7 +124,7 @@ impl InputMethodEngine {
 
     /// Get the current mode indicator string
     pub(super) fn mode_indicator(&self) -> String {
-        let base = match self.input_mode {
+        let base = match self.mode.current() {
             InputMode::Alphabet => "[A]",
             InputMode::Katakana => "[カ]",
             InputMode::Hiragana => "[あ]",

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -18,7 +18,7 @@ impl InputMethodEngine {
         // preserve the existing conversion display without re-running the model.
         // (When the buffer still contains kana we fall through and reconvert below,
         // so a mixed reading like `きょうはABC` keeps live-converting.)
-        if self.input_mode == InputMode::Alphabet
+        if self.mode.current() == InputMode::Alphabet
             && !self.live.text.is_empty()
             && !karukan_engine::contains_kana(&self.input_buf.text)
         {
@@ -34,7 +34,7 @@ impl InputMethodEngine {
         // bounded-length chunks so per-keystroke latency stays flat; for input
         // within one chunk this is identical to a whole-buffer call.
         let convert = !self.input_buf.text.is_empty()
-            && (self.input_mode != InputMode::Alphabet
+            && (self.mode.current() != InputMode::Alphabet
                 || karukan_engine::contains_kana(&self.input_buf.text));
         let candidates = if convert {
             let reading = self.input_buf.text.clone();
@@ -70,7 +70,7 @@ impl InputMethodEngine {
         };
 
         // Live conversion mode: show converted text in preedit
-        if self.live.enabled && self.input_mode != InputMode::Katakana {
+        if self.live.enabled && self.mode.current() != InputMode::Katakana {
             self.live.text = candidates[0].clone();
             let preedit = self.set_composing_state();
 
@@ -146,7 +146,7 @@ impl InputMethodEngine {
         // The full-width space gesture from Empty in any mode is
         // `Ctrl+Space` (above), which seeds a Composing session.
         if key.keysym == Keysym::SPACE && !key.modifiers.control_key && !key.modifiers.alt_key {
-            return if self.input_mode == InputMode::Hiragana {
+            return if self.mode.current() == InputMode::Hiragana {
                 EngineResult::consumed().with_action(EngineAction::Commit("\u{3000}".to_string()))
             } else {
                 EngineResult::not_consumed()
@@ -169,7 +169,7 @@ impl InputMethodEngine {
         if typed_colon
             && !key.modifiers.control_key
             && !key.modifiers.alt_key
-            && self.input_mode != InputMode::Alphabet
+            && self.mode.current() != InputMode::Alphabet
         {
             return self.start_emoji_mode();
         }
@@ -185,14 +185,13 @@ impl InputMethodEngine {
             let is_shift_alpha =
                 ch.is_ascii_uppercase() || (shift_active && ch.is_ascii_alphabetic());
 
-            if is_shift_alpha && self.input_mode != InputMode::Alphabet {
-                // Remember the mode to restore when this word is committed:
+            if is_shift_alpha {
                 // Shift-alphabet is a temporary per-word mode, not a sticky
-                // toggle, so the next word returns to kana (issue #37).
-                self.pre_alphabet_mode = Some(self.input_mode);
-                self.input_mode = InputMode::Alphabet;
+                // toggle: ModeState remembers the mode to restore when this
+                // word is committed, so the next word returns to kana (#37).
+                self.mode.enter_temporary(InputMode::Alphabet);
             }
-            let ch = if self.input_mode == InputMode::Alphabet && is_shift_alpha {
+            let ch = if self.mode.current() == InputMode::Alphabet && is_shift_alpha {
                 ch.to_ascii_uppercase()
             } else {
                 ch
@@ -208,7 +207,7 @@ impl InputMethodEngine {
         self.converters.romaji.reset();
         self.input_buf.clear();
 
-        if self.input_mode == InputMode::Alphabet {
+        if self.mode.current() == InputMode::Alphabet {
             self.input_buf.insert(&ch.to_string());
         } else {
             let prev_output_len = 0;
@@ -281,7 +280,7 @@ impl InputMethodEngine {
             Keysym::ESCAPE => self.cancel_composing(),
             Keysym::BACKSPACE => self.backspace_composing(),
             Keysym::DELETE => self.delete_composing(),
-            Keysym::SPACE if self.input_mode == InputMode::Alphabet => self.input_char(' '),
+            Keysym::SPACE if self.mode.current() == InputMode::Alphabet => self.input_char(' '),
             // Tab triggers conversion that bypasses the learning cache, so users
             // can escape stale or unwanted learned entries (mozc binds Tab to a
             // different conversion path — PredictAndConvert — in the same spirit).
@@ -301,20 +300,20 @@ impl InputMethodEngine {
                     let is_shift_alpha =
                         ch.is_ascii_uppercase() || (shift_active && ch.is_ascii_alphabetic());
 
-                    if is_shift_alpha && self.input_mode != InputMode::Alphabet {
-                        // Remember the mode to restore on commit/cancel:
-                        // Shift-alphabet is a temporary per-word mode, so the
-                        // next word returns to the prior mode (issue #37).
-                        self.pre_alphabet_mode = Some(self.input_mode);
+                    if is_shift_alpha && self.mode.current() != InputMode::Alphabet {
                         // Bake katakana before switching so preedit doesn't revert
-                        if self.input_mode == InputMode::Katakana {
+                        if self.mode.current() == InputMode::Katakana {
                             self.bake_katakana();
                         }
-                        self.input_mode = InputMode::Alphabet;
+                        // Shift-alphabet is a temporary per-word mode:
+                        // ModeState remembers the mode to restore on
+                        // commit/cancel, so the next word returns to the
+                        // prior mode (issue #37).
+                        self.mode.enter_temporary(InputMode::Alphabet);
                         self.flush_romaji_to_composed();
                         self.live.text.clear();
                     }
-                    let ch = if self.input_mode == InputMode::Alphabet && is_shift_alpha {
+                    let ch = if self.mode.current() == InputMode::Alphabet && is_shift_alpha {
                         ch.to_ascii_uppercase()
                     } else {
                         ch
@@ -328,7 +327,7 @@ impl InputMethodEngine {
 
     /// Begin a new emoji-shortcode composing session.
     ///
-    /// Resets any leftover state, switches `input_mode` to
+    /// Resets any leftover state, switches the input mode to
     /// [`InputMode::Emoji`], seeds the buffer with `:`, and refreshes
     /// the candidate list so the user sees emoji suggestions appear
     /// the moment they press `:`.
@@ -338,12 +337,10 @@ impl InputMethodEngine {
         self.live.text.clear();
         // Remember where the user was so commit/cancel/erase-to-empty
         // can drop them back into the same mode (e.g. Katakana stays
-        // Katakana). Guard against clobbering on re-entry just in case
-        // start_emoji_mode is ever called while already in Emoji mode.
-        if self.input_mode != InputMode::Emoji {
-            self.pre_emoji_mode = Some(self.input_mode);
-        }
-        self.input_mode = InputMode::Emoji;
+        // Katakana). ModeState guards against clobbering the saved mode
+        // on re-entry just in case start_emoji_mode is ever called while
+        // already in Emoji mode.
+        self.mode.enter_temporary(InputMode::Emoji);
         self.input_buf.insert(":");
         self.refresh_input_state()
     }
@@ -363,7 +360,7 @@ impl InputMethodEngine {
     /// Input a character during composing.
     /// In alphabet mode, inserts directly; otherwise goes through romaji conversion.
     pub(super) fn input_char(&mut self, ch: char) -> EngineResult {
-        if matches!(self.input_mode, InputMode::Alphabet | InputMode::Emoji) {
+        if matches!(self.mode.current(), InputMode::Alphabet | InputMode::Emoji) {
             self.input_buf.insert(&ch.to_string());
             return self.refresh_input_state();
         }
@@ -405,14 +402,14 @@ impl InputMethodEngine {
         self.flush_romaji_to_composed();
 
         let reading = self.input_buf.text.clone();
-        let text = if self.input_mode == InputMode::Emoji {
+        let text = if self.mode.current() == InputMode::Emoji {
             // Emoji mode: Enter should select the first emoji candidate the
             // EmojiRewriter would surface, not commit the literal `:smile`.
             // Falls back to the literal buffer when nothing matches (e.g.
             // `:xyz`) so the user still sees what they typed.
             self.first_emoji_candidate(&reading)
                 .unwrap_or_else(|| reading.clone())
-        } else if self.input_mode == InputMode::Katakana {
+        } else if self.mode.current() == InputMode::Katakana {
             // Katakana mode always commits katakana, ignoring live conversion
             karukan_engine::hiragana_to_katakana(&reading)
         } else if !self.live.text.is_empty() {
@@ -436,7 +433,7 @@ impl InputMethodEngine {
         // Skip the learning record for emoji mode — the buffer holds
         // a Slack-style query like `:smile`, not a hiragana reading,
         // so storing it would corrupt the kana-keyed learning cache.
-        if self.input_mode != InputMode::Emoji {
+        if self.mode.current() != InputMode::Emoji {
             self.record_learning(&reading, &text);
         }
 
@@ -445,10 +442,10 @@ impl InputMethodEngine {
         self.live.text.clear();
         self.chunks.clear();
         self.state = InputState::Empty;
-        self.exit_emoji_mode();
-        // Shift-alphabet is temporary: committing the word returns to the
-        // prior mode (Hiragana), so the next word is converted again (#37).
-        self.exit_alphabet_mode();
+        // Temporary modes (Emoji, Alphabet) end with the composition:
+        // committing the word returns to the prior mode, so the next word
+        // is converted again (#37).
+        self.mode.exit_temporary();
 
         // HideCandidates is required here: the auto-suggest/live-conversion
         // window may be open while Composing, and the macOS frontend's
@@ -481,7 +478,7 @@ impl InputMethodEngine {
         // discard the typed characters which is surprising when the
         // user just wanted to dismiss the candidate list.
         let emoji_literal =
-            if self.input_mode == InputMode::Emoji && !self.input_buf.text.is_empty() {
+            if self.mode.current() == InputMode::Emoji && !self.input_buf.text.is_empty() {
                 Some(self.input_buf.text.clone())
             } else {
                 None
@@ -492,13 +489,11 @@ impl InputMethodEngine {
         self.live.text.clear();
         self.chunks.clear();
         self.state = InputState::Empty;
-        // Emoji mode is per-session: leaving it returns the user to
-        // whatever mode they were in before typing `:` so their next
-        // word doesn't unexpectedly stay in ASCII-passthrough mode.
-        self.exit_emoji_mode();
-        // Same for Shift-triggered Alphabet mode: cancelling restores the
-        // prior mode so the next word is back in kana (#37).
-        self.exit_alphabet_mode();
+        // Temporary modes (Emoji, Alphabet) are per-session: cancelling
+        // returns the user to whatever mode they were in before, so their
+        // next word doesn't unexpectedly stay in ASCII-passthrough mode
+        // (#37).
+        self.mode.exit_temporary();
 
         if let Some(literal) = emoji_literal {
             EngineResult::consumed()

--- a/karukan-im/src/core/engine/mod.rs
+++ b/karukan-im/src/core/engine/mod.rs
@@ -132,20 +132,9 @@ pub struct InputMethodEngine {
     config: EngineConfig,
     /// Conversion timing and adaptive model metrics
     metrics: ConversionMetrics,
-    /// Current input mode (Hiragana, Katakana, or Alphabet)
-    input_mode: InputMode,
-    /// Mode active immediately before entering [`InputMode::Emoji`],
-    /// so commit/cancel/backspace-to-empty can put the user back where
-    /// they were instead of dropping them in Hiragana every time. `None`
-    /// whenever the current mode is not Emoji.
-    pre_emoji_mode: Option<InputMode>,
-    /// Mode active immediately before Shift+letter switched to
-    /// [`InputMode::Alphabet`]. Alphabet is a *temporary* per-composition
-    /// mode: commit/cancel/backspace-to-empty restores this mode so the next
-    /// word goes back to kana automatically, matching the macOS/Google IME
-    /// convention (the Shift gesture is per-word, not a sticky toggle). `None`
-    /// whenever the current mode is not Alphabet.
-    pre_alphabet_mode: Option<InputMode>,
+    /// Current input mode plus the mode to come back to when a temporary
+    /// mode (Emoji, Alphabet) ends — see [`ModeState`]
+    mode: ModeState,
     /// Composed input buffer (hiragana text, cursor position)
     input_buf: InputBuffer,
     /// Live conversion state
@@ -176,9 +165,7 @@ impl InputMethodEngine {
             surrounding_context: None,
             config: EngineConfig::default(),
             metrics: ConversionMetrics::default(),
-            input_mode: InputMode::Hiragana,
-            pre_emoji_mode: None,
-            pre_alphabet_mode: None,
+            mode: ModeState::default(),
             input_buf: InputBuffer::new(),
             live: LiveConversion::default(),
             chunks: Vec::new(),
@@ -250,39 +237,11 @@ impl InputMethodEngine {
     pub fn reset(&mut self) {
         self.state = InputState::Empty;
         self.converters.romaji.reset();
-        self.input_mode = InputMode::Hiragana;
-        self.pre_emoji_mode = None;
-        self.pre_alphabet_mode = None;
+        self.mode = ModeState::default();
         self.input_buf.clear();
         self.live.text.clear();
         self.chunks.clear();
         self.metrics = ConversionMetrics::default();
-    }
-
-    /// If currently in Emoji mode, restore the mode the user was in
-    /// before they typed `:`. Falls back to Hiragana if nothing was
-    /// saved (defensive — `start_emoji_mode` always sets it). No-op
-    /// when not in Emoji mode, so it's safe to call unconditionally
-    /// from the various exit sites.
-    pub(super) fn exit_emoji_mode(&mut self) {
-        if self.input_mode == InputMode::Emoji {
-            self.input_mode = self.pre_emoji_mode.take().unwrap_or(InputMode::Hiragana);
-        }
-    }
-
-    /// If currently in Alphabet mode, restore the mode the user was in before
-    /// Shift+letter switched to it. Falls back to Hiragana if nothing was
-    /// saved. No-op when not in Alphabet mode, so it's safe to call
-    /// unconditionally from the commit/cancel/erase-to-empty exit sites.
-    ///
-    /// This is what makes Shift-triggered alphabet input *temporary*: once the
-    /// word is committed (or abandoned), the next word returns to kana without
-    /// an explicit toggle key — the behavior US-layout users expect, since
-    /// they have no JIS かな key to switch back with (issue #37).
-    pub(super) fn exit_alphabet_mode(&mut self) {
-        if self.input_mode == InputMode::Alphabet {
-            self.input_mode = self.pre_alphabet_mode.take().unwrap_or(InputMode::Hiragana);
-        }
     }
 
     /// If the display is empty, reset to Empty state and return the result.
@@ -298,16 +257,12 @@ impl InputMethodEngine {
             // against a buffer it no longer matches).
             self.live.text.clear();
             self.chunks.clear();
-            // Emoji mode is per-session and bound to the typed `:` —
-            // if the user erased back to an empty buffer, the session
-            // is over. Restore whatever mode the user was in before
-            // entering Emoji so the next keypress doesn't get treated
-            // as a literal emoji-query char (and so a Katakana-mode user
-            // lands back in Katakana, not Hiragana).
-            self.exit_emoji_mode();
-            // Likewise, Shift-triggered Alphabet mode is per-composition:
-            // erasing back to empty ends it, so restore the prior mode.
-            self.exit_alphabet_mode();
+            // Temporary modes (Emoji, Alphabet) are per-composition:
+            // erasing back to an empty buffer ends the session, so restore
+            // the mode the user was in before entering it (a Katakana-mode
+            // user lands back in Katakana, and the next keypress doesn't
+            // get treated as a literal emoji-query char).
+            self.mode.exit_temporary();
             Some(
                 EngineResult::consumed()
                     .with_action(EngineAction::UpdatePreedit(Preedit::new()))
@@ -436,12 +391,12 @@ impl InputMethodEngine {
         }
         // Only consume the key when actually switching; otherwise pass through
         // so the system can properly track modifier state.
-        if key.is_press && self.input_mode != InputMode::Hiragana {
+        if key.is_press && self.mode.current() != InputMode::Hiragana {
             // Bake katakana before switching so preedit doesn't revert
-            if self.input_mode == InputMode::Katakana {
+            if self.mode.current() == InputMode::Katakana {
                 self.bake_katakana();
             }
-            self.input_mode = InputMode::Hiragana;
+            self.mode.set(InputMode::Hiragana);
             self.flush_romaji_to_composed();
             let aux = self.format_aux_composing();
             if matches!(self.state, InputState::Composing { .. }) {

--- a/karukan-im/src/core/engine/mode.rs
+++ b/karukan-im/src/core/engine/mode.rs
@@ -9,11 +9,11 @@ impl InputMethodEngine {
     /// One-way switch to Katakana; use Right Super to return to Hiragana.
     pub(super) fn enter_katakana_mode(&mut self) -> EngineResult {
         // Already in katakana mode: nothing to do
-        if self.input_mode == InputMode::Katakana {
+        if self.mode.current() == InputMode::Katakana {
             return EngineResult::consumed();
         }
 
-        self.input_mode = InputMode::Katakana;
+        self.mode.set(InputMode::Katakana);
         // Clear live conversion text so katakana mode takes priority on commit
         self.live.text.clear();
 
@@ -46,7 +46,7 @@ impl InputMethodEngine {
         let aux = EngineAction::UpdateAuxText(format!("ライブ変換: {}", mode));
 
         if matches!(self.state, InputState::Composing { .. })
-            && self.input_mode != InputMode::Katakana
+            && self.mode.current() != InputMode::Katakana
         {
             if self.live.enabled {
                 let mut result = self.refresh_input_state();

--- a/karukan-im/src/core/engine/tests/alphabet.rs
+++ b/karukan-im/src/core/engine/tests/alphabet.rs
@@ -5,40 +5,40 @@ use super::*;
 #[test]
 fn test_shift_alone_does_not_toggle_mode() {
     let mut engine = InputMethodEngine::new();
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Shift press alone should NOT toggle mode
     let result = engine.process_key(&press_key(Keysym::SHIFT_L));
     assert!(!result.consumed);
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Shift release is a no-op
     let result = engine.process_key(&release_key(Keysym::SHIFT_L));
     assert!(!result.consumed);
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 }
 
 #[test]
 fn test_shift_letter_enters_alphabet_mode() {
     let mut engine = InputMethodEngine::new();
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Shift+A → enters alphabet mode and inputs 'A'
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
     assert!(matches!(engine.state(), InputState::Composing { .. }));
     assert_eq!(engine.preedit().unwrap().text(), "A");
 
     // Release shift → no-op
     engine.process_key(&release_key(Keysym::SHIFT_L));
-    assert!(engine.input_mode == InputMode::Alphabet); // Still in alphabet mode
+    assert!(engine.mode.current() == InputMode::Alphabet); // Still in alphabet mode
 }
 
 #[test]
 fn test_shift_letter_fcitx5_lowercase_keysym() {
     // fcitx5 sends lowercase keysym 'a' (0x0061) with shift modifier flag
     let mut engine = InputMethodEngine::new();
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // fcitx5 sends keysym='a' (lowercase!) with modifiers.shift_key=true
     // This should enter alphabet mode and input uppercase 'A'
@@ -48,7 +48,7 @@ fn test_shift_letter_fcitx5_lowercase_keysym() {
         true,
     );
     engine.process_key(&event);
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
     assert!(matches!(engine.state(), InputState::Composing { .. }));
     // Should be uppercase 'A' in preedit
     assert_eq!(engine.preedit().unwrap().text(), "A");
@@ -61,7 +61,7 @@ fn test_shift_letter_in_hiragana_enters_alphabet_and_uppercase() {
     // Type some hiragana first
     engine.process_key(&press('a'));
     assert_eq!(engine.preedit().unwrap().text(), "あ");
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Shift press
     engine.process_key(&press_key(Keysym::SHIFT_L));
@@ -69,7 +69,7 @@ fn test_shift_letter_in_hiragana_enters_alphabet_and_uppercase() {
     // Shift+a (fcitx5 sends lowercase keysym)
     let event = KeyEvent::new(Keysym(0x0061), KeyModifiers::new().with_shift(true), true);
     engine.process_key(&event);
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
     assert_eq!(engine.preedit().unwrap().text(), "あA");
 }
 
@@ -78,7 +78,7 @@ fn test_uppercase_keysym_without_shift_flag_enters_alphabet() {
     // fcitx5 may resolve Shift into the keysym, sending 'A' (0x0041) without
     // the shift modifier flag. This must still enter alphabet mode.
     let mut engine = InputMethodEngine::new();
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Empty state: uppercase keysym without shift flag
     let event = KeyEvent::new(
@@ -88,7 +88,7 @@ fn test_uppercase_keysym_without_shift_flag_enters_alphabet() {
     );
     engine.process_key(&event);
     assert!(
-        engine.input_mode == InputMode::Alphabet,
+        engine.mode.current() == InputMode::Alphabet,
         "Uppercase keysym should enter alphabet mode even without shift flag"
     );
     assert_eq!(engine.preedit().unwrap().text(), "A");
@@ -102,7 +102,7 @@ fn test_uppercase_keysym_without_shift_flag_composing() {
     // Type hiragana first
     engine.process_key(&press('a'));
     assert_eq!(engine.preedit().unwrap().text(), "あ");
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Uppercase keysym without shift flag
     let event = KeyEvent::new(
@@ -112,7 +112,7 @@ fn test_uppercase_keysym_without_shift_flag_composing() {
     );
     engine.process_key(&event);
     assert!(
-        engine.input_mode == InputMode::Alphabet,
+        engine.mode.current() == InputMode::Alphabet,
         "Uppercase keysym should enter alphabet mode during composing"
     );
     assert_eq!(engine.preedit().unwrap().text(), "あA");
@@ -122,7 +122,7 @@ fn test_uppercase_keysym_without_shift_flag_composing() {
 fn test_shift_symbol_stays_in_hiragana_mode() {
     // Shift+symbol should NOT enter alphabet mode (only Shift+letter does)
     let mut engine = InputMethodEngine::new();
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // '!' with shift modifier → stays in hiragana mode
     let event = KeyEvent::new(
@@ -131,14 +131,14 @@ fn test_shift_symbol_stays_in_hiragana_mode() {
         true,
     );
     engine.process_key(&event);
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 }
 
 #[test]
 fn test_shift_digit_stays_in_hiragana_mode() {
     // Shift+digit should NOT enter alphabet mode (only Shift+letter does)
     let mut engine = InputMethodEngine::new();
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // '2' with shift modifier → stays in hiragana mode
     let event = KeyEvent::new(
@@ -147,7 +147,7 @@ fn test_shift_digit_stays_in_hiragana_mode() {
         true,
     );
     engine.process_key(&event);
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 }
 
 #[test]
@@ -156,7 +156,7 @@ fn test_alphabet_mode_uppercase_with_shift() {
 
     // Shift+A → enters alphabet mode and inputs 'A'
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     // Type lowercase 'a' → should be 'a'
     engine.process_key(&press('a'));
@@ -169,7 +169,7 @@ fn test_alphabet_mode_uppercase_with_shift() {
         true,
     );
     engine.process_key(&event);
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
     assert_eq!(engine.preedit().unwrap().text(), "AaA");
 }
 
@@ -179,7 +179,7 @@ fn test_alphabet_mode_direct_input() {
 
     // Shift+A → enters alphabet mode and inputs 'A'
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
     assert!(matches!(engine.state(), InputState::Composing { .. }));
     assert_eq!(engine.preedit().unwrap().text(), "A");
 
@@ -206,7 +206,7 @@ fn test_mixed_hiragana_alphabet_input() {
     engine.process_key(&press('h'));
     engine.process_key(&press('a'));
     assert_eq!(engine.preedit().unwrap().text(), "わたしは");
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Shift+L → enters alphabet mode, inputs 'L'
     // fcitx5 sends lowercase keysym with shift flag
@@ -216,7 +216,7 @@ fn test_mixed_hiragana_alphabet_input() {
         true,
     );
     engine.process_key(&event);
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
     assert_eq!(engine.preedit().unwrap().text(), "わたしはL");
 
     // Continue typing in alphabet mode (without shift → lowercase)
@@ -233,7 +233,7 @@ fn test_shift_alphabet_reverts_to_hiragana_after_commit() {
 
     // Enter alphabet mode via Shift+H from the default Hiragana mode
     engine.process_key(&press_shift('H'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     // Type and commit the alphabet word
     engine.process_key(&press('i'));
@@ -242,7 +242,7 @@ fn test_shift_alphabet_reverts_to_hiragana_after_commit() {
 
     // Shift-alphabet is a temporary per-word mode: after commit we are back
     // in Hiragana, so the next word is converted to kana again (issue #37).
-    assert!(engine.input_mode == InputMode::Hiragana);
+    assert!(engine.mode.current() == InputMode::Hiragana);
     engine.process_key(&press('a'));
     assert_eq!(engine.preedit().unwrap().text(), "あ");
 }
@@ -258,7 +258,7 @@ fn test_shift_alphabet_reverts_to_hiragana_after_cancel() {
     engine.process_key(&press_key(Keysym::ESCAPE));
     assert!(matches!(engine.state(), InputState::Empty));
     // Cancelling the temporary alphabet word restores Hiragana
-    assert!(engine.input_mode == InputMode::Hiragana);
+    assert!(engine.mode.current() == InputMode::Hiragana);
     engine.process_key(&press('a'));
     assert_eq!(engine.preedit().unwrap().text(), "あ");
 }
@@ -269,12 +269,12 @@ fn test_shift_alphabet_reverts_to_hiragana_after_erase_to_empty() {
 
     // Enter alphabet mode via Shift+A
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     // Erasing back to an empty buffer ends the temporary alphabet word
     engine.process_key(&press_key(Keysym::BACKSPACE));
     assert!(matches!(engine.state(), InputState::Empty));
-    assert!(engine.input_mode == InputMode::Hiragana);
+    assert!(engine.mode.current() == InputMode::Hiragana);
 }
 
 #[test]
@@ -284,16 +284,16 @@ fn test_shift_alphabet_from_katakana_reverts_to_katakana() {
     // Type a char, then switch to katakana mode (Ctrl+K)
     engine.process_key(&press('a'));
     engine.process_key(&press_ctrl(Keysym::KEY_K));
-    assert!(engine.input_mode == InputMode::Katakana);
+    assert!(engine.mode.current() == InputMode::Katakana);
 
     // Shift+A enters alphabet, remembering Katakana as the prior mode
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     // Commit → reverts to Katakana (the mode before the Shift gesture),
     // not all the way to Hiragana
     engine.process_key(&press_key(Keysym::RETURN));
-    assert!(engine.input_mode == InputMode::Katakana);
+    assert!(engine.mode.current() == InputMode::Katakana);
 }
 
 #[test]
@@ -317,11 +317,11 @@ fn test_alphabet_mode_aux_text() {
 #[test]
 fn test_shift_right_alone_does_not_toggle() {
     let mut engine = InputMethodEngine::new();
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Right Shift alone should NOT toggle alphabet mode
     engine.process_key(&press_key(Keysym::SHIFT_R));
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 }
 
 #[test]
@@ -330,8 +330,8 @@ fn test_reset_clears_alphabet_mode() {
 
     // Enter alphabet mode via Shift+A
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     engine.reset();
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 }

--- a/karukan-im/src/core/engine/tests/basic.rs
+++ b/karukan-im/src/core/engine/tests/basic.rs
@@ -65,7 +65,7 @@ fn space_in_empty_hiragana_commits_fullwidth_space() {
     // convention, but without the side effect of "second Space starts
     // Conversion mode" that a Composing-state insertion would cause.
     let mut engine = InputMethodEngine::new();
-    assert_eq!(engine.input_mode, InputMode::Hiragana);
+    assert_eq!(engine.mode.current(), InputMode::Hiragana);
 
     let result = engine.process_key(&press_key(Keysym::SPACE));
     assert!(result.consumed);
@@ -99,7 +99,7 @@ fn space_in_empty_katakana_passes_through() {
     // Non-Hiragana modes pass the bare Space through to the OS so the
     // application gets a normal half-width ASCII space.
     let mut engine = InputMethodEngine::new();
-    engine.input_mode = InputMode::Katakana;
+    engine.mode.set(InputMode::Katakana);
 
     let result = engine.process_key(&press_key(Keysym::SPACE));
     assert!(!result.consumed);
@@ -114,7 +114,7 @@ fn space_in_empty_katakana_passes_through() {
 #[test]
 fn space_in_empty_alphabet_passes_through() {
     let mut engine = InputMethodEngine::new();
-    engine.input_mode = InputMode::Alphabet;
+    engine.mode.enter_temporary(InputMode::Alphabet);
 
     let result = engine.process_key(&press_key(Keysym::SPACE));
     assert!(!result.consumed);

--- a/karukan-im/src/core/engine/tests/conversion.rs
+++ b/karukan-im/src/core/engine/tests/conversion.rs
@@ -50,7 +50,7 @@ fn test_alphabet_mode_space_inserts_literal_space() {
 
     // Enter alphabet mode via Shift+N
     engine.process_key(&press_shift('N'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     // Type "ew"
     engine.process_key(&press('e'));

--- a/karukan-im/src/core/engine/tests/emoji.rs
+++ b/karukan-im/src/core/engine/tests/emoji.rs
@@ -29,11 +29,11 @@ fn auto_suggest_texts(result: &crate::core::engine::EngineResult) -> Vec<String>
 #[test]
 fn typing_colon_in_empty_enters_emoji_mode() {
     let mut engine = InputMethodEngine::new();
-    assert_eq!(engine.input_mode, InputMode::Hiragana);
+    assert_eq!(engine.mode.current(), InputMode::Hiragana);
 
     let result = engine.process_key(&press_colon());
     assert!(result.consumed);
-    assert_eq!(engine.input_mode, InputMode::Emoji);
+    assert_eq!(engine.mode.current(), InputMode::Emoji);
     assert!(matches!(engine.state(), InputState::Composing { .. }));
     // Preedit shows the literal `:` rather than any kana — emoji mode
     // is supposed to bypass romaji conversion.
@@ -49,7 +49,7 @@ fn ascii_after_colon_stays_literal() {
     for ch in ['p', 'i', 'e', 'n'] {
         engine.process_key(&press(ch));
     }
-    assert_eq!(engine.input_mode, InputMode::Emoji);
+    assert_eq!(engine.mode.current(), InputMode::Emoji);
     assert_eq!(engine.preedit().unwrap().text(), ":pien");
 }
 
@@ -91,11 +91,11 @@ fn escape_commits_literal_and_exits_emoji_mode() {
     for ch in ['s', 'm', 'i', 'l', 'e'] {
         engine.process_key(&press(ch));
     }
-    assert_eq!(engine.input_mode, InputMode::Emoji);
+    assert_eq!(engine.mode.current(), InputMode::Emoji);
 
     let result = engine.process_key(&press_key(Keysym::ESCAPE));
     assert_eq!(commit_text(&result).as_deref(), Some(":smile"));
-    assert_eq!(engine.input_mode, InputMode::Hiragana);
+    assert_eq!(engine.mode.current(), InputMode::Hiragana);
     assert!(matches!(engine.state(), InputState::Empty));
 }
 
@@ -111,7 +111,7 @@ fn committing_emoji_resets_to_hiragana() {
     // Space starts conversion → first candidate selected → Return commits.
     engine.process_key(&press_key(Keysym::SPACE));
     engine.process_key(&press_key(Keysym::RETURN));
-    assert_eq!(engine.input_mode, InputMode::Hiragana);
+    assert_eq!(engine.mode.current(), InputMode::Hiragana);
     assert!(matches!(engine.state(), InputState::Empty));
 }
 
@@ -137,7 +137,7 @@ fn enter_on_emoji_query_commits_emoji_not_literal() {
     }
     let result = engine.process_key(&press_key(Keysym::RETURN));
     assert_eq!(commit_text(&result).as_deref(), Some("😄"));
-    assert_eq!(engine.input_mode, InputMode::Hiragana);
+    assert_eq!(engine.mode.current(), InputMode::Hiragana);
 }
 
 #[test]
@@ -274,13 +274,13 @@ fn backspacing_to_empty_exits_emoji_mode() {
     for ch in ['s', 'm', 'i', 'l', 'e'] {
         engine.process_key(&press(ch));
     }
-    assert_eq!(engine.input_mode, InputMode::Emoji);
+    assert_eq!(engine.mode.current(), InputMode::Emoji);
 
     for _ in 0..6 {
         engine.process_key(&press_key(Keysym::BACKSPACE));
     }
     assert!(matches!(engine.state(), InputState::Empty));
-    assert_eq!(engine.input_mode, InputMode::Hiragana);
+    assert_eq!(engine.mode.current(), InputMode::Hiragana);
 
     // And the very next keypress should behave like normal kana
     // input — `a` becomes `あ`, not literal `a`.
@@ -295,10 +295,10 @@ fn backspacing_to_empty_restores_pre_emoji_katakana_mode() {
     // A user typing in Katakana who pops into emoji and bails out
     // should land back in Katakana.
     let mut engine = InputMethodEngine::new();
-    engine.input_mode = InputMode::Katakana;
+    engine.mode.set(InputMode::Katakana);
 
     engine.process_key(&press_colon());
-    assert_eq!(engine.input_mode, InputMode::Emoji);
+    assert_eq!(engine.mode.current(), InputMode::Emoji);
     for ch in ['s', 'm', 'i', 'l', 'e'] {
         engine.process_key(&press(ch));
     }
@@ -307,33 +307,33 @@ fn backspacing_to_empty_restores_pre_emoji_katakana_mode() {
         engine.process_key(&press_key(Keysym::BACKSPACE));
     }
     assert!(matches!(engine.state(), InputState::Empty));
-    assert_eq!(engine.input_mode, InputMode::Katakana);
+    assert_eq!(engine.mode.current(), InputMode::Katakana);
 }
 
 #[test]
 fn commit_emoji_restores_pre_emoji_katakana_mode() {
     let mut engine = InputMethodEngine::new();
-    engine.input_mode = InputMode::Katakana;
+    engine.mode.set(InputMode::Katakana);
 
     engine.process_key(&press_colon());
     for ch in ['s', 'm', 'i', 'l', 'e'] {
         engine.process_key(&press(ch));
     }
     engine.process_key(&press_key(Keysym::RETURN));
-    assert_eq!(engine.input_mode, InputMode::Katakana);
+    assert_eq!(engine.mode.current(), InputMode::Katakana);
 }
 
 #[test]
 fn escape_emoji_restores_pre_emoji_katakana_mode() {
     let mut engine = InputMethodEngine::new();
-    engine.input_mode = InputMode::Katakana;
+    engine.mode.set(InputMode::Katakana);
 
     engine.process_key(&press_colon());
     for ch in ['s', 'm', 'i', 'l', 'e'] {
         engine.process_key(&press(ch));
     }
     engine.process_key(&press_key(Keysym::ESCAPE));
-    assert_eq!(engine.input_mode, InputMode::Katakana);
+    assert_eq!(engine.mode.current(), InputMode::Katakana);
 }
 
 #[test]
@@ -343,11 +343,11 @@ fn colon_in_hiragana_does_not_enter_emoji_when_already_composing() {
     // from Empty state.
     let mut engine = InputMethodEngine::new();
     engine.process_key(&press('a'));
-    assert_eq!(engine.input_mode, InputMode::Hiragana);
+    assert_eq!(engine.mode.current(), InputMode::Hiragana);
     assert!(matches!(engine.state(), InputState::Composing { .. }));
 
     engine.process_key(&press_colon());
-    assert_eq!(engine.input_mode, InputMode::Hiragana);
+    assert_eq!(engine.mode.current(), InputMode::Hiragana);
     // The `:` should have been absorbed by the existing composition,
     // not have triggered emoji mode.
     assert!(engine.preedit().unwrap().text().contains('あ'));

--- a/karukan-im/src/core/engine/tests/katakana.rs
+++ b/karukan-im/src/core/engine/tests/katakana.rs
@@ -43,7 +43,7 @@ fn test_ctrl_k_converts_to_katakana() {
     assert_eq!(engine.preedit().unwrap().text(), "アイウエオ");
     assert!(matches!(engine.state(), InputState::Composing { .. }));
     assert!(
-        engine.input_mode == InputMode::Katakana,
+        engine.mode.current() == InputMode::Katakana,
         "Should be in katakana mode"
     );
 
@@ -120,14 +120,14 @@ fn test_ctrl_k_uppercase_converts_to_katakana() {
     // Preedit should show katakana
     assert_eq!(engine.preedit().unwrap().text(), "アイウエオ");
     assert!(
-        engine.input_mode == InputMode::Katakana,
+        engine.mode.current() == InputMode::Katakana,
         "Should be in katakana mode"
     );
 
     // Type more → katakana mode persists (like alphabet mode)
     engine.process_key(&press('a'));
     assert!(
-        engine.input_mode == InputMode::Katakana,
+        engine.mode.current() == InputMode::Katakana,
         "Katakana mode should persist across input"
     );
     // Preedit should show katakana for the new input too
@@ -162,7 +162,7 @@ fn test_katakana_baked_on_switch_to_alphabet() {
 
     // Switch to alphabet mode via Shift+L → katakana should be baked in
     engine.process_key(&press_shift('L'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
     // The katakana text should be preserved, not reverted to hiragana
     assert_eq!(engine.input_buf.text, "アイウエオL");
 
@@ -194,17 +194,17 @@ fn test_ctrl_k_is_one_way_to_katakana() {
         is_press: true,
     };
     engine.process_key(&ctrl_k);
-    assert!(engine.input_mode == InputMode::Katakana);
+    assert!(engine.mode.current() == InputMode::Katakana);
     assert_eq!(engine.preedit().unwrap().text(), "アイ");
 
     // Ctrl+K again → still katakana mode (not a toggle)
     engine.process_key(&ctrl_k);
-    assert!(engine.input_mode == InputMode::Katakana);
+    assert!(engine.mode.current() == InputMode::Katakana);
     assert_eq!(engine.preedit().unwrap().text(), "アイ");
 
     // Right Super → return to hiragana mode, katakana is baked in
     engine.process_key(&press_key(Keysym::SUPER_R));
-    assert!(engine.input_mode == InputMode::Hiragana);
+    assert!(engine.mode.current() == InputMode::Hiragana);
     assert_eq!(engine.input_buf.text, "アイ");
     assert_eq!(engine.preedit().unwrap().text(), "アイ");
 

--- a/karukan-im/src/core/engine/tests/live_conversion.rs
+++ b/karukan-im/src/core/engine/tests/live_conversion.rs
@@ -183,7 +183,7 @@ fn test_alphabet_mode_with_kana_keeps_converting() {
     // "あ" then Shift+letter switches into alphabet mode -> buffer "あA"
     engine.process_key(&press('a'));
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
     assert!(karukan_engine::contains_kana(&engine.input_buf.text));
 
     // Simulate a previous live conversion result lingering on screen.
@@ -210,7 +210,7 @@ fn test_alphabet_mode_pure_latin_preserves_live_text() {
     // Enter alphabet mode with pure latin "Ab".
     engine.process_key(&press_shift('A'));
     engine.process_key(&press('b'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
     assert!(!karukan_engine::contains_kana(&engine.input_buf.text));
 
     engine.live.text = "AB".to_string();

--- a/karukan-im/src/core/engine/tests/mode_toggle.rs
+++ b/karukan-im/src/core/engine/tests/mode_toggle.rs
@@ -8,13 +8,13 @@ fn test_mode_toggle_key_switches_alphabet_to_hiragana() {
 
     // Enter alphabet mode via Shift+A
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     // Alt_R press → switch to hiragana mode (mid-composition; the toggle key
     // is the explicit way out, independent of the per-word auto-revert)
     let result = engine.process_key(&press_key(Keysym::ALT_R));
     assert!(result.consumed);
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Clear the composed "A", then type 'a' → should be 'あ' (hiragana mode)
     engine.process_key(&press_key(Keysym::RETURN));
@@ -25,12 +25,12 @@ fn test_mode_toggle_key_switches_alphabet_to_hiragana() {
 #[test]
 fn test_mode_toggle_key_noop_in_hiragana() {
     let mut engine = InputMethodEngine::new();
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Alt_R press in hiragana mode → not consumed, no mode change
     let result = engine.process_key(&press_key(Keysym::ALT_R));
     assert!(!result.consumed);
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Type 'a' → still hiragana
     engine.process_key(&press('a'));
@@ -45,12 +45,12 @@ fn test_mode_toggle_key_during_alphabet_input() {
     engine.process_key(&press_shift('A'));
     engine.process_key(&press('b'));
     assert_eq!(engine.preedit().unwrap().text(), "Ab");
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     // Alt_R → switch to hiragana
     let result = engine.process_key(&press_key(Keysym::ALT_R));
     assert!(result.consumed);
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 
     // Continue typing → hiragana
     engine.process_key(&press('k'));
@@ -64,12 +64,12 @@ fn test_super_r_also_switches_alphabet_to_hiragana() {
 
     // Enter alphabet mode via Shift+A
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     // Super_R press → switch to hiragana (one-way)
     let result = engine.process_key(&press_key(Keysym::SUPER_R));
     assert!(result.consumed);
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 }
 
 #[test]
@@ -78,10 +78,10 @@ fn test_meta_r_also_switches_alphabet_to_hiragana() {
 
     // Enter alphabet mode via Shift+A
     engine.process_key(&press_shift('A'));
-    assert!(engine.input_mode == InputMode::Alphabet);
+    assert!(engine.mode.current() == InputMode::Alphabet);
 
     // Meta_R press → switch to hiragana (one-way)
     let result = engine.process_key(&press_key(Keysym::META_R));
     assert!(result.consumed);
-    assert!(engine.input_mode != InputMode::Alphabet);
+    assert!(engine.mode.current() != InputMode::Alphabet);
 }

--- a/karukan-im/src/core/engine/types.rs
+++ b/karukan-im/src/core/engine/types.rs
@@ -141,9 +141,10 @@ pub(in crate::core) struct Converters {
 }
 
 /// Input mode for the IME engine
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum InputMode {
     /// Hiragana mode (default) — romaji is converted to hiragana
+    #[default]
     Hiragana,
     /// Katakana mode — preedit displays katakana instead of hiragana
     Katakana,
@@ -151,12 +152,97 @@ pub(crate) enum InputMode {
     Alphabet,
     /// Emoji shortcode mode — entered by typing `:` from Empty state.
     /// Behaves like [`InputMode::Alphabet`] (ASCII inserted directly,
-    /// no romaji conversion) but auto-exits back to [`InputMode::Hiragana`]
-    /// on commit/cancel so the next word lands in kana mode without the
-    /// user having to toggle anything. The `EmojiRewriter` picks up the
-    /// `:`-prefixed input from the candidate-build pipeline and surfaces
-    /// emoji candidates as the user types.
+    /// no romaji conversion) but auto-exits back to the prior mode on
+    /// commit/cancel (see [`ModeState`]) so the next word lands in kana
+    /// mode without the user having to toggle anything. The `EmojiRewriter`
+    /// picks up the `:`-prefixed input from the candidate-build pipeline
+    /// and surfaces emoji candidates as the user types.
     Emoji,
+}
+
+/// Input-mode state: the current [`InputMode`] plus the mode to come back
+/// to when a *temporary* mode ends.
+///
+/// [`InputMode::Emoji`] (entered by typing `:`) and [`InputMode::Alphabet`]
+/// (entered via Shift+letter) are temporary, per-composition modes: commit,
+/// cancel, and backspace-to-empty exit them and put the user back in the
+/// kana mode they came from (e.g. a Katakana-mode user lands back in
+/// Katakana) instead of dropping them in Hiragana every time.
+///
+/// Modeled after mozc's `Composer` (`src/composer/composer.cc`), which
+/// pairs `input_mode_` with a non-optional `comeback_input_mode_`.
+/// `comeback` always holds the last *non-temporary* mode and equals
+/// `current` whenever the current mode itself is not temporary, so exiting
+/// is an unconditional `current = comeback` with no fallback case. Because
+/// `comeback` can never be a temporary mode, even the degenerate hop from
+/// one temporary mode into another (Shift+letter while composing an emoji
+/// query moves Emoji → Alphabet) still exits to the user's real kana mode.
+///
+/// The fields are private so every transition goes through the methods
+/// below, which maintain that invariant by construction.
+#[derive(Debug, Default)]
+pub(crate) struct ModeState {
+    /// Current input mode.
+    current: InputMode,
+    /// The last non-temporary mode; what [`ModeState::exit_temporary`]
+    /// restores. Equal to `current` whenever `current` is not temporary
+    /// (mozc's `comeback_input_mode_` invariant).
+    comeback: InputMode,
+}
+
+impl ModeState {
+    /// Whether `mode` is a temporary, per-composition mode.
+    fn is_temporary(mode: InputMode) -> bool {
+        matches!(mode, InputMode::Emoji | InputMode::Alphabet)
+    }
+
+    /// The current input mode.
+    pub(crate) fn current(&self) -> InputMode {
+        self.current
+    }
+
+    /// Switch directly to `mode` (the mode-toggle key → Hiragana, Ctrl+K →
+    /// Katakana). The user explicitly picked a mode, so it also becomes the
+    /// comeback target (mozc's `SetInputMode`).
+    pub(crate) fn set(&mut self, mode: InputMode) {
+        debug_assert!(
+            !Self::is_temporary(mode),
+            "temporary mode {mode:?} must be entered via enter_temporary"
+        );
+        self.current = mode;
+        self.comeback = mode;
+    }
+
+    /// Enter a *temporary* mode (Emoji or Alphabet), remembering the
+    /// current mode for [`ModeState::exit_temporary`] (mozc's
+    /// `SetTemporaryInputMode`). Hopping from one temporary mode into
+    /// another keeps the original comeback target, so re-entry can't
+    /// clobber the saved mode.
+    pub(crate) fn enter_temporary(&mut self, mode: InputMode) {
+        debug_assert!(
+            Self::is_temporary(mode),
+            "enter_temporary called with non-temporary mode {mode:?}"
+        );
+        if !Self::is_temporary(self.current) {
+            self.comeback = self.current;
+        }
+        self.current = mode;
+    }
+
+    /// End any temporary mode: come back to the last non-temporary mode.
+    /// No-op when the current mode is not temporary (`comeback` equals
+    /// `current` then), so it's safe to call unconditionally from the
+    /// commit/cancel/erase-to-empty exit sites.
+    ///
+    /// This is what makes Shift-triggered alphabet input *temporary*: once
+    /// the word is committed (or abandoned), the next word returns to kana
+    /// without an explicit toggle key — the behavior US-layout users expect,
+    /// since they have no JIS かな key to switch back with (issue #37).
+    /// Likewise an emoji session is bound to the typed `:` and is over once
+    /// the query is committed, cancelled, or erased.
+    pub(crate) fn exit_temporary(&mut self) {
+        self.current = self.comeback;
+    }
 }
 
 /// One internal chunk of the composing buffer (at most


### PR DESCRIPTION
## 概要

`InputMethodEngine` がモード管理のために3つの状態変数を持っていました:

```rust
input_mode: InputMode,
pre_emoji_mode: Option<InputMode>,     // Emoji モード終了時の復元先
pre_alphabet_mode: Option<InputMode>,  // Alphabet モード終了時の復元先
```

「一時モードでないとき `pre_*` は `None`」という不変条件が各呼び出し箇所の規約でしか守られておらず、実際に直接切替(Right Alt / Ctrl+K)の経路では `pre_*` が dangling する潜在的不整合がありました。これらを `ModeState` struct に統合し、フィールドを private にして全遷移をメソッド経由に強制します。

## 設計: mozc の comeback パターン

mozc の `Composer`(`src/composer/composer.cc`)が同じ問題を `input_mode_` + **non-optional な** `comeback_input_mode_` のペアで解いているのを参考にしました:

```rust
pub(crate) struct ModeState {
    /// Current input mode.
    current: InputMode,
    /// The last non-temporary mode; what exit_temporary() restores.
    /// Equal to `current` whenever `current` is not temporary.
    comeback: InputMode,
}
```

- `comeback` は常に「最後にいた非一時モード(Hiragana / Katakana)」を保持し、一時モード(Emoji / Alphabet)中でないときは `current == comeback` が成立
- そのため復帰処理は条件分岐なしの `current = comeback` 1行(mozc の `ResetInputMode()` 相当)で、`Option` も `unwrap_or(Hiragana)` のような fallback も不要
- 「戻り先が存在しない」というドメインに無い状態を型から排除(エンジンは常に Hiragana で起動するので、戻り先は必ず存在する)

## API

| メソッド | 役割 | mozc 対応 |
|---|---|---|
| `current()` | 現在モードの取得 | `input_mode_` |
| `set(mode)` | 直接切替(Right Alt→Hiragana, Ctrl+K→Katakana)。`comeback` も同時更新 | `SetInputMode` |
| `enter_temporary(mode)` | Emoji/Alphabet への遷移。非一時モードから入るときだけ `comeback` を保存 | `SetTemporaryInputMode` |
| `exit_temporary()` | 無条件で `current = comeback`。非一時モード中は自然に no-op | `SetInputMode(comeback_input_mode_)` |

誤用(`set(Alphabet)` など)は `debug_assert` で捕捉します。

## 挙動の変化

通常フローは完全に挙動保存です。変わるのは以下の縮退ケースのみ:

- **Emoji → Shift+英字 → Alphabet のホップ**(絵文字クエリ合成中に大文字を打つ): 旧実装ではコミット後に空バッファのまま Emoji モードに戻るという奇妙な状態を経由していましたが、`comeback` には一時モードが入らないため、コミット時点でユーザーの本来のかなモード(例: Katakana)へ直接復帰します
- **直接切替時の dangling スロット解消**: `set()` が `comeback` も更新するため、旧実装で Ctrl+K / Right Alt 後に `pre_*` へ残っていた古い値(観測可能な影響はないが不変条件違反)が構造的に発生しなくなりました

付随して、呼び出し側の `exit_emoji_mode(); exit_alphabet_mode();` という順序依存のペア呼び出し(5箇所)が `exit_temporary()` 1発になっています。

## テスト

- `cargo test -p karukan-im`: 221 passed
- `cargo test -p karukan-fcitx5`: 22 passed
- `cargo clippy` / `cargo fmt`: クリーン
- 差分全体に対して3レンズ(挙動保存・エッジケース・見落とし)+敵対的検証のマルチエージェントレビューを実施し、挙動リグレッションの指摘ゼロ(docコメントの陳腐化2件は修正済み)

## 今後

カタカナを一時モード化して「Ctrl+K で新しいチャンクを発行する」mozc の per-chunk transliterator に近い設計は、別 PR として続きます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
