### PR TITLE
fix: モデルパスの解決をプロセス内で1回にして flaky テストを直す

### DIFF
--- a/karukan-engine/src/kanji/hf_download.rs
+++ b/karukan-engine/src/kanji/hf_download.rs
@@ -7,7 +7,24 @@ use super::error::KanjiError;
 use super::model_config::{ModelFamily, VariantConfig, registry};
 type Result<T> = super::error::Result<T>;
 use hf_hub::{HFClientSync, split_id};
+use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+/// Paths already resolved in this process, keyed by (repo, filename).
+///
+/// Resolving the same file twice is not free, and not even safe to do
+/// concurrently: unless the revision is a commit hash, hf-hub takes the
+/// network path on every call and rebuilds the snapshot symlink by removing
+/// it first, so the file briefly does not exist. A second thread that
+/// resolved the path just before can then be handed a path that vanishes
+/// under it — which is what made parallel test runs fail at random inside
+/// `LlamaModel::load_from_file`. Resolving once per process closes the
+/// window, and drops a HEAD request from every model load.
+fn resolved_paths() -> &'static Mutex<HashMap<(String, String), PathBuf>> {
+    static PATHS: OnceLock<Mutex<HashMap<(String, String), PathBuf>>> = OnceLock::new();
+    PATHS.get_or_init(Mutex::default)
+}
 
 /// Download a GGUF model from HuggingFace Hub
 ///
@@ -21,6 +38,15 @@ use std::path::PathBuf;
 /// # Environment Variables
 /// * `HF_TOKEN` - HuggingFace API token (required for private repositories)
 pub fn download_gguf(repo_id: &str, filename: &str) -> Result<PathBuf> {
+    let key = (repo_id.to_string(), filename.to_string());
+    // Held across the download so a second caller waits for the result
+    // instead of racing hf-hub for the same file. Only successes are
+    // remembered: a transient failure must not stick for the process.
+    let mut resolved = resolved_paths().lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(path) = resolved.get(&key) {
+        return Ok(path.clone());
+    }
+
     // HFClientSync::new() resolves HF_TOKEN (env var or cached login) itself
     let client = HFClientSync::new().map_err(|e| KanjiError::Download(e.into()))?;
 
@@ -37,6 +63,7 @@ pub fn download_gguf(repo_id: &str, filename: &str) -> Result<PathBuf> {
 
     tracing::info!("Downloaded to {:?}", path);
 
+    resolved.insert(key, path.clone());
     Ok(path)
 }
 


### PR DESCRIPTION
## 症状

`cargo test` の並列実行で、まれに**無関係なテストが1件だけ**落ちる。毎回別のテストで、再実行すると常に全緑。panic は llama-cpp-2 の `LlamaModel::load_from_file` の中で起きていた。

## 原因

llama.cpp のスレッド競合ではなく、**モデルファイルが一瞬消えていた**。

panic していたのは `load_from_file` 冒頭のこの行。

```rust
let path = path.as_ref();
debug_assert!(Path::new(path).exists(), "{path:?} does not exist");
```

消していたのは hf-hub。revision がコミットハッシュでない限り（karukan は revision を渡していないので `main`）、キャッシュ済みでも毎回ネットワーク経路に入り、スナップショットの symlink を作り直す。

```rust
// hf-hub cache/storage.rs create_pointer_symlink
let _ = std::fs::remove_file(&pointer);      // ← ここで一瞬 消える
std::os::unix::fs::symlink(&relative, &pointer)
```

別のスレッドが直前に解決したパスは、この瞬間だけ存在しない。並列テストでは多数のスレッドが同じモデルを解決するため、たまに踏む。

## 実証

8スレッドで同じモデルを解決しながら、別スレッドでパスの存在を監視した（使い捨てのサンプルで実行し、確認後に削除）。

| | パスが消えた回数 |
|---|---|
| 修正前 | 1,175,049回中 **2,124回** |
| 修正後 | 428回中 **0回** |

修正後のポーリング回数が激減しているのは、40回の解決が全部即時に返るようになった（HEAD リクエストが消えた）ため。

## 修正

解決済みのパスを `(repo, filename)` で覚えて、hf-hub をプロセス内で1回しか呼ばないようにした。ロックはダウンロードをまたいで保持するので、2つ目の呼び出しは hf-hub を取り合わずに結果を待つ。成功した解決だけを覚えるため、一時的な失敗がプロセス内に居座ることはない。

窓が消えるだけでなく、モデルのロードごとに走っていた HuggingFace への HEAD リクエストもなくなる。

## テスト

- `cargo test --workspace` 全通過（559件）、`cargo clippy --workspace --all-targets -- -D warnings` 警告なし
- 回帰テストは付けていない。消えている窓が狭く、テスト自体が確率的にしか失敗しないため

🤖 Generated with [Claude Code](https://claude.com/claude-code)