### PR TITLE
chore: Renovateの更新スケジュールを週1（土曜朝）に変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":timezone(Asia/Tokyo)"],
-  "schedule": ["after 9pm", "before 9am"],
+  "schedule": ["before 9am on saturday"],
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "prConcurrentLimit": 10,


### PR DESCRIPTION
## 概要
Renovateの `schedule` が `after 9pm / before 9am`（毎晩）だったため、依存更新PRが毎日作られていた。有名Rust OSS（ruff, uv, zed, helix, bevy など）は週1が主流なので、週1に変更する。

## 変更内容
- `schedule` を `["before 9am on saturday"]` に変更
  - 元からある `lockFileMaintenance` の土曜9時前と同じタイミングに集約
  - llama-cpp-2 も週1スケジュールに従う（単独PR・prPriority 5 はそのまま）

## 影響
- 脆弱性アラート由来のPRはRenovateのデフォルトでスケジュールを無視して即時作成されるため、セキュリティ対応は遅れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)