### PR TITLE
refactor: Element::DirectをConvertedに統合

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ cargo clippy --workspace  # Lint all crates
   - `mod.rs` — Main InputMethodEngine struct and core processing logic
   - `types.rs` — EngineConfig, EngineResult, EngineAction, Converters, ConversionStrategy
   - `input.rs` — Key input handling for Composing state
-  - `input_buffer.rs` — Composition record: per-display-char element array (`Romaji`/`Converted`/`Direct`) + caret index; display/reading/pending are derived views
+  - `input_buffer.rs` — Composition record: per-display-char element array (`Romaji`/`Converted`) + caret index; display/reading/pending are derived views
   - `conversion.rs` — Conversion mode handling (candidate building, commit)
   - `chunk.rs` — Live-conversion chunking: the Japanese/non-Japanese split (`is_japanese`, `group_chunks`), incremental re-chunk diff (`ChunkPlan`), and `chunked_auto_suggest`
   - `cursor.rs` — Cursor movement
@@ -183,7 +183,7 @@ The engine-internal `InputMode::Alphabet` (entered via Shift+letter on Linux/fci
 ## Key Design Patterns
 
 - IMEEngine uses a state machine: Empty → Composing → Conversion
-- `input_buf: InputBuffer` in IMEEngine is the source of truth: an element array (one element per display character — `Romaji(char)` unfired keystroke / `Converted(char)` fired output / `Direct(char)` direct input) plus a caret index. All views (display, conversion reading, aux romaji tail) are derived from it
+- `input_buf: InputBuffer` in IMEEngine is the source of truth: an element array (one element per display character — `Romaji(char)` unfired keystroke / `Converted(char)` settled character: fired output, passthrough, or direct input) plus a caret index. All views (display, conversion reading, aux romaji tail) are derived from it
 - `RomajiConverter` is stateless (pure `convert`/`flush_pending`); after each romaji keystroke the engine re-evaluates only the Romaji run ending at the caret (`evaluate_run`), re-recording fired keystrokes as `Converted`. `Converted` never re-enters evaluation, so settled text never reverts. Backspace/delete remove one element and then evaluate the run the removal joined, so the result always equals typing the remaining keystrokes fresh (`ykt` → BS → `o` → 「yこ」; `yt1t` minus the `1` → 「yっt」). Cursor moves and mode toggles never touch the array
 - Models use jinen format with special Unicode tokens (U+EE00–U+EE02) from the Private Use Area; model input is katakana (hiragana is converted to katakana before inference)
 - Model registry defined in `karukan-engine/models.toml`; default models use Q5_K_M quantization

--- a/karukan-im/src/core/engine/input_buffer.rs
+++ b/karukan-im/src/core/engine/input_buffer.rs
@@ -10,11 +10,9 @@
 //!
 //! - [`Element::Romaji`]: one keystroke not yet consumed by a rule (`y`,
 //!   `k`, a lone `n`). Shown verbatim; evaluation may later consume it.
-//! - [`Element::Converted`]: one character of settled output — a fired
-//!   rule's kana or a passthrough like `1`. Opaque to evaluation; it never
-//!   reverts.
-//! - [`Element::Direct`]: one directly-input keystroke (alphabet/emoji
-//!   mode). Opaque to evaluation.
+//! - [`Element::Converted`]: one settled character — a fired rule's kana,
+//!   a passthrough like `1`, or direct input (alphabet/emoji mode). Opaque
+//!   to evaluation; it never reverts.
 //!
 //! **Evaluation** derives everything else: the display, the conversion
 //! reading, and the aux romaji tail. After a romaji keystroke is recorded,
@@ -22,7 +20,7 @@
 //! keystrokes a rule consumed are re-recorded as its output. Elements
 //! right of the cursor are never touched, so nothing combines across the
 //! caret, and the caret moves without settling anything — `[Romaji(k),
-//! Romaji(y), Direct(K)]` plus `o` typed before the `K` evaluates to
+//! Romaji(y), Converted(K)]` plus `o` typed before the `K` evaluates to
 //! 「きょK」.
 //!
 //! Every record edit ends with an evaluation. Typing evaluates the run
@@ -39,16 +37,15 @@ use karukan_engine::RomajiConverter;
 enum Element {
     /// A keystroke not yet consumed by a conversion rule
     Romaji(char),
-    /// Settled output: a fired rule's character (`ko` → こ) or passthrough (`1`)
+    /// A settled character: fired rule output (`ko` → こ), passthrough
+    /// (`1`), or direct input — excluded from romaji evaluation
     Converted(char),
-    /// A directly-input keystroke — excluded from romaji evaluation
-    Direct(char),
 }
 
 impl Element {
     fn ch(&self) -> char {
         match self {
-            Element::Romaji(ch) | Element::Converted(ch) | Element::Direct(ch) => *ch,
+            Element::Romaji(ch) | Element::Converted(ch) => *ch,
         }
     }
 
@@ -64,8 +61,8 @@ pub(super) struct InputBuffer {
     /// per display character — is also the display position.
     ///
     /// ```text
-    /// elements: [Romaji(k), Romaji(y), Converted(1), Direct(K)]
-    /// boundary: 0         1          2             3          4
+    /// elements: [Romaji(k), Romaji(y), Converted(1), Converted(K)]
+    /// boundary: 0         1          2             3             4
     ///                                ↑ cursor = 2 (between y and 1)
     /// ```
     cursor: usize,
@@ -99,9 +96,10 @@ impl InputBuffer {
         self.evaluate_active_run(romaji);
     }
 
-    /// Record a direct-input keystroke at the caret.
+    /// Record a direct-input keystroke (alphabet/emoji mode) at the caret,
+    /// settled as-is.
     pub fn push_direct(&mut self, ch: char) {
-        self.elements.insert(self.cursor, Element::Direct(ch));
+        self.elements.insert(self.cursor, Element::Converted(ch));
         self.cursor += 1;
     }
 


### PR DESCRIPTION
#80 のフォローアップ。

## 背景

`Direct` は「ローマ字評価の対象外の直接入力」を表すために導入したが、`Converted` が最初から同じ性質を持っており、振る舞いが全箇所で同一だった：

| 判定箇所 | Converted | Direct |
|---|---|---|
| 評価（active run の境界） | 不透明 | 不透明（同一） |
| reading() / pending() | 読みに含む | 読みに含む（同一） |
| settle / 表示 / カーソル | 同一 | 同一 |
| `bake_katakana` | かな→カタカナ | スキップ — 唯一の差だが、Direct の中身は ASCII と全角スペースのみでカタカナ変換は恒等のため実質差なし |

## 変更

- `Element` を `Romaji(char)` / `Converted(char)` の2種に統合（`Converted` = 発火した規則の出力・記号パススルー・直接入力）
- `push_direct` は呼び出し側の意図（直接入力の記録）を表す名前としてそのまま。記録先が `Converted` になるだけで挙動は不変
- CLAUDE.md の要素説明を更新

挙動は完全に不変（ワークスペース全474テストグリーン、clippy クリーン）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)