### PR TITLE
refactor: live.textを廃止しchunksからの導出に一本化

### DIFF
--- a/karukan-im/core/src/core/engine/conversion.rs
+++ b/karukan-im/core/src/core/engine/conversion.rs
@@ -244,7 +244,7 @@ impl InputMethodEngine {
         // This ensures the candidate that was displayed during input is preserved
         // in the conversion candidate list even if the re-inference uses a different strategy.
         let prev_suggest_text = self.live_text_with_pending();
-        self.live.text.clear();
+        self.live.shown = false;
 
         if reading.is_empty() {
             return EngineResult::consumed();

--- a/karukan-im/core/src/core/engine/cursor.rs
+++ b/karukan-im/core/src/core/engine/cursor.rs
@@ -12,7 +12,7 @@ impl InputMethodEngine {
         if self.mode.current() == InputMode::Alphabet {
             self.mode.exit_temporary();
         }
-        self.live.text.clear();
+        self.live.shown = false;
         self.input_buf.set_cursor(new_pos(&self.input_buf));
         self.log_chunk_state("cursor");
         let preedit = self.set_composing_state();

--- a/karukan-im/core/src/core/engine/display.rs
+++ b/karukan-im/core/src/core/engine/display.rs
@@ -24,18 +24,30 @@ impl InputMethodEngine {
         self.input_buf.cursor()
     }
 
+    /// The current live-conversion text: the concatenated converted text of
+    /// the chunks while the live display is shown, empty otherwise. Derived
+    /// on demand — the string is never stored, so it cannot go stale against
+    /// the chunks.
+    pub(super) fn live_text(&self) -> String {
+        if !self.live.shown {
+            return String::new();
+        }
+        self.chunks.iter().map(|c| c.converted.as_str()).collect()
+    }
+
     /// Build a preedit for composing state.
-    /// If live conversion text is present, shows live_text + pending romaji
+    /// If live conversion text is present, shows live text + pending romaji
     /// with caret at end. That layout is only faithful while typing at the
     /// end of the composition — when the cursor is elsewhere the pending is
     /// not the visual tail, so fall back to the kana display.
     /// Otherwise shows the input buffer display with cursor-based caret.
     pub(super) fn build_composing_preedit(&self) -> Preedit {
+        let live = self.live_text();
         let live_at_end =
-            !self.live.text.is_empty() && self.input_buf.cursor() == self.input_buf.char_count();
+            !live.is_empty() && self.input_buf.cursor() == self.input_buf.char_count();
         let (display, caret) = if live_at_end {
             let buffer = self.input_buf.pending();
-            let display = format!("{}{}", self.live.text, buffer);
+            let display = format!("{}{}", live, buffer);
             let caret = display.chars().count();
             (display, caret)
         } else {
@@ -46,24 +58,21 @@ impl InputMethodEngine {
         preedit
     }
 
-    /// The live conversion result as displayed: `live.text` plus the settled
+    /// The live conversion result as displayed: the live text plus the settled
     /// pending romaji tail (早稲田 + d → 早稲田d). Committing or preserving
-    /// `live.text` alone would drop the tail, since the live suggestion only
+    /// the live text alone would drop the tail, since the live suggestion only
     /// covers the settled reading. Empty when live conversion has no result
     /// or the cursor is away from the end — there the display already fell
     /// back to kana (see `build_composing_preedit`) and the pending run sits
     /// mid-buffer, so the concatenation would not match what is shown.
     /// Must be called before `settle_romaji` (which empties the pending run).
     pub(super) fn live_text_with_pending(&self) -> String {
-        if self.live.text.is_empty() || self.input_buf.cursor() != self.input_buf.char_count() {
+        let live = self.live_text();
+        if live.is_empty() || self.input_buf.cursor() != self.input_buf.char_count() {
             return String::new();
         }
         let pending = self.input_buf.pending();
-        format!(
-            "{}{}",
-            self.live.text,
-            self.converters.romaji.convert_flush(&pending)
-        )
+        format!("{}{}", live, self.converters.romaji.convert_flush(&pending))
     }
 
     /// Format an `lctx: … rctx: …` line from explicit left/right context

--- a/karukan-im/core/src/core/engine/input.rs
+++ b/karukan-im/core/src/core/engine/input.rs
@@ -21,7 +21,7 @@ impl InputMethodEngine {
         // (When the buffer still contains kana we fall through and reconvert below,
         // so a mixed reading like `きょうはABC` keeps live-converting.)
         if self.mode.current() == InputMode::Alphabet
-            && !self.live.text.is_empty()
+            && !self.live_text().is_empty()
             && !karukan_engine::contains_kana(&full_reading)
         {
             let preedit = self.set_composing_state();
@@ -51,7 +51,7 @@ impl InputMethodEngine {
             // No useful AI suggestion — still show learning + dictionary + rule-based
             // rewriter variants. The rewriter path produces mozc-style symbol variants
             // (e.g. `「` → `『`, `【`, ...) for symbol-only inputs where the model is skipped.
-            self.live.text.clear();
+            self.live.shown = false;
             let preedit = self.set_composing_state();
             let reading = full_reading;
             let mut all_candidates = self.lookup_learning_candidates(&reading);
@@ -71,14 +71,17 @@ impl InputMethodEngine {
                 .with_action(EngineAction::UpdateAuxText(self.format_aux_composing()));
         };
 
-        // Live conversion mode: show converted text in preedit
+        // Live conversion mode: show converted text in preedit. The displayed
+        // text is derived from the chunks (`live_text`), which
+        // `chunked_auto_suggest` just rebuilt — candidates[0] is that same
+        // concatenation.
         if self.live.enabled && self.mode.current() != InputMode::Katakana {
-            self.live.text = candidates[0].clone();
+            self.live.shown = true;
             return self.suggest_result(candidates, &reading);
         }
 
         // Normal auto-suggest: show hiragana preedit
-        self.live.text.clear();
+        self.live.shown = false;
         self.suggest_result(candidates, &reading)
     }
 
@@ -282,7 +285,7 @@ impl InputMethodEngine {
                         // commit/cancel, so the next word returns to the
                         // prior mode (issue #37).
                         self.mode.enter_temporary(InputMode::Alphabet);
-                        self.live.text.clear();
+                        self.live.shown = false;
                     }
                     let ch = if self.mode.current() == InputMode::Alphabet && is_shift_alpha {
                         ch.to_ascii_uppercase()
@@ -304,7 +307,7 @@ impl InputMethodEngine {
     /// the moment they press `:`.
     pub(super) fn start_emoji_mode(&mut self) -> EngineResult {
         self.input_buf.clear();
-        self.live.text.clear();
+        self.live.shown = false;
         // Remember where the user was so commit/cancel/erase-to-empty
         // can drop them back into the same mode (e.g. Katakana stays
         // Katakana). ModeState guards against clobbering the saved mode
@@ -377,7 +380,7 @@ impl InputMethodEngine {
         if text.is_empty() {
             self.state = InputState::Empty;
             self.input_buf.clear();
-            self.live.text.clear();
+            self.live.shown = false;
             self.chunks.clear();
             return EngineResult::consumed()
                 .with_action(EngineAction::HideCandidates)
@@ -393,7 +396,7 @@ impl InputMethodEngine {
         }
 
         self.input_buf.clear();
-        self.live.text.clear();
+        self.live.shown = false;
         self.chunks.clear();
         self.state = InputState::Empty;
         // Temporary modes (Emoji, Alphabet) end with the composition:
@@ -416,8 +419,8 @@ impl InputMethodEngine {
     /// second Escape cancels input entirely.
     pub(super) fn cancel_composing(&mut self) -> EngineResult {
         // If live conversion is active, first Escape returns to hiragana display
-        if !self.live.text.is_empty() {
-            self.live.text.clear();
+        if !self.live_text().is_empty() {
+            self.live.shown = false;
             let preedit = self.set_composing_state();
             return EngineResult::consumed()
                 .with_action(EngineAction::UpdatePreedit(preedit))
@@ -438,7 +441,7 @@ impl InputMethodEngine {
         };
 
         self.input_buf.clear();
-        self.live.text.clear();
+        self.live.shown = false;
         self.chunks.clear();
         self.state = InputState::Empty;
         // Temporary modes (Emoji, Alphabet) are per-session: cancelling

--- a/karukan-im/core/src/core/engine/mod.rs
+++ b/karukan-im/core/src/core/engine/mod.rs
@@ -233,7 +233,7 @@ impl InputMethodEngine {
         self.state = InputState::Empty;
         self.mode = ModeState::default();
         self.input_buf.clear();
-        self.live.text.clear();
+        self.live.shown = false;
         self.chunks.clear();
         self.metrics = ConversionMetrics::default();
     }
@@ -245,10 +245,9 @@ impl InputMethodEngine {
             self.state = InputState::Empty;
             self.input_buf.clear();
             // Erasing the whole buffer ends the composition: drop the live
-            // conversion text and the chunks so neither leaks into the next
-            // composing session (build_composing_preedit would otherwise
-            // render a stale live.text).
-            self.live.text.clear();
+            // display and the chunks so neither leaks into the next
+            // composing session.
+            self.live.shown = false;
             self.chunks.clear();
             // Temporary modes (Emoji, Alphabet) are per-composition:
             // erasing back to an empty buffer ends the session, so restore
@@ -268,7 +267,7 @@ impl InputMethodEngine {
     }
 
     /// Update state to Composing with the current preedit, returning it.
-    /// Automatically uses live conversion display when `live.text` is non-empty.
+    /// Automatically uses live conversion display when `live_text()` is non-empty.
     fn set_composing_state(&mut self) -> Preedit {
         let preedit = self.build_composing_preedit();
         self.state = InputState::Composing {
@@ -475,7 +474,7 @@ impl InputMethodEngine {
                 // Record live conversion result in learning cache
                 self.record_learning(&reading, &text);
                 self.input_buf.clear();
-                self.live.text.clear();
+                self.live.shown = false;
                 self.state = InputState::Empty;
                 self.surrounding_context = None;
                 text

--- a/karukan-im/core/src/core/engine/mode.rs
+++ b/karukan-im/core/src/core/engine/mode.rs
@@ -15,8 +15,8 @@ impl InputMethodEngine {
         }
 
         self.mode.set(InputMode::Katakana);
-        // Clear live conversion text so katakana mode takes priority on commit
-        self.live.text.clear();
+        // Drop the live display so katakana mode takes priority on commit
+        self.live.shown = false;
 
         if self.input_buf.is_empty() {
             return EngineResult::consumed();
@@ -52,8 +52,8 @@ impl InputMethodEngine {
                 result.actions.push(aux);
                 return result;
             }
-            if !self.live.text.is_empty() {
-                self.live.text.clear();
+            if self.live.shown {
+                self.live.shown = false;
                 let preedit = self.set_composing_state();
                 return EngineResult::consumed()
                     .with_action(EngineAction::UpdatePreedit(preedit))

--- a/karukan-im/core/src/core/engine/tests/candidates.rs
+++ b/karukan-im/core/src/core/engine/tests/candidates.rs
@@ -11,7 +11,7 @@ fn test_live_text_preserved_in_conversion_via_down() {
     // Simulate typing "あい" with live conversion active
     engine.process_key(&press('a'));
     engine.process_key(&press('i'));
-    engine.live.text = "愛".to_string();
+    set_live_text(&mut engine, "愛");
 
     // Press DOWN → start_conversion()
     let result = engine.process_key(&press_key(Keysym::DOWN));
@@ -34,7 +34,7 @@ fn test_live_text_not_duplicated_in_conversion() {
     engine.process_key(&press('a'));
     engine.process_key(&press('i'));
     // live_conversion_text same as hiragana reading → should not be added
-    engine.live.text = "あい".to_string();
+    set_live_text(&mut engine, "あい");
 
     let result = engine.process_key(&press_key(Keysym::DOWN));
     assert!(result.consumed);
@@ -60,7 +60,7 @@ fn test_suggest_result_preserved_in_start_conversion() {
 
     engine.process_key(&press('a'));
     engine.process_key(&press('i'));
-    engine.live.text = "愛".to_string();
+    set_live_text(&mut engine, "愛");
 
     // Press Space → start_conversion()
     let result = engine.process_key(&press_key(Keysym::SPACE));
@@ -83,7 +83,7 @@ fn test_empty_live_text_not_added_to_candidates() {
     engine.process_key(&press('a'));
     engine.process_key(&press('i'));
     // Force empty to test the "no live text" scenario
-    engine.live.text.clear();
+    engine.live.shown = false;
 
     // DOWN → start_conversion()
     let result = engine.process_key(&press_key(Keysym::DOWN));

--- a/karukan-im/core/src/core/engine/tests/chunks.rs
+++ b/karukan-im/core/src/core/engine/tests/chunks.rs
@@ -267,7 +267,7 @@ fn test_delete_all_chars_clears_chunks() {
     assert!(matches!(engine.state(), InputState::Empty));
     assert_eq!(engine.input_buf.reading(), "");
     assert!(engine.chunks.is_empty(), "chunk cache must be cleared");
-    assert!(engine.live.text.is_empty(), "live text must be cleared");
+    assert!(engine.live_text().is_empty(), "live text must be cleared");
 }
 
 /// Type `あいうえおか` (6 hiragana chars) via romaji.

--- a/karukan-im/core/src/core/engine/tests/live_conversion.rs
+++ b/karukan-im/core/src/core/engine/tests/live_conversion.rs
@@ -25,7 +25,7 @@ fn test_live_conversion_off_unchanged() {
     engine.process_key(&press('i'));
     assert_eq!(engine.preedit().unwrap().text(), "あい");
     // live_conversion_text should be empty
-    assert!(engine.live.text.is_empty());
+    assert!(engine.live_text().is_empty());
 }
 
 #[test]
@@ -38,12 +38,12 @@ fn test_live_conversion_escape_shows_hiragana() {
     engine.process_key(&press('i'));
 
     // Simulate live conversion being active
-    engine.live.text = "愛".to_string();
+    set_live_text(&mut engine, "愛");
 
     // Press Escape -> should clear live_conversion_text and show hiragana
     let result = engine.process_key(&press_key(Keysym::ESCAPE));
     assert!(result.consumed);
-    assert!(engine.live.text.is_empty());
+    assert!(engine.live_text().is_empty());
     assert!(matches!(engine.state(), InputState::Composing { .. }));
     assert_eq!(engine.preedit().unwrap().text(), "あい");
 }
@@ -57,12 +57,12 @@ fn test_live_conversion_escape_twice_cancels() {
     engine.process_key(&press('i'));
 
     // Set live conversion text
-    engine.live.text = "愛".to_string();
+    set_live_text(&mut engine, "愛");
 
     // First Escape: clears live conversion, shows hiragana
     engine.process_key(&press_key(Keysym::ESCAPE));
     assert!(matches!(engine.state(), InputState::Composing { .. }));
-    assert!(engine.live.text.is_empty());
+    assert!(engine.live_text().is_empty());
 
     // Second Escape: cancels input entirely
     engine.process_key(&press_key(Keysym::ESCAPE));
@@ -78,7 +78,7 @@ fn test_live_conversion_commit_with_converted_text() {
     engine.process_key(&press('i'));
 
     // Simulate live conversion
-    engine.live.text = "愛".to_string();
+    set_live_text(&mut engine, "愛");
 
     // Press Enter -> should commit "愛", not "あい"
     let result = engine.process_key(&press_key(Keysym::RETURN));
@@ -97,7 +97,7 @@ fn test_live_conversion_commit_with_converted_text() {
         .unwrap();
     assert_eq!(commit_text, "愛");
     assert!(matches!(engine.state(), InputState::Empty));
-    assert!(engine.live.text.is_empty());
+    assert!(engine.live_text().is_empty());
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn test_commit_composing_hides_candidate_window() {
 
     engine.process_key(&press('a'));
     engine.process_key(&press('i'));
-    engine.live.text = "愛".to_string();
+    set_live_text(&mut engine, "愛");
 
     let result = engine.process_key(&press_key(Keysym::RETURN));
     assert!(result.consumed);
@@ -129,7 +129,7 @@ fn test_live_conversion_commit_empty_falls_back_to_hiragana() {
     let mut engine = make_live_conversion_engine();
 
     engine.process_key(&press('a'));
-    assert!(engine.live.text.is_empty());
+    assert!(engine.live_text().is_empty());
 
     let result = engine.process_key(&press_key(Keysym::RETURN));
     let commit_text = result
@@ -154,7 +154,7 @@ fn test_live_conversion_commit_keeps_pending_tail() {
     for ch in "wasedad".chars() {
         engine.process_key(&press(ch));
     }
-    engine.live.text = "早稲田".to_string();
+    set_live_text(&mut engine, "早稲田");
 
     let result = engine.process_key(&press_key(Keysym::RETURN));
     let commit_text = result
@@ -179,7 +179,7 @@ fn test_engine_commit_keeps_pending_tail() {
     for ch in "wasedad".chars() {
         engine.process_key(&press(ch));
     }
-    engine.live.text = "早稲田".to_string();
+    set_live_text(&mut engine, "早稲田");
 
     assert_eq!(engine.commit(), "早稲田d");
 }
@@ -194,7 +194,7 @@ fn test_conversion_keeps_pending_tail_of_live_candidate() {
     for ch in "wasedad".chars() {
         engine.process_key(&press(ch));
     }
-    engine.live.text = "早稲田".to_string();
+    set_live_text(&mut engine, "早稲田");
 
     engine.process_key(&press_key(Keysym::SPACE));
     assert!(matches!(engine.state(), InputState::Conversion { .. }));
@@ -226,7 +226,7 @@ fn test_commit_mid_buffer_ignores_live_text() {
     engine.process_key(&press_key(Keysym::LEFT));
     engine.process_key(&press('d'));
     assert_eq!(engine.preedit().unwrap().text(), "あdい");
-    engine.live.text = "愛".to_string();
+    set_live_text(&mut engine, "愛");
 
     let result = engine.process_key(&press_key(Keysym::RETURN));
     let commit_text = result
@@ -250,11 +250,11 @@ fn test_live_conversion_cursor_move_clears() {
 
     engine.process_key(&press('a'));
     engine.process_key(&press('i'));
-    engine.live.text = "愛".to_string();
+    set_live_text(&mut engine, "愛");
 
     // Left arrow clears live conversion
     engine.process_key(&press_key(Keysym::LEFT));
-    assert!(engine.live.text.is_empty());
+    assert!(engine.live_text().is_empty());
 }
 
 #[test]
@@ -262,7 +262,7 @@ fn test_live_conversion_build_preedit() {
     // Test build_composing_preedit constructs correct display for live conversion
     let mut engine = make_live_conversion_engine();
 
-    engine.live.text = "漢字".to_string();
+    set_live_text(&mut engine, "漢字");
 
     let preedit = engine.build_composing_preedit();
     assert_eq!(preedit.text(), "漢字");
@@ -284,7 +284,7 @@ fn test_alphabet_mode_with_kana_keeps_converting() {
     assert!(karukan_engine::contains_kana(&engine.input_buf.reading()));
 
     // Simulate a previous live conversion result lingering on screen.
-    engine.live.text = "亜A".to_string();
+    set_live_text(&mut engine, "亜A");
 
     // Typing another latin char re-runs refresh_input_state. Because the buffer
     // still has kana, the "preserve display" early-return is bypassed and
@@ -292,7 +292,7 @@ fn test_alphabet_mode_with_kana_keeps_converting() {
     // reading itself, so live.text is cleared rather than frozen.
     engine.process_key(&press('b'));
     assert!(
-        engine.live.text.is_empty(),
+        engine.live_text().is_empty(),
         "mixed kana buffer must reconvert in alphabet mode, not preserve stale live.text"
     );
 }
@@ -310,11 +310,11 @@ fn test_alphabet_mode_pure_latin_preserves_live_text() {
     assert!(engine.mode.current() == InputMode::Alphabet);
     assert!(!karukan_engine::contains_kana(&engine.input_buf.reading()));
 
-    engine.live.text = "AB".to_string();
+    set_live_text(&mut engine, "AB");
 
     // Another latin char keeps the preserved live.text (no reconversion).
     engine.process_key(&press('c'));
-    assert_eq!(engine.live.text, "AB");
+    assert_eq!(engine.live_text(), "AB");
 }
 
 // --- Ctrl+Space full-width space tests ---
@@ -431,12 +431,12 @@ fn test_toggle_off_during_composing_clears_live_text() {
     let mut engine = make_live_conversion_engine();
     engine.process_key(&press('a'));
     engine.process_key(&press('i'));
-    engine.live.text = "愛".to_string();
+    set_live_text(&mut engine, "愛");
 
     let result = engine.process_key(&press_ctrl_shift(Keysym::KEY_L_UPPER));
     assert!(result.consumed);
     assert!(!engine.live.enabled);
-    assert!(engine.live.text.is_empty());
+    assert!(engine.live_text().is_empty());
 
     let preedit_text = result.actions.iter().find_map(|a| {
         if let EngineAction::UpdatePreedit(p) = a {

--- a/karukan-im/core/src/core/engine/tests/mod.rs
+++ b/karukan-im/core/src/core/engine/tests/mod.rs
@@ -77,3 +77,15 @@ fn make_live_conversion_engine() -> InputMethodEngine {
     engine.live.enabled = true;
     engine
 }
+
+/// Simulate an active live-conversion display: install `converted` as the
+/// single chunk covering the current reading and mark the display shown.
+/// The live text is derived from the chunks, so this is the test analogue
+/// of a completed `chunked_auto_suggest`.
+fn set_live_text(engine: &mut InputMethodEngine, converted: &str) {
+    engine.chunks = vec![ComposingChunk {
+        reading: engine.input_buf.reading(),
+        converted: converted.to_string(),
+    }];
+    engine.live.shown = true;
+}

--- a/karukan-im/core/src/core/engine/types.rs
+++ b/karukan-im/core/src/core/engine/types.rs
@@ -267,20 +267,24 @@ pub(in crate::core) struct ComposingChunk {
     pub converted: String,
 }
 
-/// Live conversion state: enabled flag and current converted text
+/// Live conversion state. The displayed text itself is not stored: it is
+/// derived from the current chunks (`live_text`), so it can never go stale
+/// against them.
 #[derive(Debug, Clone, Default)]
 pub(in crate::core) struct LiveConversion {
     /// Whether live conversion is enabled (toggled via Ctrl+Shift+L)
     pub enabled: bool,
-    /// Converted text (non-empty when live conversion produced a result)
-    pub text: String,
+    /// Whether the live suggestion is currently shown in the preedit.
+    /// Cleared by gestures that fall back to the kana display (cursor moves,
+    /// first Escape, mode switches) without discarding the chunks.
+    pub shown: bool,
 }
 
 impl LiveConversion {
     pub fn new(enabled: bool) -> Self {
         Self {
             enabled,
-            text: String::new(),
+            shown: false,
         }
     }
 }


### PR DESCRIPTION
## 概要

PR #85 の上に積むリファクタリングです(base: `feature/live-conversion-cache`)。

ライブ変換の表示テキストを `LiveConversion.text: String` として二重管理するのをやめ、次の2つに分解しました。

- `LiveConversion.shown: bool` — ライブ表示が現在プリエディットに出ているか
- `live_text()` — 表示テキスト本体。`chunks` の `converted` 連結から毎回導出

## 動機

`live.text` は実質 `chunks` の連結と同じ情報で、`reset` / `commit` / `cancel` / カーソル移動 / モード切替など約15箇所で手動 `.clear()` が必要でした。PR #85 でチャンクがテキストの純関数として毎回再構築されるようになったため、導出が常に正しくなり、文字列の消し忘れで stale なプリエディットが漏れるバグの余地をクラスごと消せます。

## 設計メモ

- カーソル移動・初回 Escape・カタカナ/アルファベットモード切替は「chunks は残したまま表示だけかな表示に戻す」操作なので、`shown = false` がそれを表現します(旧実装で text だけ clear して chunks を残していた箇所と対応)
- 合成終了サイト(commit/cancel/reset)は `chunks.clear()` が導出テキストも空にするため、`shown = false` は保険的な整理です
- テストの `engine.live.text = "愛"` 直接代入は、`set_live_text` ヘルパー(chunks + shown を設定)に置き換えました

## テスト

- `cargo test -p karukan-im`: 252 passed
- `cargo test -p karukan-fcitx5`: 22 passed
- `cargo clippy --workspace` / `cargo fmt --all`: クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGiWREi2uh5NJ9ZNPEjRYn