### PR TITLE
refactor: ワークスペース全体の重複コード統合とデッドコード削除

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,6 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
- "http-body-util",
  "indicatif",
  "karukan-engine",
  "rayon",
@@ -1341,7 +1340,6 @@ dependencies = [
  "tokenizers",
  "toml",
  "tracing",
- "tracing-subscriber",
  "unicode-normalization",
  "yada",
 ]
@@ -1365,7 +1363,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio-test",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -2569,28 +2566,6 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/karukan-cli/Cargo.toml
+++ b/karukan-cli/Cargo.toml
@@ -21,7 +21,6 @@ clap = { version = "4", features = ["derive"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["fs", "cors"] }
-http-body-util = "0.1"
 
 # sudachi-dict 用
 indicatif = "0.17"

--- a/karukan-cli/src/bin/ajimee_bench.rs
+++ b/karukan-cli/src/bin/ajimee_bench.rs
@@ -6,10 +6,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use karukan_engine::kana::normalize_nfkc;
-use karukan_engine::kanji::{
-    KanjiError, LlamaCppModel, build_jinen_prompt, clean_model_output, get_path_by_id,
-    get_tokenizer_path_by_id, registry,
-};
+use karukan_engine::kanji::{build_jinen_prompt, clean_model_output};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -149,28 +146,12 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Load model
-    let model = if let Some(gguf_path) = &cli.gguf {
-        let tok_path = cli
-            .tokenizer_json
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("--tokenizer-json is required when using --gguf"))?;
-        eprintln!("Loading GGUF from {}...", gguf_path.display());
-        LlamaCppModel::from_file_with_n_ctx(gguf_path, tok_path, cli.n_ctx)
-            .with_context(|| format!("Failed to load GGUF from {}", gguf_path.display()))?
-    } else {
-        let reg = registry();
-        let variant_id = &cli.model;
-        let (_family, _variant) = reg
-            .find_variant(variant_id)
-            .ok_or(KanjiError::UnknownVariant(variant_id.to_string()))?;
-
-        eprintln!("Downloading/loading model variant: {} ...", variant_id);
-        let path = get_path_by_id(variant_id)?;
-        let tok_path = get_tokenizer_path_by_id(variant_id)?;
-        eprintln!("Model path: {}", path.display());
-        eprintln!("Tokenizer: {}", tok_path.display());
-        LlamaCppModel::from_file_with_n_ctx(&path, &tok_path, cli.n_ctx)?
-    };
+    let model = karukan_cli::load_llama_model(
+        cli.gguf.as_deref(),
+        cli.tokenizer_json.as_deref(),
+        &cli.model,
+        cli.n_ctx,
+    )?;
 
     let eos = Some(model.eos_token_id().0);
 

--- a/karukan-cli/src/bin/sudachi_dict.rs
+++ b/karukan-cli/src/bin/sudachi_dict.rs
@@ -12,12 +12,10 @@ use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
 use karukan_engine::dict::parse_sudachi_csvs;
 use karukan_engine::kana::hiragana_to_katakana;
-use karukan_engine::kanji::{
-    KanjiError, LlamaCppModel, NllScorer, get_path_by_id, get_tokenizer_path_by_id, registry,
-};
+use karukan_engine::kanji::{LlamaCppModel, NllScorer};
 use rayon::prelude::*;
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Build a scored JSON dictionary from Sudachi CSV files.
 ///
