### PR TITLE
fix: 変換キャンセル後にローマ字未確定打鍵が結合しない問題を修正

### DIFF
--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -190,10 +190,10 @@ impl InputMethodEngine {
     /// `skip_learning` is set by the Tab path to omit learning-cache
     /// candidates (Space/Down keep the default learning-included behavior).
     pub(super) fn start_conversion(&mut self, skip_learning: bool) -> EngineResult {
-        // Settle any remaining romaji
-        self.settle_romaji();
-
-        let reading = self.input_buf.reading();
+        // Resolve the reading without touching the composition: pending
+        // romaji stays live so cancelling the conversion returns to an
+        // editable buffer (けいおうd → Tab → Esc → `a` → けいおうだ)
+        let reading = self.input_buf.settled_reading(&self.converters.romaji);
 
         // Save auto-suggest/live conversion result before clearing state.
         // This ensures the candidate that was displayed during input is preserved
@@ -222,17 +222,12 @@ impl InputMethodEngine {
         }
 
         if candidates.is_empty() {
-            // No candidates: stay composing with the caret where it was,
-            // so the next key keeps appending (emoji queries with no match
-            // land here)
-            let preedit = Preedit::with_text_underlined(&reading);
-            self.state = InputState::Composing {
-                preedit: preedit.clone(),
-            };
+            // No candidates: stay composing, untouched (emoji queries with
+            // no match land here)
+            let preedit = self.set_composing_state();
             return EngineResult::consumed().with_action(EngineAction::UpdatePreedit(preedit));
         }
 
-        self.input_buf.set_cursor(0);
         let candidate_list = Self::to_conversion_candidate_list(candidates, &reading);
         self.enter_conversion_state(&reading, candidate_list)
     }
@@ -270,6 +265,7 @@ impl InputMethodEngine {
         self.state = InputState::Conversion {
             preedit: preedit.clone(),
             candidates: candidates.clone(),
+            reading: reading.to_string(),
         };
 
         EngineResult::consumed()
@@ -772,7 +768,10 @@ impl InputMethodEngine {
         // prefix-matched candidate carries a longer reading of its own, but
         // every entry that surfaces it has the typed reading as a prefix, so
         // removing by the typed reading clears the shown row and its twins.
-        let reading = self.input_buf.reading();
+        let InputState::Conversion { reading, .. } = &self.state else {
+            return EngineResult::consumed();
+        };
+        let reading = reading.clone();
         let removed = self
             .learning
             .as_mut()
@@ -796,21 +795,17 @@ impl InputMethodEngine {
         if !matches!(self.state, InputState::Conversion { .. }) {
             return EngineResult::not_consumed();
         }
-        let reading = self.input_buf.reading();
 
-        if reading.is_empty() {
+        if !self.input_buf.has_elements() {
             self.state = InputState::Empty;
-            self.input_buf.clear();
             return EngineResult::consumed()
                 .with_action(EngineAction::UpdatePreedit(Preedit::new()))
                 .with_action(EngineAction::HideCandidates)
                 .with_action(EngineAction::HideAuxText);
         }
 
-        // Rebuild the composition from the reading (no pending romaji)
-        self.input_buf.clear();
-        self.input_buf.insert(&reading);
-
+        // The composition was left untouched when the conversion started:
+        // just come back to it, pending romaji still live
         let preedit = self.set_composing_state();
 
         EngineResult::consumed()

--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -20,6 +20,16 @@ const MAX_PREDICTIVE_SUGGESTIONS: usize = 3;
 /// single key would flood the list from a large dictionary
 const MIN_PREDICTIVE_PREFIX_CHARS: usize = 2;
 
+/// How the unresolved romaji tail constrains the predictive lookup.
+enum TailConstraint {
+    /// No tail: prediction is unconstrained
+    Unconstrained,
+    /// The tail can still become these kana: narrow to them (`d` → だ/で…)
+    Narrow(Vec<String>),
+    /// The tail can no longer become kana (`yk`): no reading extends it
+    Dead,
+}
+
 /// Mozc-style width/script annotation for a pure-kana candidate, or `None`
 /// if the text mixes scripts or contains kanji/punctuation. Used to label
 /// `あ` / `ア` / `ｱ` candidates in the conversion list.
@@ -334,22 +344,23 @@ impl InputMethodEngine {
         // Predictive: dictionary readings extending the typed prefix,
         // mirroring the learning cache's prefix lookup. The full reading
         // rides on the candidate so selecting it commits and records under
-        // the right key. An unresolved romaji tail narrows the lookup to
-        // the kana it can still become; a tail that can't become kana
-        // (`yk`) suppresses prediction entirely.
-        if reading.chars().count() >= MIN_PREDICTIVE_PREFIX_CHARS {
-            let expansions = self.converters.romaji.pending_expansions(pending);
-            let tail_is_dead = !pending.is_empty() && expansions.is_empty();
-            let mut budget = if tail_is_dead { 0 } else { predictive_limit };
+        // the right key.
+        let constraint = self.tail_constraint(pending);
+        if reading.chars().count() >= MIN_PREDICTIVE_PREFIX_CHARS
+            && !matches!(constraint, TailConstraint::Dead)
+        {
+            let mut budget = predictive_limit;
             for (dict, source) in dicts {
                 if budget == 0 {
                     break;
                 }
                 let Some(dict) = dict else { continue };
-                let matches = if expansions.is_empty() {
-                    dict.predictive_search(reading, budget)
-                } else {
-                    dict.predictive_search_expanded(reading, &expansions, budget)
+                let matches = match &constraint {
+                    TailConstraint::Unconstrained => dict.predictive_search(reading, budget),
+                    TailConstraint::Narrow(expansions) => {
+                        dict.predictive_search_expanded(reading, expansions, budget)
+                    }
+                    TailConstraint::Dead => unreachable!("checked above"),
                 };
                 for m in matches {
                     if budget == 0 || candidates.len() >= limit {
@@ -367,6 +378,19 @@ impl InputMethodEngine {
         }
 
         candidates
+    }
+
+    /// Classify the unresolved romaji tail for predictive lookup.
+    fn tail_constraint(&self, pending: &str) -> TailConstraint {
+        if pending.is_empty() {
+            return TailConstraint::Unconstrained;
+        }
+        let expansions = self.converters.romaji.pending_expansions(pending);
+        if expansions.is_empty() {
+            TailConstraint::Dead
+        } else {
+            TailConstraint::Narrow(expansions)
+        }
     }
 
     /// Build conversion candidates for a reading from multiple sources.

--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -198,14 +198,8 @@ impl InputMethodEngine {
         // Save auto-suggest/live conversion result before clearing state.
         // This ensures the candidate that was displayed during input is preserved
         // in the conversion candidate list even if the re-inference uses a different strategy.
-        let mut prev_suggest_text = std::mem::take(&mut self.live.text);
-        // The live suggestion covers only the settled part of the buffer;
-        // the pending romaji was displayed after it (早稲田 + d). Append its
-        // settled form so the preserved candidate doesn't drop the tail.
-        if !prev_suggest_text.is_empty() {
-            let pending = self.input_buf.pending();
-            prev_suggest_text.push_str(&self.converters.romaji.convert_flush(&pending));
-        }
+        let prev_suggest_text = self.live_text_with_pending();
+        self.live.text.clear();
 
         if reading.is_empty() {
             return EngineResult::consumed();

--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -198,7 +198,14 @@ impl InputMethodEngine {
         // Save auto-suggest/live conversion result before clearing state.
         // This ensures the candidate that was displayed during input is preserved
         // in the conversion candidate list even if the re-inference uses a different strategy.
-        let prev_suggest_text = std::mem::take(&mut self.live.text);
+        let mut prev_suggest_text = std::mem::take(&mut self.live.text);
+        // The live suggestion covers only the settled part of the buffer;
+        // the pending romaji was displayed after it (早稲田 + d). Append its
+        // settled form so the preserved candidate doesn't drop the tail.
+        if !prev_suggest_text.is_empty() {
+            let pending = self.input_buf.pending();
+            prev_suggest_text.push_str(&self.converters.romaji.convert_flush(&pending));
+        }
 
         if reading.is_empty() {
             return EngineResult::consumed();

--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -797,7 +797,7 @@ impl InputMethodEngine {
             return EngineResult::not_consumed();
         }
 
-        if !self.input_buf.has_elements() {
+        if self.input_buf.is_empty() {
             self.state = InputState::Empty;
             return EngineResult::consumed()
                 .with_action(EngineAction::UpdatePreedit(Preedit::new()))

--- a/karukan-im/src/core/engine/conversion.rs
+++ b/karukan-im/src/core/engine/conversion.rs
@@ -194,6 +194,11 @@ impl InputMethodEngine {
         // romaji stays live so cancelling the conversion returns to an
         // editable buffer (けいおうd → Tab → Esc → `a` → けいおうだ)
         let reading = self.input_buf.settled_reading(&self.converters.romaji);
+        // The unresolved tail keeps narrowing the predictive dictionary
+        // lookup, so a suggestion visible while typing (わせd → 早稲田)
+        // stays selectable in the conversion list
+        let base = self.input_buf.reading();
+        let pending = self.input_buf.pending();
 
         // Save auto-suggest/live conversion result before clearing state.
         // This ensures the candidate that was displayed during input is preserved
@@ -206,8 +211,13 @@ impl InputMethodEngine {
         }
 
         // Get candidates from kanji converter (use full num_candidates for explicit conversion)
-        let mut candidates =
-            self.build_conversion_candidates(&reading, self.config.num_candidates, skip_learning);
+        let mut candidates = self.build_conversion_candidates(
+            &reading,
+            &base,
+            &pending,
+            self.config.num_candidates,
+            skip_learning,
+        );
 
         // If the previous auto-suggest result is not in the new candidates, insert it at the top
         // so it doesn't disappear when the conversion strategy changes.
@@ -301,9 +311,13 @@ impl InputMethodEngine {
         let mut candidates = Vec::new();
         let mut seen = HashSet::new();
 
-        // Exact matches, user dictionary first. Candidates are sorted by
-        // score at build/load time
+        // Exact matches, user dictionary first — only when no romaji tail
+        // is pending (an exact hit on the base would ignore the typed
+        // tail). Candidates are sorted by score at build/load time
         for (dict, source) in dicts {
+            if !pending.is_empty() {
+                break;
+            }
             let Some(result) = dict.and_then(|d| d.exact_match_search(reading)) else {
                 continue;
             };
@@ -363,12 +377,18 @@ impl InputMethodEngine {
     ///
     /// Priority: Learning → User Dictionary → Model → System Dictionary → Fallback
     ///
+    /// `base`/`pending` split the reading for the dictionary lookup: while
+    /// a romaji tail is unresolved the predictive search stays narrowed to
+    /// it (base わせ + `d` → わせだ…), with no tail they equal `reading`/"".
+    ///
     /// `skip_learning` suppresses the learning-cache step (1). Used by the Tab
     /// key path so users can escape a noisy learning history without losing
     /// access to dictionary/model candidates.
     pub(super) fn build_conversion_candidates(
         &mut self,
         reading: &str,
+        base: &str,
+        pending: &str,
         num_candidates: usize,
         skip_learning: bool,
     ) -> Vec<AnnotatedCandidate> {
@@ -406,7 +426,7 @@ impl InputMethodEngine {
         }
 
         // 2. Dictionary candidates (user dict first, then system dict)
-        let dict_results = self.search_dictionaries(reading, "", usize::MAX, usize::MAX);
+        let dict_results = self.search_dictionaries(base, pending, usize::MAX, usize::MAX);
         // Insert user dictionary entries at the top (after learning)
         for ac in &dict_results {
             if ac.source == CandidateSource::UserDictionary {
@@ -782,8 +802,13 @@ impl InputMethodEngine {
         }
         debug!("deleted learning entry: {} -> {}", reading, surface);
 
-        let candidates =
-            self.build_conversion_candidates(&reading, self.config.num_candidates, false);
+        let candidates = self.build_conversion_candidates(
+            &reading,
+            &reading,
+            "",
+            self.config.num_candidates,
+            false,
+        );
         if candidates.is_empty() {
             return self.cancel_conversion();
         }

--- a/karukan-im/src/core/engine/display.rs
+++ b/karukan-im/src/core/engine/display.rs
@@ -46,6 +46,23 @@ impl InputMethodEngine {
         preedit
     }
 
+    /// The live conversion result as displayed: `live.text` plus the settled
+    /// pending romaji tail (早稲田 + d → 早稲田d). Committing or preserving
+    /// `live.text` alone would drop the tail, since the live suggestion only
+    /// covers the settled reading. Empty when live conversion has no result.
+    /// Must be called before `settle_romaji` (which empties the pending run).
+    pub(super) fn live_text_with_pending(&self) -> String {
+        if self.live.text.is_empty() {
+            return String::new();
+        }
+        let pending = self.input_buf.pending();
+        format!(
+            "{}{}",
+            self.live.text,
+            self.converters.romaji.convert_flush(&pending)
+        )
+    }
+
     /// Format an `lctx: … rctx: …` line from explicit left/right context
     /// strings, each truncated to `display_context_len` (left keeps its tail,
     /// right keeps its head). Empty when both are absent or the limit is 0.

--- a/karukan-im/src/core/engine/display.rs
+++ b/karukan-im/src/core/engine/display.rs
@@ -49,10 +49,13 @@ impl InputMethodEngine {
     /// The live conversion result as displayed: `live.text` plus the settled
     /// pending romaji tail (早稲田 + d → 早稲田d). Committing or preserving
     /// `live.text` alone would drop the tail, since the live suggestion only
-    /// covers the settled reading. Empty when live conversion has no result.
+    /// covers the settled reading. Empty when live conversion has no result
+    /// or the cursor is away from the end — there the display already fell
+    /// back to kana (see `build_composing_preedit`) and the pending run sits
+    /// mid-buffer, so the concatenation would not match what is shown.
     /// Must be called before `settle_romaji` (which empties the pending run).
     pub(super) fn live_text_with_pending(&self) -> String {
-        if self.live.text.is_empty() {
+        if self.live.text.is_empty() || self.input_buf.cursor() != self.input_buf.char_count() {
             return String::new();
         }
         let pending = self.input_buf.pending();

--- a/karukan-im/src/core/engine/input.rs
+++ b/karukan-im/src/core/engine/input.rs
@@ -350,6 +350,9 @@ impl InputMethodEngine {
     /// Commit the current hiragana input (or katakana if in katakana mode)
     /// In live conversion mode, commits the converted text instead of hiragana.
     pub(super) fn commit_composing(&mut self) -> EngineResult {
+        // Resolve the live text before settling: it needs the pending run
+        let live_text = self.live_text_with_pending();
+
         // Settle any pending romaji
         self.settle_romaji();
 
@@ -364,9 +367,9 @@ impl InputMethodEngine {
         } else if self.mode.current() == InputMode::Katakana {
             // Katakana mode always commits katakana, ignoring live conversion
             karukan_engine::hiragana_to_katakana(&reading)
-        } else if !self.live.text.is_empty() {
+        } else if !live_text.is_empty() {
             // Live conversion active: commit converted text
-            self.live.text.clone()
+            live_text
         } else {
             reading.clone()
         };

--- a/karukan-im/src/core/engine/input_buffer.rs
+++ b/karukan-im/src/core/engine/input_buffer.rs
@@ -103,8 +103,9 @@ impl InputBuffer {
         self.cursor += 1;
     }
 
-    /// Record settled text at the caret (reconversion reading and other
-    /// programmatic strings).
+    /// Record settled text at the caret. Test setup only — production
+    /// code always goes through the typed-key paths.
+    #[cfg(test)]
     pub fn insert(&mut self, text: &str) {
         let count = text.chars().count();
         self.elements.splice(
@@ -181,6 +182,31 @@ impl InputBuffer {
         let len = evaluated.len();
         self.elements.splice(range, evaluated);
         len
+    }
+
+    /// The reading as it would settle: Romaji runs force-converted in
+    /// place, everything else as displayed. The non-destructive
+    /// counterpart of [`Self::settle_romaji`] — used when the composition
+    /// must stay editable (starting a conversion that Escape can undo).
+    pub fn settled_reading(&self, romaji: &RomajiConverter) -> String {
+        let mut reading = String::new();
+        let mut run = String::new();
+        for element in &self.elements {
+            match element {
+                Element::Romaji(ch) => run.push(*ch),
+                Element::Converted(ch) => {
+                    if !run.is_empty() {
+                        reading.push_str(&romaji.convert_flush(&run));
+                        run.clear();
+                    }
+                    reading.push(*ch);
+                }
+            }
+        }
+        if !run.is_empty() {
+            reading.push_str(&romaji.convert_flush(&run));
+        }
+        reading
     }
 
     /// Settle all Romaji keystrokes in place (`ltu` → っ; unmatched

--- a/karukan-im/src/core/engine/input_buffer.rs
+++ b/karukan-im/src/core/engine/input_buffer.rs
@@ -81,8 +81,8 @@ impl InputBuffer {
         self.cursor = 0;
     }
 
-    pub fn has_elements(&self) -> bool {
-        !self.elements.is_empty()
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
     }
 
     // --- Record edits -----------------------------------------------------

--- a/karukan-im/src/core/engine/mod.rs
+++ b/karukan-im/src/core/engine/mod.rs
@@ -458,11 +458,12 @@ impl InputMethodEngine {
         match &self.state {
             InputState::Empty => String::new(),
             InputState::Composing { .. } => {
-                // Settle pending romaji
+                // Resolve the live text before settling: it needs the pending run
+                let live_text = self.live_text_with_pending();
                 self.settle_romaji();
                 let reading = self.input_buf.reading();
-                let text = if !self.live.text.is_empty() {
-                    self.live.text.clone()
+                let text = if !live_text.is_empty() {
+                    live_text
                 } else {
                     reading.clone()
                 };

--- a/karukan-im/src/core/engine/mod.rs
+++ b/karukan-im/src/core/engine/mod.rs
@@ -235,7 +235,7 @@ impl InputMethodEngine {
     /// If the composition is empty, reset to Empty state and return the result.
     /// Returns None if elements remain (caller should continue normally).
     fn try_reset_if_empty(&mut self) -> Option<EngineResult> {
-        if !self.input_buf.has_elements() {
+        if self.input_buf.is_empty() {
             self.state = InputState::Empty;
             self.input_buf.clear();
             // Erasing the whole buffer ends the composition: drop the live

--- a/karukan-im/src/core/engine/mode.rs
+++ b/karukan-im/src/core/engine/mode.rs
@@ -18,7 +18,7 @@ impl InputMethodEngine {
         // Clear live conversion text so katakana mode takes priority on commit
         self.live.text.clear();
 
-        if !self.input_buf.has_elements() {
+        if self.input_buf.is_empty() {
             return EngineResult::consumed();
         }
 

--- a/karukan-im/src/core/engine/tests/learning.rs
+++ b/karukan-im/src/core/engine/tests/learning.rs
@@ -27,7 +27,7 @@ fn build_candidates_includes_learning_when_not_skipped() {
     let mut engine = engine_with_learned("あい", "藍");
 
     let texts: Vec<String> = engine
-        .build_conversion_candidates("あい", 9, false)
+        .build_conversion_candidates("あい", "あい", "", 9, false)
         .into_iter()
         .map(|c| c.text)
         .collect();
@@ -44,7 +44,7 @@ fn build_candidates_omits_learning_when_skipped() {
     let mut engine = engine_with_learned("あい", "藍");
 
     let texts: Vec<String> = engine
-        .build_conversion_candidates("あい", 9, true)
+        .build_conversion_candidates("あい", "あい", "", 9, true)
         .into_iter()
         .map(|c| c.text)
         .collect();

--- a/karukan-im/src/core/engine/tests/live_conversion.rs
+++ b/karukan-im/src/core/engine/tests/live_conversion.rs
@@ -216,6 +216,34 @@ fn test_conversion_keeps_pending_tail_of_live_candidate() {
 }
 
 #[test]
+fn test_commit_mid_buffer_ignores_live_text() {
+    // Typing away from the end shows the kana display (live text is not
+    // faithful there), so Enter must commit what is shown — あdい — and not
+    // splice the live text with the mid-buffer pending run (愛d).
+    let mut engine = make_live_conversion_engine();
+    engine.process_key(&press('a'));
+    engine.process_key(&press('i'));
+    engine.process_key(&press_key(Keysym::LEFT));
+    engine.process_key(&press('d'));
+    assert_eq!(engine.preedit().unwrap().text(), "あdい");
+    engine.live.text = "愛".to_string();
+
+    let result = engine.process_key(&press_key(Keysym::RETURN));
+    let commit_text = result
+        .actions
+        .iter()
+        .find_map(|a| {
+            if let EngineAction::Commit(text) = a {
+                Some(text.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    assert_eq!(commit_text, "あdい");
+}
+
+#[test]
 fn test_live_conversion_cursor_move_clears() {
     // Moving cursor should clear live conversion text
     let mut engine = make_live_conversion_engine();

--- a/karukan-im/src/core/engine/tests/live_conversion.rs
+++ b/karukan-im/src/core/engine/tests/live_conversion.rs
@@ -147,6 +147,37 @@ fn test_live_conversion_commit_empty_falls_back_to_hiragana() {
 }
 
 #[test]
+fn test_conversion_keeps_pending_tail_of_live_candidate() {
+    // "wasedad": the live suggestion converts only the settled reading
+    // (わせだ→早稲田) and the pending `d` is displayed after it. Starting a
+    // conversion must surface 早稲田d — not 早稲田 — as the preserved top
+    // candidate, and commit it whole.
+    let mut engine = make_live_conversion_engine();
+    for ch in "wasedad".chars() {
+        engine.process_key(&press(ch));
+    }
+    engine.live.text = "早稲田".to_string();
+
+    engine.process_key(&press_key(Keysym::SPACE));
+    assert!(matches!(engine.state(), InputState::Conversion { .. }));
+    assert_eq!(engine.preedit().unwrap().text(), "早稲田d");
+
+    let result = engine.process_key(&press_key(Keysym::RETURN));
+    let commit_text = result
+        .actions
+        .iter()
+        .find_map(|a| {
+            if let EngineAction::Commit(text) = a {
+                Some(text.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    assert_eq!(commit_text, "早稲田d");
+}
+
+#[test]
 fn test_live_conversion_cursor_move_clears() {
     // Moving cursor should clear live conversion text
     let mut engine = make_live_conversion_engine();

--- a/karukan-im/src/core/engine/tests/live_conversion.rs
+++ b/karukan-im/src/core/engine/tests/live_conversion.rs
@@ -147,6 +147,44 @@ fn test_live_conversion_commit_empty_falls_back_to_hiragana() {
 }
 
 #[test]
+fn test_live_conversion_commit_keeps_pending_tail() {
+    // "wasedad" + Enter without any Space: the display was 早稲田 + pending
+    // `d`, so the commit must be 早稲田d, not 早稲田.
+    let mut engine = make_live_conversion_engine();
+    for ch in "wasedad".chars() {
+        engine.process_key(&press(ch));
+    }
+    engine.live.text = "早稲田".to_string();
+
+    let result = engine.process_key(&press_key(Keysym::RETURN));
+    let commit_text = result
+        .actions
+        .iter()
+        .find_map(|a| {
+            if let EngineAction::Commit(text) = a {
+                Some(text.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    assert_eq!(commit_text, "早稲田d");
+    assert!(matches!(engine.state(), InputState::Empty));
+}
+
+#[test]
+fn test_engine_commit_keeps_pending_tail() {
+    // Same as above through the programmatic commit() path (focus-out).
+    let mut engine = make_live_conversion_engine();
+    for ch in "wasedad".chars() {
+        engine.process_key(&press(ch));
+    }
+    engine.live.text = "早稲田".to_string();
+
+    assert_eq!(engine.commit(), "早稲田d");
+}
+
+#[test]
 fn test_conversion_keeps_pending_tail_of_live_candidate() {
     // "wasedad": the live suggestion converts only the settled reading
     // (わせだ→早稲田) and the pending `d` is displayed after it. Starting a

--- a/karukan-im/src/core/engine/tests/pending_romaji.rs
+++ b/karukan-im/src/core/engine/tests/pending_romaji.rs
@@ -2,7 +2,8 @@
 //!
 //! Each case is a list of (keys, expected) steps: the keys are sent one
 //! keystroke at a time, then the preedit is asserted. Key tokens:
-//! `←` Left, `⌫` Backspace, `⇥` End, `␛` Escape, `␣` Space, `変` HENKAN
+//! `←` Left, `⌫` Backspace, `⇥` End, `␛` Escape, `␣` Space, `↹` Tab,
+//! `変` HENKAN
 //! (mode toggle to hiragana); an ASCII uppercase letter is typed with
 //! Shift; anything else is a plain key. An expected value of `"きょ@2"`
 //! also asserts the caret, and `"∅"` asserts the Empty state.
@@ -21,6 +22,7 @@ fn send(engine: &mut InputMethodEngine, keys: &str) {
             '⇥' => press_key(Keysym::END),
             '␛' => press_key(Keysym::ESCAPE),
             '␣' => press_key(Keysym::SPACE),
+            '↹' => press_key(Keysym::TAB),
             '変' => press_key(Keysym::HENKAN),
             c if c.is_ascii_uppercase() => press_shift(c),
             c => press(c),
@@ -158,6 +160,24 @@ fn test_editing_scenarios() {
         (
             "conversion_escape_then_continue_typing",
             &[("kyo", "きょ"), ("␣␛", "きょ"), ("u", "きょう")],
+        ),
+        // Cancelling a conversion restores the live romaji: the pending
+        // `d` still combines afterwards
+        (
+            "space_escape_keeps_pending_live",
+            &[
+                ("keioud", "けいおうd"),
+                ("␣␛", "けいおうd"),
+                ("a", "けいおうだ"),
+            ],
+        ),
+        (
+            "tab_escape_keeps_pending_live",
+            &[
+                ("keioud", "けいおうd"),
+                ("↹␛", "けいおうd"),
+                ("a", "けいおうだ"),
+            ],
         ),
         // No candidates (emoji query with no match): Space keeps composing
         // with the caret at the end, so the next key appends

--- a/karukan-im/src/core/engine/tests/predictive.rs
+++ b/karukan-im/src/core/engine/tests/predictive.rs
@@ -129,7 +129,7 @@ fn conversion_list_gets_all_predictive_candidates() {
     ));
 
     let conversion: Vec<String> = engine
-        .build_conversion_candidates("わせ", 1, false)
+        .build_conversion_candidates("わせ", "わせ", "", 1, false)
         .into_iter()
         .map(|c| c.text)
         .collect();
@@ -143,4 +143,39 @@ fn conversion_list_gets_all_predictive_candidates() {
 
     let suggestions = engine.lookup_dict_candidates("わせ");
     assert!(suggestions.len() <= 3);
+}
+
+/// The narrowed suggestion stays selectable: わせd + Space rebuilds the
+/// conversion list with the same narrowing, so 早稲田 is in the
+/// selectable candidates (and ワセリン is not).
+#[test]
+fn conversion_with_pending_keeps_narrowed_candidates() {
+    let mut engine = InputMethodEngine::new();
+    engine.dicts.system = Some(dict_from_json(
+        r#"[
+            {"reading":"わせだ","candidates":[{"surface":"早稲田","score":1000.0}]},
+            {"reading":"わせりん","candidates":[{"surface":"ワセリン","score":100.0}]}
+        ]"#,
+    ));
+
+    for ch in "wased".chars() {
+        engine.process_key(&press(ch));
+    }
+    engine.process_key(&press_key(Keysym::SPACE));
+
+    let candidates = engine.candidates().expect("conversion candidates");
+    let texts: Vec<&str> = candidates
+        .candidates()
+        .iter()
+        .map(|c| c.text.as_str())
+        .collect();
+    assert!(texts.contains(&"早稲田"), "早稲田 selectable: {texts:?}");
+    assert!(!texts.contains(&"ワセリン"), "ワセリン excluded: {texts:?}");
+
+    let waseda = candidates
+        .candidates()
+        .iter()
+        .find(|c| c.text == "早稲田")
+        .unwrap();
+    assert_eq!(waseda.reading.as_deref(), Some("わせだ"));
 }

--- a/karukan-im/src/core/engine/tests/rewriter.rs
+++ b/karukan-im/src/core/engine/tests/rewriter.rs
@@ -27,7 +27,7 @@ fn composing_engine(reading: &str) -> InputMethodEngine {
 fn conversion_texts(reading: &str) -> Vec<String> {
     let mut engine = composing_engine(reading);
     engine
-        .build_conversion_candidates(reading, 9, false)
+        .build_conversion_candidates(reading, reading, "", 9, false)
         .into_iter()
         .map(|c| c.text)
         .collect()
@@ -134,7 +134,7 @@ fn rewriter_does_not_expand_dictionary_candidates() {
     engine.dicts.user = Some(user_dict_with("てすと", ","));
 
     let texts: Vec<String> = engine
-        .build_conversion_candidates("てすと", 9, false)
+        .build_conversion_candidates("てすと", "てすと", "", 9, false)
         .into_iter()
         .map(|c| c.text)
         .collect();
@@ -151,7 +151,7 @@ fn rewriter_candidates_only_derive_from_user_input() {
     // rewrite of the typed reading. Guards against future regressions where
     // somebody re-introduces rewriting over dictionary/model/fallback entries.
     let mut engine = composing_engine("あ");
-    let candidates = engine.build_conversion_candidates("あ", 9, false);
+    let candidates = engine.build_conversion_candidates("あ", "あ", "", 9, false);
 
     let allowed: HashSet<String> = RewriterChain::default_chain()
         .rewrite_all(&["あ".to_string()])
@@ -187,7 +187,7 @@ fn alphabet_input_emits_width_and_case_variants() {
 #[test]
 fn alphabet_variants_carry_width_case_descriptions() {
     let mut engine = composing_engine("abc");
-    let candidates = engine.build_conversion_candidates("abc", 9, false);
+    let candidates = engine.build_conversion_candidates("abc", "abc", "", 9, false);
     let upper = candidates.iter().find(|c| c.text == "ABC").unwrap();
     let full_lower = candidates.iter().find(|c| c.text == "ａｂｃ").unwrap();
     let full_upper = candidates.iter().find(|c| c.text == "ＡＢＣ").unwrap();
@@ -231,7 +231,7 @@ fn typed_symbol_itself_is_annotated_via_global_lookup() {
     // (not from the rewriter). The post-pass enrichment should still attach
     // mozc's description "始めかぎ括弧" because `「` is a known symbol.
     let mut engine = composing_engine("「");
-    let candidates = engine.build_conversion_candidates("「", 9, false);
+    let candidates = engine.build_conversion_candidates("「", "「", "", 9, false);
 
     let kagi = candidates.iter().find(|c| c.text == "「").unwrap();
     assert_eq!(
@@ -257,7 +257,7 @@ fn katakana_variants_carry_width_form_description() {
     // half-width katakana → `[半]カタカナ`. The hiragana fallback also picks
     // up `[全]ひらがな` since hiragana is intrinsically full-width.
     let mut engine = composing_engine("あ");
-    let candidates = engine.build_conversion_candidates("あ", 9, false);
+    let candidates = engine.build_conversion_candidates("あ", "あ", "", 9, false);
 
     let hira = candidates.iter().find(|c| c.text == "あ").unwrap();
     assert_eq!(

--- a/karukan-im/src/core/state.rs
+++ b/karukan-im/src/core/state.rs
@@ -24,6 +24,8 @@ pub enum InputState {
         preedit: Preedit,
         /// List of conversion candidates
         candidates: CandidateList,
+        /// The (settled) reading the conversion was built from
+        reading: String,
     },
 }
 


### PR DESCRIPTION
## 問題

「けいおうd」まで打って Tab（または Space）で変換に入り、Escape で戻ってから「a」を打つと、「けいおうだ」ではなく **「けいおうdあ」** になる。

原因は `start_conversion` の `settle_romaji()` が pending の `d` を `Converted('d')` に**破壊的に確定**し、Escape の復帰も「確定済み読み文字列からの再構築」だったため、`d` が二度と結合できなくなっていたこと。

## 修正

**変換開始時に合成（要素配列）を一切変更しない**：

- 読みは非破壊の `InputBuffer::settled_reading()`（`settle_romaji` の参照版）で算出
- 変換の基となった読みは `InputState::Conversion` に保存（学習履歴削除の再構築パスが使用。候補ナビゲーション・コミットは元々候補自身が reading を持つため影響なし）
- Escape は**元の合成にそのまま戻る** — pending が生きたままなので `a` で だ に結合する。カーソル位置も保存される
- 候補ゼロで Composing に留まる分岐（絵文字不一致）も合成を触らない形に簡素化

## テスト

`けいおうd` → Space→Esc→`a` / Tab→Esc→`a` の両方で「けいおうだ」になることをシナリオテーブルに追加。全473テストグリーン、clippy クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)