### PR TITLE
fix: バイトフォールバックトークンがspecial扱いで捨てられ語彙外文字（Ψなど）が消える問題を修正

### DIFF
--- a/karukan-engine/src/kanji/llamacpp.rs
+++ b/karukan-engine/src/kanji/llamacpp.rs
@@ -14,6 +14,7 @@ use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
+use std::collections::HashSet;
 use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::OnceLock;
@@ -41,6 +42,24 @@ fn bytes_to_hex_display(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("<{:02X}>", b)).collect()
 }
 
+/// Whether an added-token string is a byte-fallback token like `<0xCE>`.
+///
+/// SentencePiece-derived tokenizer.json files mark the 256 byte-fallback
+/// tokens as `special: true`, but they carry real output bytes (a character
+/// outside the vocab is emitted as its UTF-8 bytes, e.g. `Ψ` as
+/// `<0xCE><0xA8>`), so they must never be skipped as special tokens.
+///
+/// This must classify exactly the tokens the tokenizer's `ByteFallback`
+/// decoder consumes, so the check below is a verbatim mirror of that
+/// decoder's own match
+/// (`tokenizers::decoders::byte_fallback::ByteFallback::decode_chain`).
+fn is_byte_fallback_token(token: &str) -> bool {
+    token.len() == 6
+        && token.starts_with("<0x")
+        && token.ends_with('>')
+        && u8::from_str_radix(&token[3..5], 16).is_ok()
+}
+
 /// Load and configure an external HuggingFace tokenizer from a `tokenizer.json` file.
 fn load_tokenizer<P: AsRef<Path>>(path: P) -> Result<tokenizers::Tokenizer> {
     let mut tokenizer =
@@ -66,6 +85,10 @@ pub struct LlamaCppModel {
     /// External HuggingFace tokenizer (always required).
     /// `tokenize()` and `decode()` use this instead of llama.cpp's built-in tokenizer.
     external_tokenizer: tokenizers::Tokenizer,
+    /// Token ids `decode(_, skip_special_tokens=true)` removes before
+    /// detokenizing: added tokens with `special: true`, minus the
+    /// byte-fallback tokens (see [`is_byte_fallback_token`]).
+    special_token_ids: HashSet<u32>,
     /// Number of threads for inference (0 = use llama.cpp default)
     n_threads: u32,
 }
@@ -150,11 +173,18 @@ impl LlamaCppModel {
     /// Load the external tokenizer and construct the model wrapper.
     fn finish<T: AsRef<Path>>(model: LlamaModel, tokenizer_json: T, n_ctx: u32) -> Result<Self> {
         let external_tokenizer = load_tokenizer(tokenizer_json)?;
+        let special_token_ids = external_tokenizer
+            .get_added_tokens_decoder()
+            .into_iter()
+            .filter(|(_, tok)| tok.special && !is_byte_fallback_token(&tok.content))
+            .map(|(id, _)| id)
+            .collect();
 
         Ok(Self {
             model,
             n_ctx,
             external_tokenizer,
+            special_token_ids,
             n_threads: 0,
         })
     }
@@ -196,12 +226,20 @@ impl LlamaCppModel {
     /// Decode tokens to string using the external tokenizer
     ///
     /// When `skip_special_tokens` is true, special tokens (BOS, EOS, EOG) are
-    /// excluded from the output.
+    /// excluded from the output. The filtering is done here by token id
+    /// rather than delegated to the tokenizer: tokenizer.json marks the
+    /// byte-fallback tokens (`<0xCE>` …) as special, so the tokenizer's own
+    /// `skip_special_tokens` would drop them before its ByteFallback decoder
+    /// can fuse them back into characters (`Ψ` = `<0xCE><0xA8>` would vanish).
     pub fn decode(&self, tokens: &[LlamaToken], skip_special_tokens: bool) -> Result<String> {
-        let ids: Vec<u32> = tokens.iter().map(|t| t.0 as u32).collect();
+        let ids: Vec<u32> = tokens
+            .iter()
+            .map(|t| t.0 as u32)
+            .filter(|id| !(skip_special_tokens && self.special_token_ids.contains(id)))
+            .collect();
         let text = self
             .external_tokenizer
-            .decode(&ids, skip_special_tokens)
+            .decode(&ids, false)
             .map_err(KanjiError::Inference)?;
         Ok(text)
     }
@@ -801,5 +839,28 @@ mod missing_file_tests {
     fn missing_model_file_is_err_not_panic() {
         let result = LlamaCppModel::from_file("/nonexistent/model.gguf", "/nonexistent/tok.json");
         assert!(matches!(result, Err(KanjiError::ModelLoad(_))));
+    }
+}
+
+#[cfg(test)]
+mod byte_fallback_token_tests {
+    use super::is_byte_fallback_token;
+
+    #[test]
+    fn byte_fallback_tokens_are_recognized() {
+        assert!(is_byte_fallback_token("<0x00>"));
+        assert!(is_byte_fallback_token("<0xCE>"));
+        assert!(is_byte_fallback_token("<0xff>"));
+    }
+
+    #[test]
+    fn control_tokens_are_not_byte_fallback() {
+        assert!(!is_byte_fallback_token("<s>"));
+        assert!(!is_byte_fallback_token("</s>"));
+        assert!(!is_byte_fallback_token("<unk>"));
+        assert!(!is_byte_fallback_token("<pad>"));
+        assert!(!is_byte_fallback_token("<0xGG>"));
+        assert!(!is_byte_fallback_token("<0x123>"));
+        assert!(!is_byte_fallback_token("0xCE"));
     }
 }

--- a/karukan-engine/tests/kanji_conversion_tests.rs
+++ b/karukan-engine/tests/kanji_conversion_tests.rs
@@ -78,9 +78,9 @@ mod llamacpp_tests {
         let model = load_model().expect("Failed to load");
         let cases = [
             "斉木楠雄のΨ難", // Ψ: 2-byte fallback
-            "€100",           // €: 3-byte fallback
-            "🍣を食べる",     // 🍣: 4-byte fallback
-            "ΨとΩと🍣",       // multiple fallback runs in one string
+            "€100",          // €: 3-byte fallback
+            "🍣を食べる",    // 🍣: 4-byte fallback
+            "ΨとΩと🍣",      // multiple fallback runs in one string
         ];
         for text in cases {
             let tokens = model.tokenize(text).expect("Tokenize failed");

--- a/karukan-engine/tests/kanji_conversion_tests.rs
+++ b/karukan-engine/tests/kanji_conversion_tests.rs
@@ -69,6 +69,27 @@ mod llamacpp_tests {
     }
 
     #[test]
+    fn test_decode_keeps_byte_fallback_chars() {
+        // Characters outside the vocab tokenize to byte-fallback tokens, one
+        // <0xNN> token per UTF-8 byte (Ψ → <0xCE><0xA8>). tokenizer.json
+        // marks those as special, so a naive skip_special_tokens decode would
+        // drop them (「斉木楠雄のΨ難」→「斉木楠雄の難」). decode(_, true)
+        // must keep them, whatever the byte length of the character.
+        let model = load_model().expect("Failed to load");
+        let cases = [
+            "斉木楠雄のΨ難", // Ψ: 2-byte fallback
+            "€100",           // €: 3-byte fallback
+            "🍣を食べる",     // 🍣: 4-byte fallback
+            "ΨとΩと🍣",       // multiple fallback runs in one string
+        ];
+        for text in cases {
+            let tokens = model.tokenize(text).expect("Tokenize failed");
+            let decoded = model.decode(&tokens, true).expect("Decode failed");
+            assert_eq!(decoded, text);
+        }
+    }
+
+    #[test]
     fn test_generation() {
         let model = load_model().expect("Failed to load");
         let prompt = build_prompt("ワセダ");


### PR DESCRIPTION
## 問題

「サイキクスオノサイナン」を変換すると、モデルはビーム第1候補として正しく「斉木楠雄のΨ難」を生成しているのに、ユーザーには「斉木楠雄の難」が表示され、Ψが無言で消えていた。

Ψに限らず、vocabにない文字（€・絵文字・レア記号など）はすべて同じ経路で消えていた。

## 原因

- vocabにない文字はUTF-8バイト単位のバイトフォールバックトークンで表現される（Ψ = `<0xCE><0xA8>`）
- tokenizer.json（SentencePiece変換由来）はこの256個のバイトトークンを `special: true` として登録している
- `LlamaCppModel::decode` が `skip_special_tokens=true` をtokenizersクレートに委譲していたため、ByteFallbackデコーダがバイトを文字に復元する**前に**バイトトークンが捨てられていた

## 修正

specialトークンの除去を自前のIDフィルタに変更:

- モデルロード時に「`special: true` かつバイトフォールバックトークンでない」added_tokensのIDを `special_token_ids` として収集
- `decode(_, skip_special_tokens=true)` はそのIDだけをトークン列から除去し、tokenizersには常に `skip_special_tokens=false` で渡す（バイトトークンがByteFallbackデコーダまで届く）
- バイトトークン判定 `is_byte_fallback_token` は tokenizers の `ByteFallback::decode_chain` の判定条件を逐語的にミラー（`<0xNN>` 6文字 + 16進パース）

`decode` 内部の一箇所の修正なので、greedy・ビーム探索・ajimee-bench・server など全呼び出し箇所が一括で直る。

修正後の変換結果:

```
candidate[0] = "斉木楠雄のΨ難"
candidate[1] = "斎木楠雄の災難"
candidate[2] = "斎木楠雄のΨ難"
```

## テスト

- `test_decode_keeps_byte_fallback_chars`: Ψ（2バイト）・€（3バイト）・🍣（4バイト）・複数フォールバック混在のtokenize→decode往復回帰テスト
- `is_byte_fallback_token` のユニットテスト（`<0xCE>` は認識、`</s>`/`<0xGG>`/`<0x123>` は非認識）
- karukan-engine全テスト・karukan-im全テスト（252件）パス、clippy/fmtクリーン

## 補足（根本対応）

根本原因はモデル作成時（karukan-jinen側）のtokenizer.json出力がバイトフォールバックトークンに `special: true` を付けていること。jinen側でのエクスポート修正が本質的な対応だが、配布済みモデルとキャッシュ済みtokenizer.jsonには届かないため、本PRのRust側フィルタは修正後も互換対応として残す価値がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)