### PR TITLE
chore: Renovateを設定する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ data/
 # Tracked data: symbol descriptions / variants for the rewriter
 !karukan-engine/data/
 *.json
+!renovate.json
 *.cache
 
 .fake

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":timezone(Asia/Tokyo)"],
-  "schedule": ["before 9am on saturday"],
-  "lockFileMaintenance": { "enabled": true },
+  "schedule": ["after 9pm", "before 9am"],
+  "labels": ["dependencies"],
+  "dependencyDashboard": true,
+  "prConcurrentLimit": 10,
+  "cargo": { "rangeStrategy": "update-lockfile" },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 9am on saturday"]
+  },
   "packageRules": [
     {
       "matchManagers": ["cargo"],
-      "groupName": "cargo dependencies"
+      "groupName": "cargo dependencies",
+      "minimumReleaseAge": "3 days"
     },
     {
       "matchPackageNames": ["llama-cpp-2"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":timezone(Asia/Tokyo)"],
+  "schedule": ["before 9am on saturday"],
+  "lockFileMaintenance": { "enabled": true },
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "cargo dependencies"
+    },
+    {
+      "matchPackageNames": ["llama-cpp-2"],
+      "groupName": null,
+      "prPriority": 5
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

依存関係の自動更新のために Renovate の設定ファイル（`renovate.json`）を追加します。設定内容は有名 Rust OSS（uv / biome / swc / oxc）のプラクティスを参考にしています。

## 設定内容

- **スケジュール**: 毎晩 21時〜翌9時（JST）にチェック。日中に PR 通知が来ないようにしつつ、脆弱性対応の遅れを最小化
- **Cargo 依存のグループ化**: 通常の更新は「cargo dependencies」1本の PR にまとめ、PR の洪水を防ぐ
- **`llama-cpp-2` は単独 PR**: 0.x で llama.cpp 上流に追従しており破壊的変更の可能性が高いため、個別にレビューできるよう分離（`prPriority: 5`）
- **`minimumReleaseAge: 3 days`**（biome / swc 準拠): リリース直後の版を取り込まないクールダウン。yank や不正パッケージなどサプライチェーンリスクの回避
- **`rangeStrategy: update-lockfile`**（uv 準拠): workspace のバージョン指定が緩い（`serde = "1"` など）ため、範囲内の更新も lockfile のみを更新する PR として届くようにする
- **`lockFileMaintenance`**: 週1（土曜朝）で `Cargo.lock` 全体を更新
- **Dependency Dashboard**: 保留中の更新を Issue で一覧管理
- **`prConcurrentLimit: 10`**: 同時にオープンする更新 PR は最大10本（超過分は Dashboard で待機）
- **`labels: ["dependencies"]`**: Renovate の全 PR に `dependencies` ラベルを付与
- automerge はなし（すべて手動レビュー）。GitHub Actions の更新は `config:recommended` でカバー

## 補足

- `.gitignore` の `*.json` に `!renovate.json` の例外を追加しています
- `renovate-config-validator` で設定の妥当性を確認済み
- Renovate App はインストール済みのため、この PR をマージすると設定が有効になります。オンボーディング PR #59 は不要になるので閉じます（マージ後に自動で閉じられます）

🤖 Generated with [Claude Code](https://claude.com/claude-code)