@@ -162,7 +160,7 @@ fn score_with_model(
     entries: Vec<(String, Vec<(String, i32)>)>,
     total_pairs: usize,
 ) -> Result<Vec<JsonEntry>> {
-    let model = load_model(&cli.model, cli.tokenizer_json.as_ref(), cli.n_ctx)?;
+    let model = load_model(&cli.model, cli.tokenizer_json.as_deref(), cli.n_ctx)?;
     let num_threads = rayon::current_num_threads();
 
     eprintln!("Scoring {} pairs (threads={})...", total_pairs, num_threads);
@@ -170,12 +168,7 @@ fn score_with_model(
     // Flatten all (reading, surface) pairs for parallel processing
     let mut flat_pairs: Vec<FlatPair> = Vec::with_capacity(total_pairs);
     for (entry_idx, (reading, surfaces)) in entries.iter().enumerate() {
-        let reading_katakana = hiragana_to_katakana(reading);
-        let katakana = if reading_katakana == *reading {
-            reading.clone()
-        } else {
-            reading_katakana
-        };
+        let katakana = hiragana_to_katakana(reading);
         for (surface_idx, (surface, cost)) in surfaces.iter().enumerate() {
             flat_pairs.push(FlatPair {
                 entry_idx,
@@ -260,31 +253,10 @@ fn score_with_model(
 /// Load a model by variant id or GGUF file path.
 fn load_model(
     model_spec: &str,
-    tokenizer_json: Option<&PathBuf>,
+    tokenizer_json: Option<&Path>,
     n_ctx: u32,
 ) -> Result<LlamaCppModel> {
     let path = PathBuf::from(model_spec);
-    if path.exists() {
-        let tok_path = tokenizer_json.ok_or_else(|| {
-            anyhow::anyhow!("--tokenizer-json is required when --model is a GGUF file path")
-        })?;
-        eprintln!("Loading GGUF from {}...", path.display());
-        let model = LlamaCppModel::from_file_with_n_ctx(&path, tok_path, n_ctx)
-            .with_context(|| format!("Failed to load GGUF from {}", path.display()))?;
-        return Ok(model);
-    }
-
-    let reg = registry();
-    let (_family, _variant) = reg
-        .find_variant(model_spec)
-        .ok_or(KanjiError::UnknownVariant(model_spec.to_string()))?;
-
-    eprintln!("Downloading/loading model variant: {} ...", model_spec);
-    let gguf_path = get_path_by_id(model_spec)?;
-    let tok_path = get_tokenizer_path_by_id(model_spec)?;
-    eprintln!("Model path: {}", gguf_path.display());
-    eprintln!("Tokenizer: {}", tok_path.display());
-    Ok(LlamaCppModel::from_file_with_n_ctx(
-        &gguf_path, &tok_path, n_ctx,
-    )?)
+    let gguf = path.exists().then_some(path.as_path());
+    karukan_cli::load_llama_model(gguf, tokenizer_json, model_spec, n_ctx)
 }

--- a/karukan-cli/src/lib.rs
+++ b/karukan-cli/src/lib.rs
@@ -1,0 +1,34 @@
+//! Shared helpers for the karukan-cli binaries.
+
+use anyhow::{Context, Result};
+use karukan_engine::kanji::{LlamaCppModel, get_path_by_id, get_tokenizer_path_by_id};
+use std::path::Path;
+
+/// Load a model from a direct GGUF file path or by registry variant id.
+///
+/// When `gguf` is `Some`, loads that file directly (`tokenizer_json` is
+/// required); otherwise downloads/loads the registry variant `model_id`.
+pub fn load_llama_model(
+    gguf: Option<&Path>,
+    tokenizer_json: Option<&Path>,
+    model_id: &str,
+    n_ctx: u32,
+) -> Result<LlamaCppModel> {
+    if let Some(gguf_path) = gguf {
+        let tok_path = tokenizer_json.ok_or_else(|| {
+            anyhow::anyhow!("--tokenizer-json is required when loading a GGUF file path")
+        })?;
+        eprintln!("Loading GGUF from {}...", gguf_path.display());
+        return LlamaCppModel::from_file_with_n_ctx(gguf_path, tok_path, n_ctx)
+            .with_context(|| format!("Failed to load GGUF from {}", gguf_path.display()));
+    }
+
+    eprintln!("Downloading/loading model variant: {} ...", model_id);
+    let gguf_path = get_path_by_id(model_id)?;
+    let tok_path = get_tokenizer_path_by_id(model_id)?;
+    eprintln!("Model path: {}", gguf_path.display());
+    eprintln!("Tokenizer: {}", tok_path.display());
+    Ok(LlamaCppModel::from_file_with_n_ctx(
+        &gguf_path, &tok_path, n_ctx,
+    )?)
+}

--- a/karukan-engine/Cargo.toml
+++ b/karukan-engine/Cargo.toml
@@ -22,7 +22,6 @@ serde_yaml = "0.9"
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 toml.workspace = true
 
 # llama.cpp bindings for GGUF inference

--- a/karukan-engine/src/dict.rs
+++ b/karukan-engine/src/dict.rs
@@ -387,11 +387,7 @@ impl Dictionary {
         entries.dedup_by(|b, a| {
             if a.reading == b.reading {
                 // Merge candidates from b into a
-                for cand in std::mem::take(&mut b.candidates) {
-                    if !a.candidates.iter().any(|c| c.surface == cand.surface) {
-                        a.candidates.push(cand);
-                    }
-                }
+                extend_candidates_unique(&mut a.candidates, std::mem::take(&mut b.candidates));
                 true
             } else {
                 false
@@ -439,11 +435,7 @@ impl Dictionary {
                     reading_order.push(entry.reading.clone());
                 }
                 let candidates = merged.entry(entry.reading).or_default();
-                for cand in entry.candidates {
-                    if !candidates.iter().any(|c| c.surface == cand.surface) {
-                        candidates.push(cand);
-                    }
-                }
+                extend_candidates_unique(candidates, entry.candidates);
             }
         }
 
@@ -461,6 +453,15 @@ impl Dictionary {
         entries.sort_by(|a, b| a.reading.as_bytes().cmp(b.reading.as_bytes()));
 
         Self::build_from_entries(entries).map(Some)
+    }
+}
+
+/// Append candidates to `dst`, skipping any whose surface is already present.
+fn extend_candidates_unique(dst: &mut Vec<Candidate>, src: impl IntoIterator<Item = Candidate>) {
+    for cand in src {
+        if !dst.iter().any(|c| c.surface == cand.surface) {
+            dst.push(cand);
+        }
     }
 }
 
@@ -498,6 +499,15 @@ fn unescape_unicode(s: &str) -> String {
         }
     }
     result
+}
+
+/// Insert a (surface, cost) pair into a surfaces map, keeping the minimum cost
+/// for duplicate surfaces.
+fn insert_min_cost(surfaces: &mut HashMap<String, i32>, surface: String, cost: i32) {
+    let entry = surfaces.entry(surface).or_insert(cost);
+    if cost < *entry {
+        *entry = cost;
+    }
 }
 
 /// Parse a single Sudachi CSV file into a map of reading → {surface → min_cost}.
@@ -549,10 +559,7 @@ pub fn parse_sudachi_csv(path: &Path) -> Result<HashMap<String, HashMap<String, 
         }
 
         let surfaces = map.entry(reading).or_default();
-        let entry = surfaces.entry(surface).or_insert(cost);
-        if cost < *entry {
-            *entry = cost;
-        }
+        insert_min_cost(surfaces, surface, cost);
     }
 
     Ok(map)
@@ -575,17 +582,14 @@ pub fn parse_sudachi_csvs(
 }
 
 /// Merge `source` reading map into `target`, keeping minimum costs.
-pub fn merge_reading_maps(
+fn merge_reading_maps(
     target: &mut HashMap<String, HashMap<String, i32>>,
     source: HashMap<String, HashMap<String, i32>>,
 ) {
     for (reading, surfaces) in source {
         let target_surfaces = target.entry(reading).or_default();
         for (surface, cost) in surfaces {
-            let entry = target_surfaces.entry(surface).or_insert(cost);
-            if cost < *entry {
-                *entry = cost;
-            }
+            insert_min_cost(target_surfaces, surface, cost);
         }
     }
 }

--- a/karukan-engine/src/kana.rs
+++ b/karukan-engine/src/kana.rs
@@ -193,13 +193,6 @@ pub fn katakana_to_half_width(text: &str) -> String {
     out
 }
 
-/// Convert hiragana to half-width katakana.
-///
-/// Equivalent to `katakana_to_half_width(hiragana_to_katakana(text))`.
-pub fn hiragana_to_half_katakana(text: &str) -> String {
-    katakana_to_half_width(&hiragana_to_katakana(text))
-}
-
 /// Map a half-width ASCII alphanumeric character (digit / Latin letter) to
 /// its full-width form (e.g. `a` → `ａ`, `Z` → `Ｚ`, `5` → `５`). All other
 /// characters pass through unchanged.
@@ -322,13 +315,6 @@ mod tests {
         // Pass through non-katakana
         assert_eq!(katakana_to_half_width("abc"), "abc");
         assert_eq!(katakana_to_half_width("漢字"), "漢字");
-    }
-
-    #[test]
-    fn test_hiragana_to_half_katakana() {
-        assert_eq!(hiragana_to_half_katakana("あ"), "ｱ");
-        assert_eq!(hiragana_to_half_katakana("がっこう"), "ｶﾞｯｺｳ");
-        assert_eq!(hiragana_to_half_katakana("ぱぴぷぺぽ"), "ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ");
     }
 
     #[test]

--- a/karukan-engine/src/kanji/llamacpp.rs
+++ b/karukan-engine/src/kanji/llamacpp.rs
@@ -75,21 +75,7 @@ impl LlamaCppModel {
     ///
     /// GPT-2 models use CPU only (Metal has issues with GPT-2).
     pub fn from_file<P: AsRef<Path>, T: AsRef<Path>>(path: P, tokenizer_json: T) -> Result<Self> {
-        let backend = get_backend()?;
-
-        // GPT-2 has Metal issues, use CPU
-        let model_params = LlamaModelParams::default().with_n_gpu_layers(0);
-
-        let model = LlamaModel::load_from_file(backend, path.as_ref(), &model_params)
-            .map_err(|e| KanjiError::ModelLoad(e.into()))?;
-        let external_tokenizer = load_tokenizer(tokenizer_json)?;
-
-        Ok(Self {
-            model,
-            n_ctx: 256,
-            external_tokenizer,
-            n_threads: 0,
-        })
+        Self::from_file_with_n_ctx(path, tokenizer_json, 256)
     }
 
     /// Load a GGUF model with a pre-tokenizer type override.
@@ -125,14 +111,7 @@ impl LlamaCppModel {
 
         let model = LlamaModel::load_from_file(backend, path.as_ref(), &params)
             .map_err(|e| KanjiError::ModelLoad(e.into()))?;
-        let external_tokenizer = load_tokenizer(tokenizer_json)?;
-
-        Ok(Self {
-            model,
-            n_ctx: 256,
-            external_tokenizer,
-            n_threads: 0,
-        })
+        Self::finish(model, tokenizer_json, 256)
     }
 
     /// Load a GGUF model with explicit context window size
@@ -143,10 +122,16 @@ impl LlamaCppModel {
     ) -> Result<Self> {
         let backend = get_backend()?;
 
+        // GPT-2 has Metal issues, use CPU
         let model_params = LlamaModelParams::default().with_n_gpu_layers(0);
 
         let model = LlamaModel::load_from_file(backend, path.as_ref(), &model_params)
             .map_err(|e| KanjiError::ModelLoad(e.into()))?;
+        Self::finish(model, tokenizer_json, n_ctx)
+    }
+
+    /// Load the external tokenizer and construct the model wrapper.
+    fn finish<T: AsRef<Path>>(model: LlamaModel, tokenizer_json: T, n_ctx: u32) -> Result<Self> {
         let external_tokenizer = load_tokenizer(tokenizer_json)?;
 
         Ok(Self {
@@ -564,6 +549,18 @@ impl LlamaCppModel {
         Ok(all_results)
     }
 
+    /// Add input tokens to a batch as a single sequence, requesting logits
+    /// only for the last token.
+    fn add_input_tokens(&self, batch: &mut LlamaBatch, tokens: &[LlamaToken]) -> Result<()> {
+        for (i, token) in tokens.iter().enumerate() {
+            let is_last = i == tokens.len() - 1;
+            batch
+                .add(*token, i as i32, &[0], is_last)
+                .map_err(|e| KanjiError::Inference(e.into()))?;
+        }
+        Ok(())
+    }
+
     /// Process a token sequence and return the logits at the last position.
     ///
     /// Creates a fresh context for each call. Used by true beam search where
@@ -578,12 +575,7 @@ impl LlamaCppModel {
             .map_err(|e| KanjiError::Inference(e.into()))?;
 
         let mut batch = LlamaBatch::new(512, 1);
-        for (i, token) in tokens.iter().enumerate() {
-            let is_last = i == tokens.len() - 1;
-            batch
-                .add(*token, i as i32, &[0], is_last)
-                .map_err(|e| KanjiError::Inference(e.into()))?;
-        }
+        self.add_input_tokens(&mut batch, tokens)?;
         ctx.decode(&mut batch)
             .map_err(|e| KanjiError::Inference(e.into()))?;
 
@@ -652,12 +644,7 @@ impl LlamaCppModel {
         let mut generated = input_tokens.to_vec();
 
         // Process input tokens
-        for (i, token) in input_tokens.iter().enumerate() {
-            let is_last = i == input_tokens.len() - 1;
-            batch
-                .add(*token, i as i32, &[0], is_last)
-                .map_err(|e| KanjiError::Inference(e.into()))?;
-        }
+        self.add_input_tokens(&mut batch, input_tokens)?;
 
         ctx.decode(&mut batch)
             .map_err(|e| KanjiError::Inference(e.into()))?;
@@ -669,18 +656,8 @@ impl LlamaCppModel {
         for n_cur in (input_tokens.len()..).take(max_new_tokens) {
             let new_token = sampler.sample(&ctx, -1);
 
-            // Check for EOS using the provided token ID
-            if eos_token_id.is_some_and(|eos| new_token.0 == eos) {
-                break;
-            }
-
-            // Check against model's EOS token
-            if new_token == model_eos {
-                break;
-            }
-
-            // Check if model thinks it's end of generation
-            if self.model.is_eog_token(new_token) {
+            // Check for EOS
+            if self.is_eos_token(new_token, eos_token_id, model_eos) {
                 break;
             }
 

--- a/karukan-engine/src/rewriter/alphabet.rs
+++ b/karukan-engine/src/rewriter/alphabet.rs
@@ -9,9 +9,7 @@
 //! Each variant carries a description tagged with mozc's width markers
 //! (`[半]` / `[全]`) plus 大文字/小文字, e.g. `ＡＢＣ` → `[全]英大文字`.
 
-use crate::kana::{ascii_to_fullwidth_char, fullwidth_to_ascii_char};
-
-use super::{RewriteOutput, Rewriter};
+use super::{RewriteOutput, Rewriter, to_fullwidth, to_halfwidth};
 
 /// Rewriter that produces width/case variants for alphabetic input.
 pub struct AlphabetRewriter;
@@ -40,14 +38,14 @@ enum Case {
 
 /// Build one variant + its mozc-style description.
 fn build_variant(original: &str, width: Width, case: Case) -> (String, &'static str) {
-    let half: String = original.chars().map(fullwidth_to_ascii_char).collect();
+    let half = to_halfwidth(original);
     let cased = match case {
         Case::Lower => half.to_ascii_lowercase(),
         Case::Upper => half.to_ascii_uppercase(),
     };
     let text = match width {
         Width::Half => cased,
-        Width::Full => cased.chars().map(ascii_to_fullwidth_char).collect(),
+        Width::Full => to_fullwidth(&cased),
     };
     let desc = match (width, case) {
         (Width::Half, Case::Lower) => "[半]英小文字",

--- a/karukan-engine/src/rewriter/mod.rs
+++ b/karukan-engine/src/rewriter/mod.rs
@@ -30,6 +30,28 @@ pub use half_katakana::HalfWidthKatakanaRewriter;
 pub use number::NumberRewriter;
 pub use symbol::{SymbolRewriter, description};
 
+use crate::kana::{ascii_to_fullwidth_char, fullwidth_to_ascii_char};
+
+/// True iff every character is a halfwidth (`0-9`) or fullwidth (`０-９`)
+/// decimal digit, and the string is non-empty. Shared gate for digit-only
+/// rewriting so arbitrary candidates with stray digits aren't expanded.
+pub(crate) fn is_pure_digit(text: &str) -> bool {
+    !text.is_empty()
+        && text
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('\u{FF10}'..='\u{FF19}').contains(&c))
+}
+
+/// Convert every full-width ASCII alphanumeric character to half-width.
+pub(crate) fn to_halfwidth(text: &str) -> String {
+    text.chars().map(fullwidth_to_ascii_char).collect()
+}
+
+/// Convert every half-width ASCII alphanumeric character to full-width.
+pub(crate) fn to_fullwidth(text: &str) -> String {
+    text.chars().map(ascii_to_fullwidth_char).collect()
+}
+
 /// One result of rewriting: the variant text and an optional description used
 /// as the candidate's annotation (e.g. `三点リーダ` for `…`).
 pub type RewriteOutput = (String, Option<String>);

--- a/karukan-engine/src/rewriter/number.rs
+++ b/karukan-engine/src/rewriter/number.rs
@@ -9,8 +9,7 @@
 //! Inputs must be pure decimal digits — mixed text like `20世紀` is left
 //! alone.
 
-use super::{RewriteOutput, Rewriter};
-use crate::kana::{ascii_to_fullwidth_char, fullwidth_to_ascii_char};
+use super::{RewriteOutput, Rewriter, is_pure_digit, to_fullwidth, to_halfwidth};
 
 // ---------- tables ----------
 //
@@ -59,25 +58,6 @@ const DESC_CIRCLED: &str = "丸数字";
 const DESC_HEX: &str = "16進数";
 const DESC_OCT: &str = "8進数";
 const DESC_BIN: &str = "2進数";
-
-// ---------- input gates ----------
-
-/// True iff every character is a halfwidth (`0-9`) or fullwidth (`０-９`)
-/// decimal digit, and the string is non-empty.
-fn is_pure_digit(text: &str) -> bool {
-    !text.is_empty()
-        && text
-            .chars()
-            .all(|c| c.is_ascii_digit() || ('\u{FF10}'..='\u{FF19}').contains(&c))
-}
-
-fn to_halfwidth(text: &str) -> String {
-    text.chars().map(fullwidth_to_ascii_char).collect()
-}
-
-fn to_fullwidth(text: &str) -> String {
-    text.chars().map(ascii_to_fullwidth_char).collect()
-}
 
 // ---------- kanji rendering ----------
 

--- a/karukan-engine/src/rewriter/symbol.rs
+++ b/karukan-engine/src/rewriter/symbol.rs
@@ -44,9 +44,7 @@ use std::sync::LazyLock;
 
 use serde::Deserialize;
 
-use crate::kana::{ascii_to_fullwidth_char, fullwidth_to_ascii_char};
-
-use super::{RewriteOutput, Rewriter};
+use super::{RewriteOutput, Rewriter, is_pure_digit, to_fullwidth, to_halfwidth};
 
 const SYMBOLS_YAML: &str = include_str!("../../data/symbols.yml");
 
@@ -149,16 +147,6 @@ impl SymbolRewriter {
     }
 }
 
-/// True if every character is an ASCII digit or full-width digit (and the
-/// string is non-empty). Used to gate digit-only width-pair generation so
-/// arbitrary candidates with stray digits aren't expanded.
-fn is_pure_digit(text: &str) -> bool {
-    !text.is_empty()
-        && text
-            .chars()
-            .all(|c| c.is_ascii_digit() || ('\u{FF10}'..='\u{FF19}').contains(&c))
-}
-
 /// For a digit-only string, return the all-full-width and all-half-width forms
 /// that differ from the input. Supports arbitrary length (e.g. `123` → `１２３`,
 /// `１２` → `12`).
@@ -166,8 +154,8 @@ fn digit_width_variants(candidate: &str) -> Vec<String> {
     if !is_pure_digit(candidate) {
         return Vec::new();
     }
-    let full: String = candidate.chars().map(ascii_to_fullwidth_char).collect();
-    let half: String = candidate.chars().map(fullwidth_to_ascii_char).collect();
+    let full = to_fullwidth(candidate);
+    let half = to_halfwidth(candidate);
     let mut out = Vec::new();
     if full != candidate {
         out.push(full);

--- a/karukan-engine/src/romaji/converter.rs
+++ b/karukan-engine/src/romaji/converter.rs
@@ -1,6 +1,5 @@
 use super::rules::build_rules;
 use super::trie::TrieNode;
-use crate::kana::hiragana_to_katakana;
 
 /// Events that can occur during conversion
 #[derive(Debug, Clone, PartialEq)]
@@ -233,11 +232,6 @@ impl RomajiConverter {
         &self.output
     }
 
-    /// Get the current output converted to katakana
-    pub fn output_katakana(&self) -> String {
-        hiragana_to_katakana(&self.output)
-    }
-
     /// Get the current buffer (unconverted input)
     pub fn buffer(&self) -> &str {
         &self.buffer
@@ -247,16 +241,6 @@ impl RomajiConverter {
     pub fn reset(&mut self) {
         self.buffer.clear();
         self.output.clear();
-    }
-
-    /// Get both output and buffer as a single string
-    pub fn full_text(&self) -> String {
-        format!("{}{}", self.output, self.buffer)
-    }
-
-    /// Get both output and buffer as a single string, with output converted to katakana
-    pub fn full_text_katakana(&self) -> String {
-        format!("{}{}", hiragana_to_katakana(&self.output), self.buffer)
     }
 }
 
@@ -447,30 +431,5 @@ mod tests {
         }
         assert_eq!(conv.output(), "あ？b？ちゃ");
         assert_eq!(conv.buffer(), "");
-    }
-
-    #[test]
-    fn test_output_katakana() {
-        let mut conv = RomajiConverter::new();
-        "watashi".chars().for_each(|c| {
-            conv.push(c);
-        });
-        // "watash" → "わたし" with "i" still possible as part of "shi" etc.
-        // Actually: w→buffered, wa→わ, t→buffered, ta→た, s→buffered, sh→buffered, shi→し
-        assert_eq!(conv.output(), "わたし");
-        assert_eq!(conv.output_katakana(), "ワタシ");
-        assert_eq!(conv.buffer(), "");
-    }
-
-    #[test]
-    fn test_full_text_katakana() {
-        let mut conv = RomajiConverter::new();
-        // "kak" → か + k(buffered)
-        "kak".chars().for_each(|c| {
-            conv.push(c);
-        });
-        assert_eq!(conv.output(), "か");
-        assert_eq!(conv.buffer(), "k");
-        assert_eq!(conv.full_text_katakana(), "カk");
     }
 }

--- a/karukan-engine/src/romaji/mod.rs
+++ b/karukan-engine/src/romaji/mod.rs
@@ -3,4 +3,3 @@ mod rules;
 mod trie;
 
 pub use converter::{BackspaceResult, ConversionEvent, RomajiConverter};
-pub use trie::SearchResult;

--- a/karukan-fcitx5/fcitx5-addon/src/karukan.cpp
+++ b/karukan-fcitx5/fcitx5-addon/src/karukan.cpp
@@ -49,8 +49,7 @@ void KarukanCandidateWord::select(InputContext* inputContext) const {
 
 // --- KarukanCandidateList ---
 
-KarukanCandidateList::KarukanCandidateList(KarukanEngine* engine, InputContext* ic)
-    : engine_(engine), ic_(ic) {
+KarukanCandidateList::KarukanCandidateList(KarukanEngine* engine) : engine_(engine) {
     setLayoutHint(CandidateLayoutHint::Vertical);
     setPageSize(9);
     // Set selection key labels (1-9)
@@ -153,15 +152,7 @@ void KarukanState::keyEvent(KeyEvent& keyEvent) {
     // For apps without SurroundingText capability (terminals), this clears
     // the context so stale data doesn't persist.
     if (karukan_engine_is_empty(rustEngine_) && !isRelease) {
-        if (ic_->capabilityFlags().test(CapabilityFlag::SurroundingText) &&
-            ic_->surroundingText().isValid()) {
-            const auto& surrounding = ic_->surroundingText();
-            const std::string& text = surrounding.text();
-            uint32_t cursor = surrounding.cursor();
-            karukan_engine_set_surrounding_text(rustEngine_, text.c_str(), cursor);
-        } else {
-            karukan_engine_set_surrounding_text(rustEngine_, "", 0);
-        }
+        captureSurroundingText();
     }
 
     // Process key through Rust engine
@@ -198,10 +189,7 @@ void KarukanState::updateUI() {
     // preedit/candidates/aux in one shot.
     // New preedit/candidates/aux are re-set below if the engine produced them.
     if (karukan_engine_has_commit(rustEngine_)) {
-        const char* commitText = karukan_engine_get_commit(rustEngine_);
-        if (commitText && karukan_engine_get_commit_len(rustEngine_) > 0) {
-            ic_->commitString(commitText);
-        }
+        emitPendingCommit();
         inputPanel.reset();
     }
 
@@ -243,7 +231,7 @@ void KarukanState::updateUI() {
         if (karukan_engine_should_hide_candidates(rustEngine_)) {
             inputPanel.setCandidateList(nullptr);
         } else {
-            auto candidateList = std::make_unique<KarukanCandidateList>(engine_, ic_);
+            auto candidateList = std::make_unique<KarukanCandidateList>(engine_);
             candidateList->updateCandidates(rustEngine_);
             inputPanel.setCandidateList(std::move(candidateList));
         }
@@ -251,6 +239,25 @@ void KarukanState::updateUI() {
 
     ic_->updatePreedit();
     ic_->updateUserInterface(UserInterfaceComponent::InputPanel);
+}
+
+void KarukanState::captureSurroundingText() {
+    if (ic_->capabilityFlags().test(CapabilityFlag::SurroundingText) &&
+        ic_->surroundingText().isValid()) {
+        const auto& surrounding = ic_->surroundingText();
+        const std::string& text = surrounding.text();
+        uint32_t cursor = surrounding.cursor();
+        karukan_engine_set_surrounding_text(rustEngine_, text.c_str(), cursor);
+    } else {
+        karukan_engine_set_surrounding_text(rustEngine_, "", 0);
+    }
+}
+
+void KarukanState::emitPendingCommit() {
+    const char* commitText = karukan_engine_get_commit(rustEngine_);
+    if (commitText && karukan_engine_get_commit_len(rustEngine_) > 0) {
+        ic_->commitString(commitText);
+    }
 }
 
 // --- KarukanEngine ---
@@ -290,15 +297,7 @@ void KarukanEngine::activate(const InputMethodEntry& entry, InputContextEvent& e
     // Capture surrounding text on activation for accurate context.
     // For apps without SurroundingText capability, this clears the context.
     if (state->rustEngine()) {
-        if (ic->capabilityFlags().test(CapabilityFlag::SurroundingText) &&
-            ic->surroundingText().isValid()) {
-            const auto& surrounding = ic->surroundingText();
-            const std::string& text = surrounding.text();
-            uint32_t cursor = surrounding.cursor();
-            karukan_engine_set_surrounding_text(state->rustEngine(), text.c_str(), cursor);
-        } else {
-            karukan_engine_set_surrounding_text(state->rustEngine(), "", 0);
-        }
+        state->captureSurroundingText();
     }
 }
 
@@ -312,10 +311,7 @@ void KarukanEngine::deactivate(const InputMethodEntry& entry, InputContextEvent&
     // This ensures preedit is not lost when Super/Windows key is pressed
     if (state->rustEngine()) {
         if (karukan_engine_commit(state->rustEngine())) {
-            const char* commitText = karukan_engine_get_commit(state->rustEngine());
-            if (commitText && karukan_engine_get_commit_len(state->rustEngine()) > 0) {
-                ic->commitString(commitText);
-            }
+            state->emitPendingCommit();
         }
         // Persist learning cache on deactivation (azooKey-style)
         karukan_engine_save_learning(state->rustEngine());

--- a/karukan-fcitx5/fcitx5-addon/src/karukan.h
+++ b/karukan-fcitx5/fcitx5-addon/src/karukan.h
@@ -35,12 +35,11 @@ private:
 // Candidate list class
 class KarukanCandidateList : public CommonCandidateList {
 public:
-    KarukanCandidateList(KarukanEngine* engine, InputContext* ic);
+    KarukanCandidateList(KarukanEngine* engine);
     void updateCandidates(::KarukanEngine* rustEngine);
 
 private:
     KarukanEngine* engine_;
-    InputContext* ic_;
 };
 
 // Per-input-context state
@@ -52,6 +51,8 @@ public:
     void keyEvent(KeyEvent& keyEvent);
     void reset();
     void updateUI();
+    void captureSurroundingText();
+    void emitPendingCommit();
 
     ::KarukanEngine* rustEngine() { return rustEngine_; }
 
@@ -73,11 +74,7 @@ public:
     void activate(const InputMethodEntry& entry, InputContextEvent& event) override;
     void deactivate(const InputMethodEntry& entry, InputContextEvent& event) override;
 
-    Instance* instance() { return instance_; }
-
     void selectCandidate(InputContext* ic, int index);
-
-    auto& factory() { return factory_; }
 
 private:
     Instance* instance_;

--- a/karukan-im/Cargo.toml
+++ b/karukan-im/Cargo.toml
@@ -37,7 +37,6 @@ directories = "5"
 anyhow.workspace = true
 
 [dev-dependencies]
-tokio-test = "0.4"
 tempfile.workspace = true
 
 [features]

--- a/karukan-im/src/config/settings.rs
+++ b/karukan-im/src/config/settings.rs
@@ -164,8 +164,7 @@ impl Settings {
         }
 
         debug!("Loading config from {:?}", config_file);
-        let content = fs::read_to_string(&config_file)?;
-        parse_with_defaults(&content)
+        Self::load_from(&config_file)
     }
 
     /// Load settings from a specific file, merged on top of defaults.
@@ -180,15 +179,8 @@ impl Settings {
             anyhow::bail!("Could not determine config directory");
         };
 
-        // Create config directory if it doesn't exist
-        if let Some(parent) = config_file.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
         debug!("Saving config to {:?}", config_file);
-        let content = toml::to_string_pretty(self)?;
-        fs::write(&config_file, content)?;
-        Ok(())
+        self.save_to(&config_file)
     }
 
     /// Save settings to a specific file

--- a/karukan-im/src/core/candidate.rs
+++ b/karukan-im/src/core/candidate.rs
@@ -94,21 +94,6 @@ impl CandidateList {
         Self::new(strings.into_iter().map(Candidate::new).collect())
     }
 
-    /// Create a candidate list from strings, attaching the same reading to
-    /// every candidate.
-    pub fn from_strings_with_reading(
-        strings: impl IntoIterator<Item = impl Into<String>>,
-        reading: impl Into<String>,
-    ) -> Self {
-        let reading = reading.into();
-        Self::new(
-            strings
-                .into_iter()
-                .map(|s| Candidate::with_reading(s, &reading))
-                .collect(),
-        )
-    }
-
     /// Get all candidates
     pub fn candidates(&self) -> &[Candidate] {
         &self.candidates
@@ -247,16 +232,6 @@ impl CandidateList {
         let absolute_index = self.page_start() + page_index - 1;
         if absolute_index < self.candidates.len() {
             self.cursor = absolute_index;
-            self.selected()
-        } else {
-            None
-        }
-    }
-
-    /// Select a candidate by absolute index
-    pub fn select(&mut self, index: usize) -> Option<&Candidate> {
-        if index < self.candidates.len() {
-            self.cursor = index;
             self.selected()
         } else {
             None

--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -256,10 +256,7 @@ impl InputMethodEngine {
     fn enter_conversion_state(&mut self, reading: &str, candidates: CandidateList) -> EngineResult {
         let selected_text = candidates.selected_text().unwrap_or(reading).to_string();
 
-        let preedit = Preedit::from_segments(
-            vec![PreeditSegment::highlighted(&selected_text)],
-            selected_text.chars().count(),
-        );
+        let preedit = Preedit::with_text_highlighted(&selected_text);
 
         self.state = InputState::Conversion {
             preedit: preedit.clone(),
@@ -612,7 +609,7 @@ impl InputMethodEngine {
     }
 
     /// Get selected text and reading from conversion state, or None if not in conversion
-    fn selected_conversion_info(&self) -> Option<(String, Option<String>)> {
+    pub(super) fn selected_conversion_info(&self) -> Option<(String, Option<String>)> {
         match &self.state {
             InputState::Conversion { candidates, .. } => {
                 let text = candidates.selected_text().unwrap_or("").to_string();
@@ -630,6 +627,23 @@ impl InputMethodEngine {
         }
     }
 
+    /// Record the committed conversion in the learning cache and reset to Empty state.
+    ///
+    /// Skips learning when the buffer is a `:shortcode` query — the
+    /// reading would be e.g. `:smile`, which isn't a hiragana key
+    /// and would corrupt the kana-keyed learning cache.
+    fn finish_conversion(&mut self, text: &str, reading: &Option<String>) {
+        if self.mode.current() != InputMode::Emoji
+            && let Some(reading) = reading
+        {
+            self.record_learning(reading, text);
+        }
+
+        self.state = InputState::Empty;
+        self.input_buf.text.clear();
+        self.mode.exit_temporary();
+    }
+
     /// Commit the current conversion
     fn commit_conversion(&mut self) -> EngineResult {
         let Some((text, reading)) = self.selected_conversion_info() else {
@@ -640,18 +654,7 @@ impl InputMethodEngine {
             return EngineResult::consumed();
         }
 
-        // Skip learning when the buffer is a `:shortcode` query — the
-        // reading would be e.g. `:smile`, which isn't a hiragana key
-        // and would corrupt the kana-keyed learning cache.
-        if self.mode.current() != InputMode::Emoji
-            && let Some(reading) = &reading
-        {
-            self.record_learning(reading, &text);
-        }
-
-        self.state = InputState::Empty;
-        self.input_buf.text.clear();
-        self.mode.exit_temporary();
+        self.finish_conversion(&text, &reading);
 
         EngineResult::consumed()
             .with_action(EngineAction::HideCandidates)
@@ -665,15 +668,7 @@ impl InputMethodEngine {
             return EngineResult::not_consumed();
         };
 
-        if self.mode.current() != InputMode::Emoji
-            && let Some(reading) = &reading
-        {
-            self.record_learning(reading, &text);
-        }
-
-        self.state = InputState::Empty;
-        self.input_buf.text.clear();
-        self.mode.exit_temporary();
+        self.finish_conversion(&text, &reading);
 
         // Start new input with the character
         let new_input_result = self.start_input(ch);
@@ -803,12 +798,7 @@ impl InputMethodEngine {
         selected_text: &str,
         candidates: &CandidateList,
     ) -> EngineResult {
-        let mut preedit = Preedit::with_text(selected_text);
-        preedit.set_attributes(vec![PreeditAttribute::new(
-            0,
-            selected_text.chars().count(),
-            AttributeType::Highlight,
-        )]);
+        let preedit = Preedit::with_text_highlighted(selected_text);
 
         if let Some(p) = self.state.preedit_mut() {
             *p = preedit.clone();

--- a/karukan-im/src/core/engine/display.rs
+++ b/karukan-im/src/core/engine/display.rs
@@ -53,10 +53,8 @@ impl InputMethodEngine {
         } else {
             (self.build_input_display(), self.display_caret_position())
         };
-        let len = display.chars().count();
-        let mut preedit = Preedit::with_text(&display);
+        let mut preedit = Preedit::with_text_underlined(&display);
         preedit.set_caret(caret);
-        preedit.set_attributes(vec![PreeditAttribute::underline(0, len)]);
         preedit
     }
 
@@ -69,19 +67,16 @@ impl InputMethodEngine {
             return String::new();
         }
         let lctx = left.filter(|s| !s.is_empty()).map(|left| {
-            let char_count = left.chars().count();
-            if char_count > max_len {
-                let start = char_count - max_len;
-                format!("...{}", left.chars().skip(start).collect::<String>())
+            if left.chars().count() > max_len {
+                format!("...{}", keep_last_chars(left, max_len))
             } else {
                 left.to_string()
             }
         });
 
         let rctx = right.filter(|s| !s.is_empty()).map(|right| {
-            let char_count = right.chars().count();
-            if char_count > max_len {
-                format!("{}...", right.chars().take(max_len).collect::<String>())
+            if right.chars().count() > max_len {
+                format!("{}...", keep_first_chars(right, max_len))
             } else {
                 right.to_string()
             }
@@ -262,12 +257,6 @@ impl InputMethodEngine {
 
     /// Truncate a context string to safe size for API calls
     pub(super) fn truncate_context(&self, context: &str) -> String {
-        let char_count = context.chars().count();
-        if char_count > self.config.max_api_context_len {
-            let start = char_count - self.config.max_api_context_len;
-            context.chars().skip(start).collect()
-        } else {
-            context.to_string()
-        }
+        keep_last_chars(context, self.config.max_api_context_len)
     }
 }

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -72,42 +72,31 @@ impl InputMethodEngine {
         // Live conversion mode: show converted text in preedit
         if self.live.enabled && self.mode.current() != InputMode::Katakana {
             self.live.text = candidates[0].clone();
-            let preedit = self.set_composing_state();
-
-            // Same candidate ordering as normal auto-suggest (learning → model →
-            // dictionary). Including the model candidates guarantees the list is
-            // never empty, so the candidate window — whose aux line is where
-            // frontends show the raw reading once the preedit displays converted
-            // text — stays on screen for the whole live conversion.
-            let mut all_candidates = self.lookup_learning_candidates(&reading);
-            let model_candidates: Vec<Candidate> = candidates
-                .into_iter()
-                .map(|s| Candidate::with_reading(s, &reading))
-                .collect();
-            append_candidates_dedup(&mut all_candidates, model_candidates);
-            append_candidates_dedup(&mut all_candidates, self.lookup_dict_candidates(&reading));
-            let aux = self.format_aux_suggest(&self.input_buf.text.clone());
-            return EngineResult::consumed()
-                .with_action(EngineAction::UpdatePreedit(preedit))
-                .with_action(EngineAction::ShowCandidates(CandidateList::new(
-                    all_candidates,
-                )))
-                .with_action(EngineAction::UpdateAuxText(aux));
+            return self.suggest_result(candidates, &reading);
         }
 
-        // Normal auto-suggest: show hiragana preedit + learning/model/dict candidates
+        // Normal auto-suggest: show hiragana preedit
         self.live.text.clear();
+        self.suggest_result(candidates, &reading)
+    }
+
+    /// Build the auto-suggest result shared by live conversion and normal
+    /// auto-suggest: composing preedit, candidate list, and aux text.
+    ///
+    /// Candidate ordering is learning → model → dictionary. Including the
+    /// model candidates guarantees the list is never empty, so the candidate
+    /// window — whose aux line is where frontends show the raw reading once
+    /// the preedit displays converted text — stays on screen for the whole
+    /// live conversion.
+    fn suggest_result(&mut self, candidates: Vec<String>, reading: &str) -> EngineResult {
         let preedit = self.set_composing_state();
-        // Learning candidates first (highest priority)
-        let mut all_candidates = self.lookup_learning_candidates(&reading);
-        // Then model inference candidates
+        let mut all_candidates = self.lookup_learning_candidates(reading);
         let model_candidates: Vec<Candidate> = candidates
             .into_iter()
-            .map(|s| Candidate::with_reading(s, &reading))
+            .map(|s| Candidate::with_reading(s, reading))
             .collect();
         append_candidates_dedup(&mut all_candidates, model_candidates);
-        // Then dictionary candidates
-        append_candidates_dedup(&mut all_candidates, self.lookup_dict_candidates(&reading));
+        append_candidates_dedup(&mut all_candidates, self.lookup_dict_candidates(reading));
         let aux = self.format_aux_suggest(&self.input_buf.text.clone());
         EngineResult::consumed()
             .with_action(EngineAction::UpdatePreedit(preedit))

--- a/karukan-im/src/core/engine/mod.rs
+++ b/karukan-im/src/core/engine/mod.rs
@@ -28,7 +28,7 @@ use tracing::{debug, trace};
 
 use super::candidate::{Candidate, CandidateList};
 use super::keycode::{KeyEvent, Keysym};
-use super::preedit::{AttributeType, Preedit, PreeditAttribute, PreeditSegment};
+use super::preedit::Preedit;
 use super::state::InputState;
 use crate::config::settings::Settings;
 
@@ -117,6 +117,26 @@ pub fn resolve_variant_id(model: Option<&str>) -> anyhow::Result<String> {
             }
         }
         _ => Ok(reg.default_model.clone()),
+    }
+}
+
+/// Keep at most the last `n` characters of `s`.
+fn keep_last_chars(s: &str, n: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count > n {
+        s.chars().skip(char_count - n).collect()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Keep at most the first `n` characters of `s`.
+fn keep_first_chars(s: &str, n: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count > n {
+        s.chars().take(n).collect()
+    } else {
+        s.to_string()
     }
 }
 
@@ -356,28 +376,20 @@ impl InputMethodEngine {
         let left = if left_context.is_empty() {
             None
         } else {
-            let left_count = left_context.chars().count();
-            Some(if left_count > self.config.max_api_context_len {
-                let start = left_count - self.config.max_api_context_len;
-                left_context.chars().skip(start).collect()
-            } else {
-                left_context.to_string()
-            })
+            Some(keep_last_chars(
+                left_context,
+                self.config.max_api_context_len,
+            ))
         };
 
         // Truncate right context to max length (keep beginning)
         let right = if right_context.is_empty() {
             None
         } else {
-            let right_count = right_context.chars().count();
-            Some(if right_count > self.config.max_api_context_len {
-                right_context
-                    .chars()
-                    .take(self.config.max_api_context_len)
-                    .collect()
-            } else {
-                right_context.to_string()
-            })
+            Some(keep_first_chars(
+                right_context,
+                self.config.max_api_context_len,
+            ))
         };
 
         self.surrounding_context = Some(SurroundingContext { left, right });
@@ -511,9 +523,10 @@ impl InputMethodEngine {
                 self.surrounding_context = None;
                 text
             }
-            InputState::Conversion { candidates, .. } => {
-                let text = candidates.selected_text().unwrap_or("").to_string();
-                let reading = candidates.selected().and_then(|c| c.reading.clone());
+            InputState::Conversion { .. } => {
+                let (text, reading) = self
+                    .selected_conversion_info()
+                    .expect("state is Conversion");
                 // Record conversion result in learning cache
                 if let Some(reading) = &reading {
                     self.record_learning(reading, &text);

--- a/karukan-im/src/core/keycode.rs
+++ b/karukan-im/src/core/keycode.rs
@@ -77,20 +77,6 @@ impl Keysym {
     pub const KEY_P: Keysym = Keysym(0x0070); // lowercase 'p'
     pub const KEY_P_UPPER: Keysym = Keysym(0x0050); // uppercase 'P'
 
-    // Function keys
-    pub const F1: Keysym = Keysym(0xffbe);
-    pub const F2: Keysym = Keysym(0xffbf);
-    pub const F3: Keysym = Keysym(0xffc0);
-    pub const F4: Keysym = Keysym(0xffc1);
-    pub const F5: Keysym = Keysym(0xffc2);
-    pub const F6: Keysym = Keysym(0xffc3);
-    pub const F7: Keysym = Keysym(0xffc4);
-    pub const F8: Keysym = Keysym(0xffc5);
-    pub const F9: Keysym = Keysym(0xffc6);
-    pub const F10: Keysym = Keysym(0xffc7);
-    pub const F11: Keysym = Keysym(0xffc8);
-    pub const F12: Keysym = Keysym(0xffc9);
-
     /// Check if this keysym represents a printable character
     pub fn is_printable(&self) -> bool {
         // ASCII printable range (0x20-0x7e)
@@ -112,16 +98,6 @@ impl Keysym {
             0x0031..=0x0039 => Some((self.0 - 0x0030) as usize),
             _ => None,
         }
-    }
-
-    /// Check if this is a shift key
-    pub fn is_shift(&self) -> bool {
-        matches!(*self, Self::SHIFT_L | Self::SHIFT_R)
-    }
-
-    /// Check if this is a control key
-    pub fn is_control(&self) -> bool {
-        matches!(*self, Self::CONTROL_L | Self::CONTROL_R)
     }
 
     /// Check if this key switches back to hiragana input mode.

--- a/karukan-im/src/core/preedit.rs
+++ b/karukan-im/src/core/preedit.rs
@@ -103,6 +103,17 @@ impl Preedit {
         }
     }
 
+    /// Create a preedit with text and highlight the entire text
+    pub fn with_text_highlighted(text: impl Into<String>) -> Self {
+        let text = text.into();
+        let len = text.chars().count();
+        Self {
+            attributes: vec![PreeditAttribute::new(0, len, AttributeType::Highlight)],
+            text,
+            caret: len,
+        }
+    }
+
     /// Get the preedit text
     pub fn text(&self) -> &str {
         &self.text

--- a/karukan-macos/Sources/KarukanIME/EngineClient.swift
+++ b/karukan-macos/Sources/KarukanIME/EngineClient.swift
@@ -45,11 +45,11 @@ class EngineClient {
         }
     }
 
-    func processKeySync(_ key: EngineKeyEvent, isRelease: Bool = false) -> KeyResult? {
+    func processKeySync(_ key: EngineKeyEvent) -> KeyResult? {
         let params: [String: Any] = [
             "keysym": key.keysym,
             "modifiers": key.modifiers.jsonObject,
-            "is_release": isRelease,
+            "is_release": false,
         ]
         return keyResultSync(method: "process_key", params: params, timeout: 3.0)
     }

--- a/karukan-macos/Sources/KarukanIME/KarukanInputController.swift
+++ b/karukan-macos/Sources/KarukanIME/KarukanInputController.swift
@@ -39,11 +39,7 @@ class KarukanInputController: IMKInputController {
                 flags: event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             )
             if fired, let client = sender as? (any IMKTextInput) {
-                let key = EngineKeyEvent(
-                    keysym: KeyCodeMap.superRKeysym, modifiers: KeyModifiers())
-                if let result = engineClient.processKeySync(key) {
-                    apply(actions: result.actions, client: client)
-                }
+                sendKanaToggle(client: client)
             }
             return false
         }
@@ -63,10 +59,7 @@ class KarukanInputController: IMKInputController {
         // consume so the system doesn't process keyCode 104 after the engine
         // returns not_consumed (already in hiragana mode).
         if event.keyCode == KeyCodeMap.kanaKeyCode {
-            let key = EngineKeyEvent(keysym: KeyCodeMap.superRKeysym, modifiers: KeyModifiers())
-            if let result = engineClient.processKeySync(key) {
-                apply(actions: result.actions, client: client)
-            }
+            sendKanaToggle(client: client)
             return true
         }
 
@@ -97,6 +90,15 @@ class KarukanInputController: IMKInputController {
         }
         apply(actions: result.actions, client: client)
         return result.consumed
+    }
+
+    /// Send the return-to-hiragana toggle (Super_R) to the engine and apply
+    /// the resulting actions.
+    private func sendKanaToggle(client: any IMKTextInput) {
+        let key = EngineKeyEvent(keysym: KeyCodeMap.superRKeysym, modifiers: KeyModifiers())
+        if let result = engineClient.processKeySync(key) {
+            apply(actions: result.actions, client: client)
+        }
     }
 
     // MARK: - Lifecycle


### PR DESCRIPTION
## 概要

ワークスペース全体を対象にリファクタリング候補を洗い出し、動作を変えない28件を適用しました(正味 **−232行**)。すべての変更は「重複の抽出」「デッドコード削除」「未使用依存の削除」のいずれかで、機能変更・バグ修正は含みません。

## 変更内容

### 重複ロジックの統合
- **karukan-im**: ライブ変換/通常オートサジェストで丸ごと重複していた候補リスト構築を `suggest_result()` に統合。`Preedit::with_text_highlighted()` を新設して3箇所の手組みハイライト構築を置換。コミット時の学習記録+状態リセットを `finish_conversion()` に、先頭/末尾N文字トランケート(5箇所)を `keep_first_chars`/`keep_last_chars` に統合。`Settings::load/save` は `load_from/save_to` へ委譲
- **karukan-engine**: rewriter 3ファイルで重複していた `is_pure_digit`・全半角変換を rewriter/mod.rs に一本化。dict.rs の min-cost 挿入と surface 重複排除マージを helper 化。llamacpp.rs の EOS 判定インライン再実装を既存 `is_eos_token()` に置換、`from_file*` コンストラクタ共通部を `finish()` に、プリフィルループを `add_input_tokens()` に統合
- **karukan-cli**: `src/lib.rs` を新設し、sudachi-dict / ajimee-bench で重複していたモデルローダーを `load_llama_model()` に統合
- **fcitx5アドオン**: keyEvent/activate で逐語重複していた surrounding text 取得を `captureSurroundingText()`、updateUI/deactivate のコミット送出を `emitPendingCommit()` に抽出
- **karukan-macos**: JIS かなキーと右⌘タップで重複していたトグル送信を `sendKanaToggle()` に抽出

### デッドコード削除
- `RomajiConverter::output_katakana/full_text/full_text_katakana`、`kana::hiragana_to_half_katakana`、`romaji::SearchResult` re-export(engine)
- `CandidateList::from_strings_with_reading/select`、`Keysym::is_shift/is_control`、F1–F12 定数(im)
- `KarukanCandidateList::ic_` メンバ、`instance()/factory()` アクセサ(fcitx5)
- `processKeySync` の未使用 `isRelease` 引数(macos)

いずれもワークスペース全体の grep で呼び出しゼロを確認済み。crate root の re-export(engine/im の prelude)は crates.io 公開時の API 互換性を考慮して温存しています。

### 依存整理
- `tracing-subscriber`(engine)、`http-body-util`(cli)、`tokio-test`(im)を削除

### 軽微な挙動ノート(意図的)
- cli: tokenizer 必須エラーの文言を2種類から1つに統一(`--tokenizer-json is required when loading a GGUF file path`)
- im: `Settings::save` の debug ログが `create_dir_all` の前に出るように(ログ順のみ)

## 検証

- `cargo clippy --workspace --all-targets`: 警告ゼロ
- `cargo test --workspace`: 450件全パス(ベースライン453件との差3件は削除したデッドコード自身のテスト)
- fcitx5 アドオン: `cmake --build` でコンパイル・リンク成功
- `cargo fmt --all`: 差分なし
- karukan-macos は Linux 上に Swift コンパイラがないため未コンパイル。全シンボルの grep 照合(呼び出し側はすべて1引数形式)と diff レビューで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
