### PR TITLE
build: リリースプロファイルを thin LTO にして再ビルドを2.6倍速くする

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,4 @@ karukan-im = { path = "karukan-im/core" }
 tempfile = "3"
 
 [profile.release]
-lto = true
-codegen-units = 1
+lto = "thin"

--- a/karukan-im/fcitx5/README.md
+++ b/karukan-im/fcitx5/README.md
@@ -36,10 +36,12 @@ sudo cmake --install build
 fcitx5 -r
 ```
 
-> [!TIP]
-> ビルドしたマシンでしか使わないなら、ビルド前に `export RUSTFLAGS="-C target-cpu=native"` を
-> 設定するとCPU固有の命令が有効になり、変換が約5%速くなります(AJIMEE-Bench 200問で実測)。
-> 他のCPUでは動かないバイナリになるため、配布する場合は設定しないでください。
+> [!NOTE]
+> 既定でビルドマシンのCPU固有命令を使ってビルドします(`-C target-cpu=native`、変換が約5%速くなります)。
+> ビルドしたマシンでしか動かないバイナリになるため、配布用にビルドする場合は
+> `cmake -B build -DKARUKAN_NATIVE=OFF ...` を指定してください。自前の `RUSTFLAGS` を
+> 設定している場合はそちらが優先されます。手元で `cargo build --release` を直接叩くと
+> フラグの差でリビルドが走る点だけ注意してください。
 
 ### Build & Install (ユーザーローカル)
 

--- a/karukan-im/fcitx5/README.md
+++ b/karukan-im/fcitx5/README.md
@@ -36,6 +36,11 @@ sudo cmake --install build
 fcitx5 -r
 ```
 
+> [!TIP]
+> ビルドしたマシンでしか使わないなら、ビルド前に `export RUSTFLAGS="-C target-cpu=native"` を
+> 設定するとCPU固有の命令が有効になり、変換が約5%速くなります(AJIMEE-Bench 200問で実測)。
+> 他のCPUでは動かないバイナリになるため、配布する場合は設定しないでください。
+
 ### Build & Install (ユーザーローカル)
 
 `~/.local` にインストールします。sudo 不要ですが、`FCITX_ADDON_DIRS` の手動設定が必要です。

--- a/karukan-im/fcitx5/fcitx5-addon/CMakeLists.txt
+++ b/karukan-im/fcitx5/fcitx5-addon/CMakeLists.txt
@@ -28,8 +28,18 @@ set(KARUKAN_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
 # Build Rust library as a custom target
 find_program(CARGO cargo REQUIRED)
+
+# The addon is normally built on the machine it runs on, so optimize for its
+# CPU by default (measured ~5% faster conversion). Turn OFF when building a
+# binary for distribution; an externally set RUSTFLAGS always wins.
+option(KARUKAN_NATIVE "Optimize for the build machine's CPU (-C target-cpu=native)" ON)
+set(KARUKAN_CARGO_ENV "")
+if(KARUKAN_NATIVE AND NOT DEFINED ENV{RUSTFLAGS})
+    set(KARUKAN_CARGO_ENV ${CMAKE_COMMAND} -E env "RUSTFLAGS=-C target-cpu=native")
+endif()
+
 add_custom_target(karukan_rust_lib ALL
-    COMMAND ${CARGO} build --release -p karukan-fcitx5
+    COMMAND ${KARUKAN_CARGO_ENV} ${CARGO} build --release -p karukan-fcitx5
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../.."
     COMMENT "Building karukan-fcitx5 Rust library"
     BYPRODUCTS "${KARUKAN_RUST_LIB}"


### PR DESCRIPTION
fcitx5アドオンのビルド(内部で `cargo build --release -p karukan-fcitx5` が走る)が異常に遅い原因を計測したところ、`[profile.release]` の fat LTO + `codegen-units = 1` だった。fat LTO は最終リンクで全依存(karukan-engine、tokenizers、reqwest系、llama.cppバインディング)を単一スレッドで再最適化するため、どんな小さな編集でも毎回この直列リンクを払う。

## ビルド時間の計測 (16コア / 83GB RAM)

| 計測 | fat LTO + cg=1 (変更前) | thin LTO (変更後) |
|---|---|---:|
| no-op ビルド | 0.17s | 変わらず |
| 1ファイル touch 後の再ビルド | 52.5s (CPU 100% = 1コアのみ) | **19.9s** (CPU ~1200%) |
| フルビルド | - | 2m03s |

## 実行時性能への影響: 実測ゼロ

AJIMEE-Bench 200問(jinen-v2-small-q5、各構成3回)で確認:

| 構成 | 実行時間(中央値) | 精度 |
|---|---:|---:|
| fat LTO + cg=1 | 9.25s | 87.00% (NFKC) |
| thin LTO | 9.21s | 87.00% (NFKC) |

差は測定ブレ(±0.05s)の中。推論のホットパスは llama.cpp 側の C++(llama.cpp 自身のビルドで -O3 コンパイル)にあり、Rust の LTO 設定の影響を受けないため。バイナリサイズは 19.4MB → 25.8MB に増えるが、デスクトップIMEでは問題にならない。

あわせて、同計測で `RUSTFLAGS="-C target-cpu=native"` が約5%短縮(9.25s→8.81s)と分かったので、fcitx5 アドオンのビルドは **native を既定**にした(アドオンはビルドしたマシンで動かすのが通常ケースのため)。配布用ビルドは `-DKARUKAN_NATIVE=OFF`、自前の RUSTFLAGS があればそちらが優先される。

fcitx5 ユーザーはアドオンをソースからビルドするため、開発の編集サイクルだけでなく全ユーザーのインストールも速くなる。CI の Build Release ジョブも短縮される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

