### PR TITLE
feat: jinen-v1.1-beta をモデルレジストリに追加（設定でopt-in）

### DIFF
--- a/karukan-engine/README.md
+++ b/karukan-engine/README.md
@@ -103,10 +103,13 @@ let results = dict.common_prefix_search("きょうと");
 
 モデルは`models.toml`で定義されています。`Backend::from_variant_id()`で指定すると自動的にダウンロードされます。
 
-| バリアントID | パラメータ数 | 量子化 | デフォルト |
-|------------|-----------|--------------|---------|
-| `jinen-v1-xsmall-q5` | 26M | Q5_K_M | |
-| `jinen-v1-small-q5` | 90M | Q5_K_M | Yes |
+| バリアントID | ベースモデル | パラメータ数 | 量子化 | デフォルト |
+|------------|-----------|-----------|--------------|---------|
+| `jinen-v1-xsmall-q5` | GPT-2 | 26M | Q5_K_M | |
+| `jinen-v1-small-q5` | GPT-2 | 90M | Q5_K_M | Yes |
+| `jinen-v1.1-beta-q5` | Qwen3 | 109M | Q5_K_M | |
+
+IMEで使うモデルは設定ファイルの `model` / `light_model` で切り替えられます（[karukan-im の Configuration](../karukan-im/README.md#configuration) 参照）。
 
 ### jinen Format
 

--- a/karukan-engine/models.toml
+++ b/karukan-engine/models.toml
@@ -1,4 +1,4 @@
-default_model = "jinen-v1-small-q5"
+default_model = "jinen-v1.1-beta-q5"
 
 [models.jinen-v1-xsmall]
 repo_id = "togatogah/jinen-v1-xsmall.gguf"
@@ -17,3 +17,12 @@ display_name = "jinen-v1-small (GPT-2 Small, 90M)"
 id = "jinen-v1-small-q5"
 filename = "jinen-v1-small-Q5_K_M.gguf"
 display_name = "jinen-v1-small (Q5_K_M)"
+
+[models."jinen-v1.1-beta"]
+repo_id = "togatogah/jinen-v1.1-beta"
+display_name = "jinen-v1.1-beta (Qwen3, 109M)"
+
+[models."jinen-v1.1-beta".variants.q5]
+id = "jinen-v1.1-beta-q5"
+filename = "jinen-v1.1-beta-Q5_K_M.gguf"
+display_name = "jinen-v1.1-beta (Q5_K_M)"

--- a/karukan-engine/models.toml
+++ b/karukan-engine/models.toml
@@ -19,7 +19,7 @@ filename = "jinen-v1-small-Q5_K_M.gguf"
 display_name = "jinen-v1-small (Q5_K_M)"
 
 [models."jinen-v1.1-beta"]
-repo_id = "togatogah/jinen-v1.1-beta"
+repo_id = "togatogah/jinen-v1.1-beta.gguf"
 display_name = "jinen-v1.1-beta (Qwen3, 109M)"
 
 [models."jinen-v1.1-beta".variants.q5]

--- a/karukan-engine/models.toml
+++ b/karukan-engine/models.toml
@@ -1,4 +1,4 @@
-default_model = "jinen-v1.1-beta-q5"
+default_model = "jinen-v1-small-q5"
 
 [models.jinen-v1-xsmall]
 repo_id = "togatogah/jinen-v1-xsmall.gguf"

--- a/karukan-engine/src/kanji/model_config.rs
+++ b/karukan-engine/src/kanji/model_config.rs
@@ -94,7 +94,7 @@ mod tests {
     #[test]
     fn test_parse_registry() {
         let reg = registry();
-        assert_eq!(reg.default_model, "jinen-v1.1-beta-q5");
+        assert_eq!(reg.default_model, "jinen-v1-small-q5");
         assert_eq!(reg.models.len(), 3, "Expected exactly 3 model families");
     }
 
@@ -122,8 +122,8 @@ mod tests {
     fn test_default_variant() {
         let reg = registry();
         let (family, variant) = reg.default_variant().expect("default not found");
-        assert_eq!(variant.id, "jinen-v1.1-beta-q5");
-        assert_eq!(family.repo_id, "togatogah/jinen-v1.1-beta");
+        assert_eq!(variant.id, "jinen-v1-small-q5");
+        assert_eq!(family.repo_id, "togatogah/jinen-v1-small.gguf");
     }
 
     #[test]

--- a/karukan-engine/src/kanji/model_config.rs
+++ b/karukan-engine/src/kanji/model_config.rs
@@ -94,8 +94,8 @@ mod tests {
     #[test]
     fn test_parse_registry() {
         let reg = registry();
-        assert_eq!(reg.default_model, "jinen-v1-small-q5");
-        assert_eq!(reg.models.len(), 2, "Expected exactly 2 model families");
+        assert_eq!(reg.default_model, "jinen-v1.1-beta-q5");
+        assert_eq!(reg.models.len(), 3, "Expected exactly 3 model families");
     }
 
     #[test]
@@ -122,8 +122,8 @@ mod tests {
     fn test_default_variant() {
         let reg = registry();
         let (family, variant) = reg.default_variant().expect("default not found");
-        assert_eq!(variant.id, "jinen-v1-small-q5");
-        assert_eq!(family.repo_id, "togatogah/jinen-v1-small.gguf");
+        assert_eq!(variant.id, "jinen-v1.1-beta-q5");
+        assert_eq!(family.repo_id, "togatogah/jinen-v1.1-beta");
     }
 
     #[test]
@@ -132,19 +132,20 @@ mod tests {
         let ids = reg.all_variant_ids();
         assert_eq!(
             ids.len(),
-            2,
-            "Expected exactly 2 variants, got {}",
+            3,
+            "Expected exactly 3 variants, got {}",
             ids.len()
         );
         assert!(ids.contains(&"jinen-v1-xsmall-q5"));
         assert!(ids.contains(&"jinen-v1-small-q5"));
+        assert!(ids.contains(&"jinen-v1.1-beta-q5"));
     }
 
     #[test]
     fn test_iter_variants() {
         let reg = registry();
         let count = reg.iter_variants().count();
-        assert_eq!(count, 2, "Expected exactly 2 variants, got {}", count);
+        assert_eq!(count, 3, "Expected exactly 3 variants, got {}", count);
     }
 
     #[test]

--- a/karukan-im/README.md
+++ b/karukan-im/README.md
@@ -86,6 +86,14 @@ max_entries = 10000            # 学習エントリの最大数
 max_surface_chars = 50         # 学習する変換結果の最大文字数
 ```
 
+`model` / `light_model` に指定できるモデルIDは以下です（指定したモデルは初回利用時にHugging Faceから自動ダウンロードされます）。設定変更後はfcitx5の再起動（macOSは `killall KarukanIME`）で反映されます。
+
+| モデルID | ベースモデル | パラメータ数 |
+|---------|-----------|-----------|
+| `jinen-v1-xsmall-q5` | GPT-2 | 26M |
+| `jinen-v1-small-q5` | GPT-2 | 90M |
+| `jinen-v1.1-beta-q5` | Qwen3 | 109M（beta） |
+
 > [!NOTE]
 > 上記は主要な設定項目の抜粋です。全項目の正確な既定値と説明は [`config/default.toml`](config/default.toml) を参照してください（各設定行に日本語コメント付き）。
 

--- a/karukan-im/config/default.toml
+++ b/karukan-im/config/default.toml
@@ -22,7 +22,7 @@ beam_width = 3
 # メインモデルの推論がこの時間(ms)を超えたらlight_modelに自動切替(0で無効)
 max_latency_ms = 100
 # Model variant id or GGUF path (uses registry default if unset)
-model = "jinen-v1-small-q5"
+model = "jinen-v1.1-beta-q5"
 # Beam search model for Space conversion (uses default model only if unset)
 light_model = "jinen-v1-xsmall-q5"
 # 推論スレッド数（0 = 全コア使用）

--- a/karukan-im/config/default.toml
+++ b/karukan-im/config/default.toml
@@ -22,7 +22,7 @@ beam_width = 3
 # メインモデルの推論がこの時間(ms)を超えたらlight_modelに自動切替(0で無効)
 max_latency_ms = 100
 # Model variant id or GGUF path (uses registry default if unset)
-model = "jinen-v1.1-beta-q5"
+model = "jinen-v1-small-q5"
 # Beam search model for Space conversion (uses default model only if unset)
 light_model = "jinen-v1-xsmall-q5"
 # 推論スレッド数（0 = 全コア使用）


### PR DESCRIPTION
## 概要

[togatogah/jinen-v1.1-beta.gguf](https://huggingface.co/togatogah/jinen-v1.1-beta.gguf) (Qwen3, 109M) をモデルレジストリに追加します。

デフォルトモデルは従来どおり `jinen-v1-small-q5` のままです。v1.1-beta はまだ beta のため、使いたいユーザーが設定ファイルで opt-in する形にしています。

```toml
# ~/.config/karukan-im/config.toml
# (macOS: ~/Library/Application Support/com.karukan.karukan-im/config.toml)
[conversion]
model = "jinen-v1.1-beta-q5"
```

指定したモデルは初回利用時にHugging Faceから自動ダウンロードされます。

## 変更内容

- `karukan-engine/models.toml`: `jinen-v1.1-beta` ファミリと `jinen-v1.1-beta-q5` (Q5_K_M) バリアントを追加（`default_model` は `jinen-v1-small-q5` のまま）
- `karukan-engine/src/kanji/model_config.rs`: レジストリのテストを3ファミリに更新
- `karukan-engine/README.md`: モデル表に v1.1-beta を追加、ベースモデル列を追加
- `karukan-im/README.md`: `model` / `light_model` に指定できるモデルID一覧と反映方法を追記

`light_model` は `jinen-v1-xsmall-q5` のまま据え置きです。

## 動作確認

- `cargo test -p karukan-engine --lib kanji::model_config` … 8 passed
- `cargo fmt --all --check` / `cargo clippy -p karukan-engine --all-targets` … クリーン
- `model = "jinen-v1.1-beta-q5"` を指定した状態で `karukan-server` からモデルの自動ダウンロード・ロードと実変換を確認:

| 入力 | 出力 |
|---|---|
| きょうはいいてんきですね | 今日はいい天気ですね |
| かんじへんかんのてすとをします | 漢字変換のテストをします |
| とうきょうとにすんでいます | 東京都に住んでいます |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
